### PR TITLE
Add CocoaPods installation to the README

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -16,13 +16,6 @@ flutter channel master
 flutter upgrade
 ```
 
-You will also need to update CocoaPods to the latest version in order to build
-for iOS. To do so, run the following command on a MacOS machine:
-
-```bash
-sudo gem install cocoapods
-```
-
 When you're done, use this command to return to the safety of the stable
 channel:
 

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -16,6 +16,13 @@ flutter channel master
 flutter upgrade
 ```
 
+You will also need to update CocoaPods to the latest version in order to build
+for iOS. To do so, run the following command on a MacOS machine:
+
+```bash
+sudo gem install cocoapods
+```
+
 When you're done, use this command to return to the safety of the stable
 channel:
 

--- a/experimental/add_to_app/README.md
+++ b/experimental/add_to_app/README.md
@@ -1,6 +1,6 @@
 # Add-to-App Sample
 
-***The Add-to-App sample is designed to build with Flutter's `master` channel
+***The Add-to-App sample is designed to build with Flutter's `master` channel.
 See the [README](../README.md) in the `experimental` directory for details.***
 
 This directory contains a bunch of Android and iOS projects that each import

--- a/experimental/add_to_app/README.md
+++ b/experimental/add_to_app/README.md
@@ -1,8 +1,7 @@
 # Add-to-App Sample
 
 ***The Add-to-App sample is designed to build with Flutter's `master` channel
-and the latest version of CocoaPods. See the [README](../README.md) in the
-`experimental` directory for details.***
+See the [README](../README.md) in the `experimental` directory for details.***
 
 This directory contains a bunch of Android and iOS projects that each import
 a standalone Flutter module called `flutter_module`.
@@ -14,6 +13,17 @@ a standalone Flutter module called `flutter_module`.
   - Whether to build the Flutter module from source each time the app builds or
     rely on a separately pre-built module.
   - Whether plugins are needed by the Flutter module used in the app.
+
+## Installing Cocoapods
+
+The iOS samples in this repo require the latest version of Cocoapods. To install it,
+run the following command on a MacOS machine:
+
+```bash
+sudo gem install cocoapods
+```
+
+See https://guides.cocoapods.org/using/getting-started.html for more details.
 
 ## The important bits
 


### PR DESCRIPTION
In `experimental/add_to_app` it references that CocoaPods needs to be updated, however there is no mention on this README of how one should proceed to do so.

As such, instructions have been added.

If needed, the following can also be added:

"To verify that you have the latest version, you can run the command:

```bash
pod --version
```

And check with the [latest releases](https://github.com/CocoaPods/CocoaPods/releases) of CocoaPods."