### PR TITLE
Ensure flutter format and fix offending files

### DIFF
--- a/place_tracker/lib/place_map.dart
+++ b/place_tracker/lib/place_map.dart
@@ -224,7 +224,6 @@ class PlaceMapState extends State<PlaceMap> {
 
   void _confirmAddPlace(BuildContext context) async {
     if (_pendingMarker != null) {
-
       // Create a new Place and map it to the marker we just added.
       final Place newPlace = Place(
         id: Uuid().v1(),

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -18,7 +18,7 @@ do
 	../flutter/bin/flutter analyze
 
 	# Run the formatter on all the dart files to make sure everything's linted.
-	find . | grep "\.dart$" | xargs ../flutter/bin/flutter format -n
+	../flutter/bin/flutter format -n --set-exit-if-changed .
 
 	# Run the actual tests.
 	../flutter/bin/flutter test

--- a/veggieseasons/lib/screens/list.dart
+++ b/veggieseasons/lib/screens/list.dart
@@ -13,11 +13,8 @@ import 'package:veggieseasons/styles.dart';
 import 'package:veggieseasons/widgets/veggie_card.dart';
 
 class ListScreen extends StatelessWidget {
-  List<Widget> _generateVeggieRows(
-    List<Veggie> veggies,
-    Preferences prefs,
-    { bool inSeason = true }
-  ) {
+  List<Widget> _generateVeggieRows(List<Veggie> veggies, Preferences prefs,
+      {bool inSeason = true}) {
     final cards = List<Widget>();
 
     for (Veggie veggie in veggies) {
@@ -27,7 +24,8 @@ class ListScreen extends StatelessWidget {
             future: prefs.preferredCategories,
             builder: (context, snapshot) {
               final data = snapshot.data ?? Set<VeggieCategory>();
-              return VeggieCard(veggie, inSeason, data.contains(veggie.category));
+              return VeggieCard(
+                  veggie, inSeason, data.contains(veggie.category));
             }),
       ));
     }
@@ -69,7 +67,8 @@ class ListScreen extends StatelessWidget {
           ),
         );
 
-        rows.addAll(_generateVeggieRows(appState.unavailableVeggies, prefs, inSeason: false));
+        rows.addAll(_generateVeggieRows(appState.unavailableVeggies, prefs,
+            inSeason: false));
 
         return DecoratedBox(
           decoration: BoxDecoration(color: Color(0xffffffff)),

--- a/veggieseasons/lib/styles.dart
+++ b/veggieseasons/lib/styles.dart
@@ -270,8 +270,7 @@ abstract class Styles {
 
   static const servingInfoBorderColor = Color(0xffb0b0b0);
 
-    static const ColorFilter desaturatedColorFilter =
+  static const ColorFilter desaturatedColorFilter =
       // 222222 is a random color that has low color saturation.
       ColorFilter.mode(Color(0xFF222222), BlendMode.saturation);
- 
 }

--- a/veggieseasons/lib/widgets/veggie_card.dart
+++ b/veggieseasons/lib/widgets/veggie_card.dart
@@ -130,9 +130,8 @@ class VeggieCard extends StatelessWidget {
               decoration: BoxDecoration(
                 image: DecorationImage(
                   fit: BoxFit.cover,
-                  colorFilter: isInSeason
-                      ? null
-                      : Styles.desaturatedColorFilter,
+                  colorFilter:
+                      isInSeason ? null : Styles.desaturatedColorFilter,
                   image: AssetImage(
                     veggie.imageAssetPath,
                   ),


### PR DESCRIPTION
The current Travis script will only print offending files, but won’t fail the build. Added `--set-exit-if-changed` to fix that.

Also, simplified the call from using `grep` and `xargs` to simple `flutter format .`, which recurses directories.

Lastly, fixed offending files that needed `dartfmt`. (But not in the directories that aren’t covered by `travis_script.sh`.