### PR TITLE
Set google_maps_flutter's version to <=0.1.0 in place_tracker.

### DIFF
--- a/place_tracker/pubspec.yaml
+++ b/place_tracker/pubspec.yaml
@@ -12,10 +12,7 @@ dependencies:
 
   cupertino_icons: ^0.1.2
 
-  google_maps_flutter:
-    git:
-      url: git://github.com/flutter/plugins
-      path: packages/google_maps_flutter
+  google_maps_flutter: ^0.0.3
 
   uuid: 1.0.3
 


### PR DESCRIPTION
A breaking API change is coming in 0.1.0, setting a dependency constraint
to keep the place_tracker sample building.