### PR TITLE
Update semantic label of study back button to better explain the action

### DIFF
--- a/gallery/gallery/lib/l10n/gallery_localizations.dart
+++ b/gallery/gallery/lib/l10n/gallery_localizations.dart
@@ -229,6 +229,14 @@ class GalleryLocalizations {
         desc: r'Represents a link to the Flutter samples github repository.');
   }
 
+  String get backToGallery {
+    return Intl.message(r'Back to Gallery',
+        locale: _localeName,
+        name: 'backToGallery',
+        desc:
+            r'Semantic label for back button to exit a study and return to the gallery.');
+  }
+
   String get bottomNavigationAccountTab {
     return Intl.message(r'Account',
         locale: _localeName,

--- a/gallery/gallery/lib/l10n/intl_en_US.arb
+++ b/gallery/gallery/lib/l10n/intl_en_US.arb
@@ -13,6 +13,10 @@
       }
     }
   },
+  "backToGallery": "Back to Gallery",
+  "@backToGallery": {
+    "description": "Semantic label for back button to exit a study and return to the gallery home page."
+  },
   "homeHeaderGallery": "Gallery",
   "@homeHeaderGallery": {
     "description": "Header title on home screen for Gallery section."

--- a/gallery/gallery/lib/l10n/intl_en_US.xml
+++ b/gallery/gallery/lib/l10n/intl_en_US.xml
@@ -14,6 +14,10 @@
     description="A description about how to view the source code for this app."
     >To see the source code for this app, please visit the {value}.</string>
   <string
+    name="backToGallery"
+    description="Semantic label for back button to exit a study and return to the gallery."
+    >Back to Gallery</string>
+  <string
     name="homeHeaderGallery"
     description="Header title on home screen for Gallery section."
     >Gallery</string>

--- a/gallery/gallery/lib/l10n/messages_en_US.dart
+++ b/gallery/gallery/lib/l10n/messages_en_US.dart
@@ -82,6 +82,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "aboutDialogDescription": m0,
         "aboutFlutterSamplesRepo":
             MessageLookupByLibrary.simpleMessage("Flutter samples Github repo"),
+        "backToGallery":
+            MessageLookupByLibrary.simpleMessage("Back to Gallery"),
         "bottomNavigationAccountTab":
             MessageLookupByLibrary.simpleMessage("Account"),
         "bottomNavigationAlarmTab":

--- a/gallery/gallery/lib/pages/home.dart
+++ b/gallery/gallery/lib/pages/home.dart
@@ -847,10 +847,13 @@ class _StudyWrapperState extends State<_StudyWrapper> {
               ),
               Align(
                 alignment: AlignmentDirectional.bottomStart,
-                child: Semantics(
-                  sortKey: const OrdinalSortKey(0),
-                  child: Padding(
-                    padding: const EdgeInsets.all(16),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Semantics(
+                    sortKey: const OrdinalSortKey(0),
+                    label: GalleryLocalizations.of(context).backToGallery,
+                    button: true,
+                    excludeSemantics: true,
                     child: FloatingActionButton.extended(
                       focusNode: backButtonFocusNode,
                       onPressed: () {


### PR DESCRIPTION
The study back button takes you back to the gallery and so the semantic label reflects that now.

Closes [#480](https://github.com/material-components/material-components-flutter-gallery/issues/480)