### PR TITLE
Add bottom padding to search results

### DIFF
--- a/veggieseasons/lib/screens/search.dart
+++ b/veggieseasons/lib/screens/search.dart
@@ -76,6 +76,7 @@ class _SearchScreenState extends State<SearchScreen> {
                 _createSearchBox(),
                 Expanded(
                   child: ListView(
+                    padding: const EdgeInsets.only(bottom: 200.0),
                     children: _generateVeggieRows(model.searchVeggies(_terms)),
                   ),
                 ),


### PR DESCRIPTION
Fixes an issue with the search screen where iOS virtual keyboard overlaps the bottom of the search results listing.