### PR TITLE
Make in-season and not-in-season cards different

### DIFF
--- a/veggieseasons/lib/screens/list.dart
+++ b/veggieseasons/lib/screens/list.dart
@@ -13,7 +13,11 @@ import 'package:veggieseasons/styles.dart';
 import 'package:veggieseasons/widgets/veggie_card.dart';
 
 class ListScreen extends StatelessWidget {
-  List<Widget> _generateVeggieRows(List<Veggie> veggies, Preferences prefs) {
+  List<Widget> _generateVeggieRows(
+    List<Veggie> veggies,
+    Preferences prefs,
+    { bool inSeason = true }
+  ) {
     final cards = List<Widget>();
 
     for (Veggie veggie in veggies) {
@@ -23,7 +27,7 @@ class ListScreen extends StatelessWidget {
             future: prefs.preferredCategories,
             builder: (context, snapshot) {
               final data = snapshot.data ?? Set<VeggieCategory>();
-              return VeggieCard(veggie, data.contains(veggie.category));
+              return VeggieCard(veggie, inSeason, data.contains(veggie.category));
             }),
       ));
     }
@@ -65,12 +69,14 @@ class ListScreen extends StatelessWidget {
           ),
         );
 
-        rows.addAll(_generateVeggieRows(appState.unavailableVeggies, prefs));
+        rows.addAll(_generateVeggieRows(appState.unavailableVeggies, prefs, inSeason: false));
 
         return DecoratedBox(
           decoration: BoxDecoration(color: Color(0xffffffff)),
-          child: ListView(
-            children: rows,
+          child: CupertinoScrollbar(
+            child: ListView(
+              children: rows,
+            ),
           ),
         );
       },

--- a/veggieseasons/lib/screens/list.dart
+++ b/veggieseasons/lib/screens/list.dart
@@ -73,10 +73,8 @@ class ListScreen extends StatelessWidget {
 
         return DecoratedBox(
           decoration: BoxDecoration(color: Color(0xffffffff)),
-          child: CupertinoScrollbar(
-            child: ListView(
-              children: rows,
-            ),
+          child: ListView(
+            children: rows,
           ),
         );
       },

--- a/veggieseasons/lib/styles.dart
+++ b/veggieseasons/lib/styles.dart
@@ -269,4 +269,9 @@ abstract class Styles {
   );
 
   static const servingInfoBorderColor = Color(0xffb0b0b0);
+
+    static const ColorFilter desaturatedColorFilter =
+      // 222222 is a random color that has low color saturation.
+      ColorFilter.mode(Color(0xFF222222), BlendMode.saturation);
+ 
 }

--- a/veggieseasons/lib/widgets/veggie_card.dart
+++ b/veggieseasons/lib/widgets/veggie_card.dart
@@ -132,8 +132,7 @@ class VeggieCard extends StatelessWidget {
                   fit: BoxFit.cover,
                   colorFilter: isInSeason
                       ? null
-                      // 222222 is a random color that has low color saturation.
-                      : ColorFilter.mode(Color(0xFF222222), BlendMode.saturation),
+                      : Styles.desaturatedColorFilter,
                   image: AssetImage(
                     veggie.imageAssetPath,
                   ),

--- a/veggieseasons/lib/widgets/veggie_card.dart
+++ b/veggieseasons/lib/widgets/veggie_card.dart
@@ -76,10 +76,14 @@ class _PressableCardState extends State<PressableCard> {
 }
 
 class VeggieCard extends StatelessWidget {
-  VeggieCard(this.veggie, this.isPreferredCategory);
+  VeggieCard(this.veggie, this.isInSeason, this.isPreferredCategory);
 
   /// Veggie to be displayed by the card.
   final Veggie veggie;
+
+  /// If the veggie is in season, it's displayed more prominently and the
+  /// image is fully saturated. Otherwise, it's reduced and de-saturated.
+  final bool isInSeason;
 
   /// Whether [veggie] falls into one of user's preferred [VeggieCategory]s
   final bool isPreferredCategory;
@@ -119,10 +123,23 @@ class VeggieCard extends StatelessWidget {
       },
       child: Stack(
         children: [
-          Image.asset(
-            veggie.imageAssetPath,
-            fit: BoxFit.cover,
-            semanticLabel: 'A card background featuring ${veggie.name}',
+          Semantics(
+            label: 'A card background featuring ${veggie.name}',
+            child: Container(
+              height: isInSeason ? 350 : 150,
+              decoration: BoxDecoration(
+                image: DecorationImage(
+                  fit: BoxFit.cover,
+                  colorFilter: isInSeason
+                      ? null
+                      // 222222 is a random color that has low color saturation.
+                      : ColorFilter.mode(Color(0xFF222222), BlendMode.saturation),
+                  image: AssetImage(
+                    veggie.imageAssetPath,
+                  ),
+                ),
+              ),
+            ),
           ),
           Positioned(
             bottom: 0.0,


### PR DESCRIPTION
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/156888/55757814-dc601280-5a09-11e9-8c66-0e98b3a947b8.gif)

You'll have to exercise some artistic taste on top of this but it looks like this

Fixes https://github.com/flutter/flutter/issues/30737

Tangentially fixes https://github.com/flutter/flutter/issues/30511