### PR TITLE
Make use of (context) consistent

### DIFF
--- a/provider_counter/test/widget_test.dart
+++ b/provider_counter/test/widget_test.dart
@@ -8,7 +8,7 @@ void main() {
     // Build our app, provide it with a model, and trigger a frame.
     await tester.pumpWidget(
       ChangeNotifierProvider(
-        builder: (_) => Counter(),
+        builder: (context) => Counter(),
         child: MyApp(),
       ),
     );


### PR DESCRIPTION
Since we’re not using `(_)` anywhere else in this example, doing this here is weird.