### PR TITLE
jsonexample maintenance

### DIFF
--- a/jsonexample/README.md
+++ b/jsonexample/README.md
@@ -30,6 +30,16 @@ instantiating models and populating their fields.
 Each tab page in the app deserializes one type of data with one library.
 These Widgets show what app code using the above libraries might look like.
 
+## Generating 
+
+The lib/build_value and lib/json_serializable use build_runner to generate
+files. If you make a change to these files, you need to re-run the generator
+using `build_runner`:
+
+```
+flutter pub run build_runner build
+```
+
 ## Questions/issues
 
 If you have a general question about JSON serialization in Flutter, the

--- a/jsonexample/analysis_options.yaml
+++ b/jsonexample/analysis_options.yaml
@@ -1,8 +1,9 @@
-include: package:pedantic/analysis_options.1.7.0.yaml
+include: package:pedantic/analysis_options.1.8.0.yaml
 
 analyzer:
   exclude:
     - lib/json_serializable/*.g.dart
+    - lib/built_value/*.g.dart
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false

--- a/jsonexample/build.yaml
+++ b/jsonexample/build.yaml
@@ -4,13 +4,6 @@ targets:
       built_value_generator|built_value:
         generate_for:
         - lib/built_value/*.dart
-        options:
-          header: |
-            // Copyright 2018 The Chromium Authors. All rights reserved.
-            // Use of this source code is governed by a BSD-style license that can be
-            // found in the LICENSE file.
-
-            // GENERATED CODE - DO NOT MODIFY BY HAND
       json_serializable|json_serializable:
         generate_for:
         - lib/json_serializable/*.dart

--- a/jsonexample/lib/built_value/built_complex_object.g.dart
+++ b/jsonexample/lib/built_value/built_complex_object.g.dart
@@ -17,7 +17,7 @@ class _$BuiltComplexObjectSerializer
   final String wireName = 'BuiltComplexObject';
 
   @override
-  Iterable serialize(Serializers serializers, BuiltComplexObject object,
+  Iterable<Object> serialize(Serializers serializers, BuiltComplexObject object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object>[];
     if (object.aString != null) {
@@ -72,12 +72,12 @@ class _$BuiltComplexObjectSerializer
             specifiedType: const FullType(
                 BuiltList, const [const FullType(BuiltSimpleObject)])));
     }
-
     return result;
   }
 
   @override
-  BuiltComplexObject deserialize(Serializers serializers, Iterable serialized,
+  BuiltComplexObject deserialize(
+      Serializers serializers, Iterable<Object> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new BuiltComplexObjectBuilder();
 
@@ -108,25 +108,25 @@ class _$BuiltComplexObjectSerializer
           result.aListOfStrings.replace(serializers.deserialize(value,
                   specifiedType:
                       const FullType(BuiltList, const [const FullType(String)]))
-              as BuiltList);
+              as BuiltList<dynamic>);
           break;
         case 'aListOfInts':
           result.aListOfInts.replace(serializers.deserialize(value,
                   specifiedType:
                       const FullType(BuiltList, const [const FullType(int)]))
-              as BuiltList);
+              as BuiltList<dynamic>);
           break;
         case 'aListOfDoubles':
           result.aListOfDoubles.replace(serializers.deserialize(value,
                   specifiedType:
                       const FullType(BuiltList, const [const FullType(double)]))
-              as BuiltList);
+              as BuiltList<dynamic>);
           break;
         case 'aListOfObjects':
           result.aListOfObjects.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
                       BuiltList, const [const FullType(BuiltSimpleObject)]))
-              as BuiltList);
+              as BuiltList<dynamic>);
           break;
       }
     }

--- a/jsonexample/lib/built_value/built_simple_object.g.dart
+++ b/jsonexample/lib/built_value/built_simple_object.g.dart
@@ -17,7 +17,7 @@ class _$BuiltSimpleObjectSerializer
   final String wireName = 'BuiltSimpleObject';
 
   @override
-  Iterable serialize(Serializers serializers, BuiltSimpleObject object,
+  Iterable<Object> serialize(Serializers serializers, BuiltSimpleObject object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object>[];
     if (object.aString != null) {
@@ -59,12 +59,12 @@ class _$BuiltSimpleObjectSerializer
             specifiedType:
                 const FullType(BuiltList, const [const FullType(double)])));
     }
-
     return result;
   }
 
   @override
-  BuiltSimpleObject deserialize(Serializers serializers, Iterable serialized,
+  BuiltSimpleObject deserialize(
+      Serializers serializers, Iterable<Object> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new BuiltSimpleObjectBuilder();
 
@@ -90,19 +90,19 @@ class _$BuiltSimpleObjectSerializer
           result.aListOfStrings.replace(serializers.deserialize(value,
                   specifiedType:
                       const FullType(BuiltList, const [const FullType(String)]))
-              as BuiltList);
+              as BuiltList<dynamic>);
           break;
         case 'aListOfInts':
           result.aListOfInts.replace(serializers.deserialize(value,
                   specifiedType:
                       const FullType(BuiltList, const [const FullType(int)]))
-              as BuiltList);
+              as BuiltList<dynamic>);
           break;
         case 'aListOfDoubles':
           result.aListOfDoubles.replace(serializers.deserialize(value,
                   specifiedType:
                       const FullType(BuiltList, const [const FullType(double)]))
-              as BuiltList);
+              as BuiltList<dynamic>);
           break;
       }
     }

--- a/jsonexample/lib/json_serializable/serializable_complex_object.g.dart
+++ b/jsonexample/lib/json_serializable/serializable_complex_object.g.dart
@@ -9,25 +9,25 @@ part of 'serializable_complex_object.dart';
 SerializableComplexObject _$SerializableComplexObjectFromJson(
     Map<String, dynamic> json) {
   return SerializableComplexObject(
-      aString: json['aString'] as String,
-      anInt: json['anInt'] as int,
-      aDouble: (json['aDouble'] as num)?.toDouble(),
-      anObject: json['anObject'] == null
-          ? null
-          : SerializableSimpleObject.fromJson(
-              json['anObject'] as Map<String, dynamic>),
-      aListOfStrings:
-          (json['aListOfStrings'] as List)?.map((e) => e as String)?.toList(),
-      aListOfInts:
-          (json['aListOfInts'] as List)?.map((e) => e as int)?.toList(),
-      aListOfDoubles: (json['aListOfDoubles'] as List)
-          ?.map((e) => (e as num)?.toDouble())
-          ?.toList(),
-      aListOfObjects: (json['aListOfObjects'] as List)
-          ?.map((e) => e == null
-              ? null
-              : SerializableSimpleObject.fromJson(e as Map<String, dynamic>))
-          ?.toList());
+    aString: json['aString'] as String,
+    anInt: json['anInt'] as int,
+    aDouble: (json['aDouble'] as num)?.toDouble(),
+    anObject: json['anObject'] == null
+        ? null
+        : SerializableSimpleObject.fromJson(
+            json['anObject'] as Map<String, dynamic>),
+    aListOfStrings:
+        (json['aListOfStrings'] as List)?.map((e) => e as String)?.toList(),
+    aListOfInts: (json['aListOfInts'] as List)?.map((e) => e as int)?.toList(),
+    aListOfDoubles: (json['aListOfDoubles'] as List)
+        ?.map((e) => (e as num)?.toDouble())
+        ?.toList(),
+    aListOfObjects: (json['aListOfObjects'] as List)
+        ?.map((e) => e == null
+            ? null
+            : SerializableSimpleObject.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
 }
 
 Map<String, dynamic> _$SerializableComplexObjectToJson(
@@ -40,5 +40,5 @@ Map<String, dynamic> _$SerializableComplexObjectToJson(
       'aListOfStrings': instance.aListOfStrings,
       'aListOfInts': instance.aListOfInts,
       'aListOfDoubles': instance.aListOfDoubles,
-      'aListOfObjects': instance.aListOfObjects
+      'aListOfObjects': instance.aListOfObjects,
     };

--- a/jsonexample/lib/json_serializable/serializable_simple_object.g.dart
+++ b/jsonexample/lib/json_serializable/serializable_simple_object.g.dart
@@ -13,10 +13,10 @@ SerializableSimpleObject _$SerializableSimpleObjectFromJson(
     anInt: json['anInt'] as int,
     aDouble: (json['aDouble'] as num)?.toDouble(),
     aListOfStrings:
-        (json['aListOfStrings'] as List)?.map((dynamic e) => e as String)?.toList(),
-    aListOfInts: (json['aListOfInts'] as List)?.map((dynamic e) => e as int)?.toList(),
+        (json['aListOfStrings'] as List)?.map((e) => e as String)?.toList(),
+    aListOfInts: (json['aListOfInts'] as List)?.map((e) => e as int)?.toList(),
     aListOfDoubles: (json['aListOfDoubles'] as List)
-        ?.map((dynamic e) => (e as num)?.toDouble())
+        ?.map((e) => (e as num)?.toDouble())
         ?.toList(),
   );
 }

--- a/jsonexample/lib/json_serializable/serializable_simple_object.g.dart
+++ b/jsonexample/lib/json_serializable/serializable_simple_object.g.dart
@@ -9,16 +9,16 @@ part of 'serializable_simple_object.dart';
 SerializableSimpleObject _$SerializableSimpleObjectFromJson(
     Map<String, dynamic> json) {
   return SerializableSimpleObject(
-      aString: json['aString'] as String,
-      anInt: json['anInt'] as int,
-      aDouble: (json['aDouble'] as num)?.toDouble(),
-      aListOfStrings:
-          (json['aListOfStrings'] as List)?.map((e) => e as String)?.toList(),
-      aListOfInts:
-          (json['aListOfInts'] as List)?.map((e) => e as int)?.toList(),
-      aListOfDoubles: (json['aListOfDoubles'] as List)
-          ?.map((e) => (e as num)?.toDouble())
-          ?.toList());
+    aString: json['aString'] as String,
+    anInt: json['anInt'] as int,
+    aDouble: (json['aDouble'] as num)?.toDouble(),
+    aListOfStrings:
+        (json['aListOfStrings'] as List)?.map((dynamic e) => e as String)?.toList(),
+    aListOfInts: (json['aListOfInts'] as List)?.map((dynamic e) => e as int)?.toList(),
+    aListOfDoubles: (json['aListOfDoubles'] as List)
+        ?.map((dynamic e) => (e as num)?.toDouble())
+        ?.toList(),
+  );
 }
 
 Map<String, dynamic> _$SerializableSimpleObjectToJson(
@@ -29,5 +29,5 @@ Map<String, dynamic> _$SerializableSimpleObjectToJson(
       'aDouble': instance.aDouble,
       'aListOfStrings': instance.aListOfStrings,
       'aListOfInts': instance.aListOfInts,
-      'aListOfDoubles': instance.aListOfDoubles
+      'aListOfDoubles': instance.aListOfDoubles,
     };

--- a/jsonexample/pubspec.lock
+++ b/jsonexample/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.2.0"
   build_config:
     dependency: transitive
     description:
@@ -56,28 +56,28 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.7"
+    version: "1.1.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.8"
+    version: "1.7.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "4.1.0"
   built_collection:
     dependency: "direct main"
     description:
@@ -140,7 +140,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   csslib:
     dependency: transitive
     description:
@@ -199,7 +199,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0+2"
+    version: "0.14.0+3"
   http:
     dependency: transitive
     description:
@@ -456,6 +456,6 @@ packages:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.16"
+    version: "2.2.0"
 sdks:
   dart: ">=2.5.0 <3.0.0"

--- a/jsonexample/pubspec.yaml
+++ b/jsonexample/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  build_runner: ^1.6.8
+  build_runner: ^1.7.1
   built_value_generator: ^6.7.1
   json_serializable: ^3.2.2
   pedantic: ^1.8.0+1
@@ -23,4 +23,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-


### PR DESCRIPTION
This updates the json sample with the latest tooling and re-runs the generator.

I ran into an issue where the generated files don't play nicely with the `implicit-dynamic: false` flag in analysis_options.yaml. Normally, this wouldn't be a problem, since we are excluding the generated files in analysis_options.yaml, but those files still seem to be included when IntelliJ and the dartanalyzer command run. Strangely, `flutter analyze` succeeds. I've filed an issue for this [here](https://github.com/dart-lang/sdk/issues/38753). 

Since this doesn't break CI and the app still works, this is probably OK to merge.