### PR TITLE
[Gallery] Add platform setting for macOS, Linux, Windows

### DIFF
--- a/gallery/gallery/lib/l10n/gallery_localizations.dart
+++ b/gallery/gallery/lib/l10n/gallery_localizations.dart
@@ -83,10 +83,6 @@ class GalleryLocalizations {
   /// Returns a list of localizations delegates containing this delegate along with
   /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
   /// and GlobalWidgetsLocalizations.delegate.
-  ///
-  /// Additional delegates can be added by appending to this list in
-  /// MaterialApp. This list does not have to be used at all if a custom list
-  /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
     delegate,
@@ -2771,20 +2767,6 @@ class GalleryLocalizations {
         locale: _localeName,
         name: 'settingsLocale',
         desc: r'Title for locale setting.');
-  }
-
-  String get settingsPlatformAndroid {
-    return Intl.message(r'Android',
-        locale: _localeName,
-        name: 'settingsPlatformAndroid',
-        desc: r'Title for Android platform setting.');
-  }
-
-  String get settingsPlatformIOS {
-    return Intl.message(r'iOS',
-        locale: _localeName,
-        name: 'settingsPlatformIOS',
-        desc: r'Title for iOS platform setting.');
   }
 
   String get settingsPlatformMechanics {

--- a/gallery/gallery/lib/l10n/intl_en_US.arb
+++ b/gallery/gallery/lib/l10n/intl_en_US.arb
@@ -405,14 +405,6 @@
   "@settingsPlatformMechanics": {
     "description": "Title for platform mechanics (iOS/Android) setting."
   },
-  "settingsPlatformAndroid": "Android",
-  "@settingsPlatformAndroid": {
-    "description": "Title for Android platform setting."
-  },
-  "settingsPlatformIOS": "iOS",
-  "@settingsPlatformIOS": {
-    "description": "Title for iOS platform setting."
-  },
   "settingsTheme": "Theme",
   "@settingsTheme": {
     "description": "Title for the theme setting."

--- a/gallery/gallery/lib/l10n/intl_en_US.xml
+++ b/gallery/gallery/lib/l10n/intl_en_US.xml
@@ -370,14 +370,6 @@
     description="Title for platform mechanics (iOS/Android) setting."
     >Platform mechanics</string>
   <string
-    name="settingsPlatformAndroid"
-    description="Title for Android platform setting."
-    >Android</string>
-  <string
-    name="settingsPlatformIOS"
-    description="Title for iOS platform setting."
-    >iOS</string>
-  <string
     name="settingsTheme"
     description="Title for the theme setting."
     >Theme</string>

--- a/gallery/gallery/lib/l10n/messages_af.dart
+++ b/gallery/gallery/lib/l10n/messages_af.dart
@@ -678,9 +678,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Stuur terugvoer"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Lig"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Locale"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platformmeganika"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_all.dart
+++ b/gallery/gallery/lib/l10n/messages_all.dart
@@ -15,485 +15,485 @@ import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 import 'package:intl/src/intl_helpers.dart';
 
-import 'messages_af.dart' as messages_af;
-import 'messages_am.dart' as messages_am;
-import 'messages_ar.dart' as messages_ar;
-import 'messages_ar_EG.dart' as messages_ar_eg;
-import 'messages_ar_JO.dart' as messages_ar_jo;
-import 'messages_ar_MA.dart' as messages_ar_ma;
-import 'messages_ar_SA.dart' as messages_ar_sa;
-import 'messages_as.dart' as messages_as;
-import 'messages_az.dart' as messages_az;
-import 'messages_be.dart' as messages_be;
-import 'messages_bg.dart' as messages_bg;
-import 'messages_bn.dart' as messages_bn;
-import 'messages_bs.dart' as messages_bs;
-import 'messages_ca.dart' as messages_ca;
-import 'messages_cs.dart' as messages_cs;
-import 'messages_da.dart' as messages_da;
-import 'messages_de.dart' as messages_de;
-import 'messages_de_AT.dart' as messages_de_at;
-import 'messages_de_CH.dart' as messages_de_ch;
-import 'messages_el.dart' as messages_el;
-import 'messages_en_AU.dart' as messages_en_au;
-import 'messages_en_CA.dart' as messages_en_ca;
-import 'messages_en_GB.dart' as messages_en_gb;
-import 'messages_en_IE.dart' as messages_en_ie;
-import 'messages_en_IN.dart' as messages_en_in;
-import 'messages_en_NZ.dart' as messages_en_nz;
-import 'messages_en_SG.dart' as messages_en_sg;
-import 'messages_en_US.dart' as messages_en_us;
-import 'messages_en_ZA.dart' as messages_en_za;
+import 'messages_ko.dart' as messages_ko;
 import 'messages_es.dart' as messages_es;
-import 'messages_es_419.dart' as messages_es_419;
-import 'messages_es_AR.dart' as messages_es_ar;
-import 'messages_es_BO.dart' as messages_es_bo;
-import 'messages_es_CL.dart' as messages_es_cl;
-import 'messages_es_CO.dart' as messages_es_co;
-import 'messages_es_CR.dart' as messages_es_cr;
-import 'messages_es_DO.dart' as messages_es_do;
-import 'messages_es_EC.dart' as messages_es_ec;
-import 'messages_es_GT.dart' as messages_es_gt;
-import 'messages_es_HN.dart' as messages_es_hn;
-import 'messages_es_MX.dart' as messages_es_mx;
-import 'messages_es_NI.dart' as messages_es_ni;
-import 'messages_es_PA.dart' as messages_es_pa;
-import 'messages_es_PE.dart' as messages_es_pe;
-import 'messages_es_PR.dart' as messages_es_pr;
-import 'messages_es_PY.dart' as messages_es_py;
-import 'messages_es_SV.dart' as messages_es_sv;
-import 'messages_es_US.dart' as messages_es_us;
-import 'messages_es_UY.dart' as messages_es_uy;
-import 'messages_es_VE.dart' as messages_es_ve;
-import 'messages_et.dart' as messages_et;
-import 'messages_eu.dart' as messages_eu;
-import 'messages_fa.dart' as messages_fa;
-import 'messages_fi.dart' as messages_fi;
-import 'messages_fil.dart' as messages_fil;
-import 'messages_fr.dart' as messages_fr;
-import 'messages_fr_CA.dart' as messages_fr_ca;
-import 'messages_fr_CH.dart' as messages_fr_ch;
 import 'messages_gl.dart' as messages_gl;
-import 'messages_gsw.dart' as messages_gsw;
-import 'messages_gu.dart' as messages_gu;
-import 'messages_he.dart' as messages_he;
-import 'messages_hi.dart' as messages_hi;
-import 'messages_hr.dart' as messages_hr;
+import 'messages_en_ZA.dart' as messages_en_za;
+import 'messages_si.dart' as messages_si;
+import 'messages_es_NI.dart' as messages_es_ni;
+import 'messages_es_CO.dart' as messages_es_co;
+import 'messages_fi.dart' as messages_fi;
+import 'messages_da.dart' as messages_da;
 import 'messages_hu.dart' as messages_hu;
-import 'messages_hy.dart' as messages_hy;
+import 'messages_kn.dart' as messages_kn;
+import 'messages_ky.dart' as messages_ky;
 import 'messages_id.dart' as messages_id;
 import 'messages_is.dart' as messages_is;
-import 'messages_it.dart' as messages_it;
-import 'messages_ja.dart' as messages_ja;
-import 'messages_ka.dart' as messages_ka;
-import 'messages_kk.dart' as messages_kk;
+import 'messages_es_AR.dart' as messages_es_ar;
+import 'messages_ar_SA.dart' as messages_ar_sa;
+import 'messages_es_CL.dart' as messages_es_cl;
+import 'messages_ro.dart' as messages_ro;
+import 'messages_sk.dart' as messages_sk;
 import 'messages_km.dart' as messages_km;
-import 'messages_kn.dart' as messages_kn;
-import 'messages_ko.dart' as messages_ko;
-import 'messages_ky.dart' as messages_ky;
-import 'messages_lo.dart' as messages_lo;
-import 'messages_lt.dart' as messages_lt;
-import 'messages_lv.dart' as messages_lv;
-import 'messages_mk.dart' as messages_mk;
+import 'messages_en_CA.dart' as messages_en_ca;
+import 'messages_hr.dart' as messages_hr;
+import 'messages_he.dart' as messages_he;
+import 'messages_pt_BR.dart' as messages_pt_br;
+import 'messages_eu.dart' as messages_eu;
+import 'messages_pt.dart' as messages_pt;
+import 'messages_fr_CA.dart' as messages_fr_ca;
+import 'messages_es_US.dart' as messages_es_us;
+import 'messages_de_CH.dart' as messages_de_ch;
+import 'messages_et.dart' as messages_et;
+import 'messages_de.dart' as messages_de;
+import 'messages_gsw.dart' as messages_gsw;
+import 'messages_sl.dart' as messages_sl;
+import 'messages_es_BO.dart' as messages_es_bo;
+import 'messages_de_AT.dart' as messages_de_at;
+import 'messages_pa.dart' as messages_pa;
+import 'messages_kk.dart' as messages_kk;
+import 'messages_it.dart' as messages_it;
 import 'messages_ml.dart' as messages_ml;
+import 'messages_sr_Latn.dart' as messages_sr_latn;
+import 'messages_es_SV.dart' as messages_es_sv;
+import 'messages_uk.dart' as messages_uk;
+import 'messages_es_419.dart' as messages_es_419;
+import 'messages_or.dart' as messages_or;
+import 'messages_cs.dart' as messages_cs;
+import 'messages_es_PY.dart' as messages_es_py;
+import 'messages_tl.dart' as messages_tl;
+import 'messages_am.dart' as messages_am;
+import 'messages_az.dart' as messages_az;
 import 'messages_mn.dart' as messages_mn;
-import 'messages_mr.dart' as messages_mr;
-import 'messages_ms.dart' as messages_ms;
 import 'messages_my.dart' as messages_my;
 import 'messages_nb.dart' as messages_nb;
-import 'messages_ne.dart' as messages_ne;
-import 'messages_nl.dart' as messages_nl;
-import 'messages_or.dart' as messages_or;
-import 'messages_pa.dart' as messages_pa;
-import 'messages_pl.dart' as messages_pl;
-import 'messages_pt.dart' as messages_pt;
-import 'messages_pt_BR.dart' as messages_pt_br;
-import 'messages_pt_PT.dart' as messages_pt_pt;
-import 'messages_ro.dart' as messages_ro;
-import 'messages_ru.dart' as messages_ru;
-import 'messages_si.dart' as messages_si;
-import 'messages_sk.dart' as messages_sk;
-import 'messages_sl.dart' as messages_sl;
-import 'messages_sq.dart' as messages_sq;
-import 'messages_sr.dart' as messages_sr;
-import 'messages_sr_Latn.dart' as messages_sr_latn;
-import 'messages_sv.dart' as messages_sv;
-import 'messages_sw.dart' as messages_sw;
-import 'messages_ta.dart' as messages_ta;
-import 'messages_te.dart' as messages_te;
+import 'messages_en_IE.dart' as messages_en_ie;
+import 'messages_be.dart' as messages_be;
+import 'messages_ca.dart' as messages_ca;
 import 'messages_th.dart' as messages_th;
-import 'messages_tl.dart' as messages_tl;
-import 'messages_tr.dart' as messages_tr;
-import 'messages_uk.dart' as messages_uk;
-import 'messages_ur.dart' as messages_ur;
-import 'messages_uz.dart' as messages_uz;
-import 'messages_vi.dart' as messages_vi;
-import 'messages_zh.dart' as messages_zh;
-import 'messages_zh_CN.dart' as messages_zh_cn;
-import 'messages_zh_HK.dart' as messages_zh_hk;
-import 'messages_zh_TW.dart' as messages_zh_tw;
+import 'messages_pt_PT.dart' as messages_pt_pt;
+import 'messages_es_DO.dart' as messages_es_do;
+import 'messages_es_GT.dart' as messages_es_gt;
+import 'messages_ar_MA.dart' as messages_ar_ma;
 import 'messages_zu.dart' as messages_zu;
+import 'messages_uz.dart' as messages_uz;
+import 'messages_bs.dart' as messages_bs;
+import 'messages_lo.dart' as messages_lo;
+import 'messages_mk.dart' as messages_mk;
+import 'messages_ne.dart' as messages_ne;
+import 'messages_fil.dart' as messages_fil;
+import 'messages_es_HN.dart' as messages_es_hn;
+import 'messages_bg.dart' as messages_bg;
+import 'messages_mr.dart' as messages_mr;
+import 'messages_lv.dart' as messages_lv;
+import 'messages_af.dart' as messages_af;
+import 'messages_es_PE.dart' as messages_es_pe;
+import 'messages_es_PR.dart' as messages_es_pr;
+import 'messages_ms.dart' as messages_ms;
+import 'messages_en_GB.dart' as messages_en_gb;
+import 'messages_ar.dart' as messages_ar;
+import 'messages_en_SG.dart' as messages_en_sg;
+import 'messages_tr.dart' as messages_tr;
+import 'messages_te.dart' as messages_te;
+import 'messages_as.dart' as messages_as;
+import 'messages_lt.dart' as messages_lt;
+import 'messages_vi.dart' as messages_vi;
+import 'messages_ur.dart' as messages_ur;
+import 'messages_ta.dart' as messages_ta;
+import 'messages_es_EC.dart' as messages_es_ec;
+import 'messages_zh_HK.dart' as messages_zh_hk;
+import 'messages_nl.dart' as messages_nl;
+import 'messages_es_PA.dart' as messages_es_pa;
+import 'messages_zh.dart' as messages_zh;
+import 'messages_en_IN.dart' as messages_en_in;
+import 'messages_bn.dart' as messages_bn;
+import 'messages_en_AU.dart' as messages_en_au;
+import 'messages_fa.dart' as messages_fa;
+import 'messages_en_NZ.dart' as messages_en_nz;
+import 'messages_pl.dart' as messages_pl;
+import 'messages_sw.dart' as messages_sw;
+import 'messages_ar_EG.dart' as messages_ar_eg;
+import 'messages_sv.dart' as messages_sv;
+import 'messages_el.dart' as messages_el;
+import 'messages_zh_TW.dart' as messages_zh_tw;
+import 'messages_ja.dart' as messages_ja;
+import 'messages_hi.dart' as messages_hi;
+import 'messages_en_US.dart' as messages_en_us;
+import 'messages_es_MX.dart' as messages_es_mx;
+import 'messages_es_VE.dart' as messages_es_ve;
+import 'messages_es_CR.dart' as messages_es_cr;
+import 'messages_ru.dart' as messages_ru;
+import 'messages_sq.dart' as messages_sq;
+import 'messages_zh_CN.dart' as messages_zh_cn;
+import 'messages_fr_CH.dart' as messages_fr_ch;
+import 'messages_ar_JO.dart' as messages_ar_jo;
+import 'messages_gu.dart' as messages_gu;
+import 'messages_ka.dart' as messages_ka;
+import 'messages_sr.dart' as messages_sr;
+import 'messages_es_UY.dart' as messages_es_uy;
+import 'messages_fr.dart' as messages_fr;
+import 'messages_hy.dart' as messages_hy;
 
 typedef Future<dynamic> LibraryLoader();
 Map<String, LibraryLoader> _deferredLibraries = {
-  'af': () => new Future.value(null),
-  'am': () => new Future.value(null),
-  'ar': () => new Future.value(null),
-  'ar_EG': () => new Future.value(null),
-  'ar_JO': () => new Future.value(null),
-  'ar_MA': () => new Future.value(null),
-  'ar_SA': () => new Future.value(null),
-  'as': () => new Future.value(null),
-  'az': () => new Future.value(null),
-  'be': () => new Future.value(null),
-  'bg': () => new Future.value(null),
-  'bn': () => new Future.value(null),
-  'bs': () => new Future.value(null),
-  'ca': () => new Future.value(null),
-  'cs': () => new Future.value(null),
-  'da': () => new Future.value(null),
-  'de': () => new Future.value(null),
-  'de_AT': () => new Future.value(null),
-  'de_CH': () => new Future.value(null),
-  'el': () => new Future.value(null),
-  'en_AU': () => new Future.value(null),
-  'en_CA': () => new Future.value(null),
-  'en_GB': () => new Future.value(null),
-  'en_IE': () => new Future.value(null),
-  'en_IN': () => new Future.value(null),
-  'en_NZ': () => new Future.value(null),
-  'en_SG': () => new Future.value(null),
-  'en_US': () => new Future.value(null),
-  'en_ZA': () => new Future.value(null),
+  'ko': () => new Future.value(null),
   'es': () => new Future.value(null),
-  'es_419': () => new Future.value(null),
-  'es_AR': () => new Future.value(null),
-  'es_BO': () => new Future.value(null),
-  'es_CL': () => new Future.value(null),
-  'es_CO': () => new Future.value(null),
-  'es_CR': () => new Future.value(null),
-  'es_DO': () => new Future.value(null),
-  'es_EC': () => new Future.value(null),
-  'es_GT': () => new Future.value(null),
-  'es_HN': () => new Future.value(null),
-  'es_MX': () => new Future.value(null),
-  'es_NI': () => new Future.value(null),
-  'es_PA': () => new Future.value(null),
-  'es_PE': () => new Future.value(null),
-  'es_PR': () => new Future.value(null),
-  'es_PY': () => new Future.value(null),
-  'es_SV': () => new Future.value(null),
-  'es_US': () => new Future.value(null),
-  'es_UY': () => new Future.value(null),
-  'es_VE': () => new Future.value(null),
-  'et': () => new Future.value(null),
-  'eu': () => new Future.value(null),
-  'fa': () => new Future.value(null),
-  'fi': () => new Future.value(null),
-  'fil': () => new Future.value(null),
-  'fr': () => new Future.value(null),
-  'fr_CA': () => new Future.value(null),
-  'fr_CH': () => new Future.value(null),
   'gl': () => new Future.value(null),
-  'gsw': () => new Future.value(null),
-  'gu': () => new Future.value(null),
-  'he': () => new Future.value(null),
-  'hi': () => new Future.value(null),
-  'hr': () => new Future.value(null),
+  'en_ZA': () => new Future.value(null),
+  'si': () => new Future.value(null),
+  'es_NI': () => new Future.value(null),
+  'es_CO': () => new Future.value(null),
+  'fi': () => new Future.value(null),
+  'da': () => new Future.value(null),
   'hu': () => new Future.value(null),
-  'hy': () => new Future.value(null),
+  'kn': () => new Future.value(null),
+  'ky': () => new Future.value(null),
   'id': () => new Future.value(null),
   'is': () => new Future.value(null),
-  'it': () => new Future.value(null),
-  'ja': () => new Future.value(null),
-  'ka': () => new Future.value(null),
-  'kk': () => new Future.value(null),
+  'es_AR': () => new Future.value(null),
+  'ar_SA': () => new Future.value(null),
+  'es_CL': () => new Future.value(null),
+  'ro': () => new Future.value(null),
+  'sk': () => new Future.value(null),
   'km': () => new Future.value(null),
-  'kn': () => new Future.value(null),
-  'ko': () => new Future.value(null),
-  'ky': () => new Future.value(null),
-  'lo': () => new Future.value(null),
-  'lt': () => new Future.value(null),
-  'lv': () => new Future.value(null),
-  'mk': () => new Future.value(null),
+  'en_CA': () => new Future.value(null),
+  'hr': () => new Future.value(null),
+  'he': () => new Future.value(null),
+  'pt_BR': () => new Future.value(null),
+  'eu': () => new Future.value(null),
+  'pt': () => new Future.value(null),
+  'fr_CA': () => new Future.value(null),
+  'es_US': () => new Future.value(null),
+  'de_CH': () => new Future.value(null),
+  'et': () => new Future.value(null),
+  'de': () => new Future.value(null),
+  'gsw': () => new Future.value(null),
+  'sl': () => new Future.value(null),
+  'es_BO': () => new Future.value(null),
+  'de_AT': () => new Future.value(null),
+  'pa': () => new Future.value(null),
+  'kk': () => new Future.value(null),
+  'it': () => new Future.value(null),
   'ml': () => new Future.value(null),
+  'sr_Latn': () => new Future.value(null),
+  'es_SV': () => new Future.value(null),
+  'uk': () => new Future.value(null),
+  'es_419': () => new Future.value(null),
+  'or': () => new Future.value(null),
+  'cs': () => new Future.value(null),
+  'es_PY': () => new Future.value(null),
+  'tl': () => new Future.value(null),
+  'am': () => new Future.value(null),
+  'az': () => new Future.value(null),
   'mn': () => new Future.value(null),
-  'mr': () => new Future.value(null),
-  'ms': () => new Future.value(null),
   'my': () => new Future.value(null),
   'nb': () => new Future.value(null),
-  'ne': () => new Future.value(null),
-  'nl': () => new Future.value(null),
-  'or': () => new Future.value(null),
-  'pa': () => new Future.value(null),
-  'pl': () => new Future.value(null),
-  'pt': () => new Future.value(null),
-  'pt_BR': () => new Future.value(null),
-  'pt_PT': () => new Future.value(null),
-  'ro': () => new Future.value(null),
-  'ru': () => new Future.value(null),
-  'si': () => new Future.value(null),
-  'sk': () => new Future.value(null),
-  'sl': () => new Future.value(null),
-  'sq': () => new Future.value(null),
-  'sr': () => new Future.value(null),
-  'sr_Latn': () => new Future.value(null),
-  'sv': () => new Future.value(null),
-  'sw': () => new Future.value(null),
-  'ta': () => new Future.value(null),
-  'te': () => new Future.value(null),
+  'en_IE': () => new Future.value(null),
+  'be': () => new Future.value(null),
+  'ca': () => new Future.value(null),
   'th': () => new Future.value(null),
-  'tl': () => new Future.value(null),
-  'tr': () => new Future.value(null),
-  'uk': () => new Future.value(null),
-  'ur': () => new Future.value(null),
-  'uz': () => new Future.value(null),
-  'vi': () => new Future.value(null),
-  'zh': () => new Future.value(null),
-  'zh_CN': () => new Future.value(null),
-  'zh_HK': () => new Future.value(null),
-  'zh_TW': () => new Future.value(null),
+  'pt_PT': () => new Future.value(null),
+  'es_DO': () => new Future.value(null),
+  'es_GT': () => new Future.value(null),
+  'ar_MA': () => new Future.value(null),
   'zu': () => new Future.value(null),
+  'uz': () => new Future.value(null),
+  'bs': () => new Future.value(null),
+  'lo': () => new Future.value(null),
+  'mk': () => new Future.value(null),
+  'ne': () => new Future.value(null),
+  'fil': () => new Future.value(null),
+  'es_HN': () => new Future.value(null),
+  'bg': () => new Future.value(null),
+  'mr': () => new Future.value(null),
+  'lv': () => new Future.value(null),
+  'af': () => new Future.value(null),
+  'es_PE': () => new Future.value(null),
+  'es_PR': () => new Future.value(null),
+  'ms': () => new Future.value(null),
+  'en_GB': () => new Future.value(null),
+  'ar': () => new Future.value(null),
+  'en_SG': () => new Future.value(null),
+  'tr': () => new Future.value(null),
+  'te': () => new Future.value(null),
+  'as': () => new Future.value(null),
+  'lt': () => new Future.value(null),
+  'vi': () => new Future.value(null),
+  'ur': () => new Future.value(null),
+  'ta': () => new Future.value(null),
+  'es_EC': () => new Future.value(null),
+  'zh_HK': () => new Future.value(null),
+  'nl': () => new Future.value(null),
+  'es_PA': () => new Future.value(null),
+  'zh': () => new Future.value(null),
+  'en_IN': () => new Future.value(null),
+  'bn': () => new Future.value(null),
+  'en_AU': () => new Future.value(null),
+  'fa': () => new Future.value(null),
+  'en_NZ': () => new Future.value(null),
+  'pl': () => new Future.value(null),
+  'sw': () => new Future.value(null),
+  'ar_EG': () => new Future.value(null),
+  'sv': () => new Future.value(null),
+  'el': () => new Future.value(null),
+  'zh_TW': () => new Future.value(null),
+  'ja': () => new Future.value(null),
+  'hi': () => new Future.value(null),
+  'en_US': () => new Future.value(null),
+  'es_MX': () => new Future.value(null),
+  'es_VE': () => new Future.value(null),
+  'es_CR': () => new Future.value(null),
+  'ru': () => new Future.value(null),
+  'sq': () => new Future.value(null),
+  'zh_CN': () => new Future.value(null),
+  'fr_CH': () => new Future.value(null),
+  'ar_JO': () => new Future.value(null),
+  'gu': () => new Future.value(null),
+  'ka': () => new Future.value(null),
+  'sr': () => new Future.value(null),
+  'es_UY': () => new Future.value(null),
+  'fr': () => new Future.value(null),
+  'hy': () => new Future.value(null),
 };
 
 MessageLookupByLibrary _findExact(String localeName) {
   switch (localeName) {
-    case 'af':
-      return messages_af.messages;
-    case 'am':
-      return messages_am.messages;
-    case 'ar':
-      return messages_ar.messages;
-    case 'ar_EG':
-      return messages_ar_eg.messages;
-    case 'ar_JO':
-      return messages_ar_jo.messages;
-    case 'ar_MA':
-      return messages_ar_ma.messages;
-    case 'ar_SA':
-      return messages_ar_sa.messages;
-    case 'as':
-      return messages_as.messages;
-    case 'az':
-      return messages_az.messages;
-    case 'be':
-      return messages_be.messages;
-    case 'bg':
-      return messages_bg.messages;
-    case 'bn':
-      return messages_bn.messages;
-    case 'bs':
-      return messages_bs.messages;
-    case 'ca':
-      return messages_ca.messages;
-    case 'cs':
-      return messages_cs.messages;
-    case 'da':
-      return messages_da.messages;
-    case 'de':
-      return messages_de.messages;
-    case 'de_AT':
-      return messages_de_at.messages;
-    case 'de_CH':
-      return messages_de_ch.messages;
-    case 'el':
-      return messages_el.messages;
-    case 'en_AU':
-      return messages_en_au.messages;
-    case 'en_CA':
-      return messages_en_ca.messages;
-    case 'en_GB':
-      return messages_en_gb.messages;
-    case 'en_IE':
-      return messages_en_ie.messages;
-    case 'en_IN':
-      return messages_en_in.messages;
-    case 'en_NZ':
-      return messages_en_nz.messages;
-    case 'en_SG':
-      return messages_en_sg.messages;
-    case 'en_US':
-      return messages_en_us.messages;
-    case 'en_ZA':
-      return messages_en_za.messages;
+    case 'ko':
+      return messages_ko.messages;
     case 'es':
       return messages_es.messages;
-    case 'es_419':
-      return messages_es_419.messages;
-    case 'es_AR':
-      return messages_es_ar.messages;
-    case 'es_BO':
-      return messages_es_bo.messages;
-    case 'es_CL':
-      return messages_es_cl.messages;
-    case 'es_CO':
-      return messages_es_co.messages;
-    case 'es_CR':
-      return messages_es_cr.messages;
-    case 'es_DO':
-      return messages_es_do.messages;
-    case 'es_EC':
-      return messages_es_ec.messages;
-    case 'es_GT':
-      return messages_es_gt.messages;
-    case 'es_HN':
-      return messages_es_hn.messages;
-    case 'es_MX':
-      return messages_es_mx.messages;
-    case 'es_NI':
-      return messages_es_ni.messages;
-    case 'es_PA':
-      return messages_es_pa.messages;
-    case 'es_PE':
-      return messages_es_pe.messages;
-    case 'es_PR':
-      return messages_es_pr.messages;
-    case 'es_PY':
-      return messages_es_py.messages;
-    case 'es_SV':
-      return messages_es_sv.messages;
-    case 'es_US':
-      return messages_es_us.messages;
-    case 'es_UY':
-      return messages_es_uy.messages;
-    case 'es_VE':
-      return messages_es_ve.messages;
-    case 'et':
-      return messages_et.messages;
-    case 'eu':
-      return messages_eu.messages;
-    case 'fa':
-      return messages_fa.messages;
-    case 'fi':
-      return messages_fi.messages;
-    case 'fil':
-      return messages_fil.messages;
-    case 'fr':
-      return messages_fr.messages;
-    case 'fr_CA':
-      return messages_fr_ca.messages;
-    case 'fr_CH':
-      return messages_fr_ch.messages;
     case 'gl':
       return messages_gl.messages;
-    case 'gsw':
-      return messages_gsw.messages;
-    case 'gu':
-      return messages_gu.messages;
-    case 'he':
-      return messages_he.messages;
-    case 'hi':
-      return messages_hi.messages;
-    case 'hr':
-      return messages_hr.messages;
+    case 'en_ZA':
+      return messages_en_za.messages;
+    case 'si':
+      return messages_si.messages;
+    case 'es_NI':
+      return messages_es_ni.messages;
+    case 'es_CO':
+      return messages_es_co.messages;
+    case 'fi':
+      return messages_fi.messages;
+    case 'da':
+      return messages_da.messages;
     case 'hu':
       return messages_hu.messages;
-    case 'hy':
-      return messages_hy.messages;
+    case 'kn':
+      return messages_kn.messages;
+    case 'ky':
+      return messages_ky.messages;
     case 'id':
       return messages_id.messages;
     case 'is':
       return messages_is.messages;
-    case 'it':
-      return messages_it.messages;
-    case 'ja':
-      return messages_ja.messages;
-    case 'ka':
-      return messages_ka.messages;
-    case 'kk':
-      return messages_kk.messages;
+    case 'es_AR':
+      return messages_es_ar.messages;
+    case 'ar_SA':
+      return messages_ar_sa.messages;
+    case 'es_CL':
+      return messages_es_cl.messages;
+    case 'ro':
+      return messages_ro.messages;
+    case 'sk':
+      return messages_sk.messages;
     case 'km':
       return messages_km.messages;
-    case 'kn':
-      return messages_kn.messages;
-    case 'ko':
-      return messages_ko.messages;
-    case 'ky':
-      return messages_ky.messages;
-    case 'lo':
-      return messages_lo.messages;
-    case 'lt':
-      return messages_lt.messages;
-    case 'lv':
-      return messages_lv.messages;
-    case 'mk':
-      return messages_mk.messages;
+    case 'en_CA':
+      return messages_en_ca.messages;
+    case 'hr':
+      return messages_hr.messages;
+    case 'he':
+      return messages_he.messages;
+    case 'pt_BR':
+      return messages_pt_br.messages;
+    case 'eu':
+      return messages_eu.messages;
+    case 'pt':
+      return messages_pt.messages;
+    case 'fr_CA':
+      return messages_fr_ca.messages;
+    case 'es_US':
+      return messages_es_us.messages;
+    case 'de_CH':
+      return messages_de_ch.messages;
+    case 'et':
+      return messages_et.messages;
+    case 'de':
+      return messages_de.messages;
+    case 'gsw':
+      return messages_gsw.messages;
+    case 'sl':
+      return messages_sl.messages;
+    case 'es_BO':
+      return messages_es_bo.messages;
+    case 'de_AT':
+      return messages_de_at.messages;
+    case 'pa':
+      return messages_pa.messages;
+    case 'kk':
+      return messages_kk.messages;
+    case 'it':
+      return messages_it.messages;
     case 'ml':
       return messages_ml.messages;
+    case 'sr_Latn':
+      return messages_sr_latn.messages;
+    case 'es_SV':
+      return messages_es_sv.messages;
+    case 'uk':
+      return messages_uk.messages;
+    case 'es_419':
+      return messages_es_419.messages;
+    case 'or':
+      return messages_or.messages;
+    case 'cs':
+      return messages_cs.messages;
+    case 'es_PY':
+      return messages_es_py.messages;
+    case 'tl':
+      return messages_tl.messages;
+    case 'am':
+      return messages_am.messages;
+    case 'az':
+      return messages_az.messages;
     case 'mn':
       return messages_mn.messages;
-    case 'mr':
-      return messages_mr.messages;
-    case 'ms':
-      return messages_ms.messages;
     case 'my':
       return messages_my.messages;
     case 'nb':
       return messages_nb.messages;
-    case 'ne':
-      return messages_ne.messages;
-    case 'nl':
-      return messages_nl.messages;
-    case 'or':
-      return messages_or.messages;
-    case 'pa':
-      return messages_pa.messages;
-    case 'pl':
-      return messages_pl.messages;
-    case 'pt':
-      return messages_pt.messages;
-    case 'pt_BR':
-      return messages_pt_br.messages;
-    case 'pt_PT':
-      return messages_pt_pt.messages;
-    case 'ro':
-      return messages_ro.messages;
-    case 'ru':
-      return messages_ru.messages;
-    case 'si':
-      return messages_si.messages;
-    case 'sk':
-      return messages_sk.messages;
-    case 'sl':
-      return messages_sl.messages;
-    case 'sq':
-      return messages_sq.messages;
-    case 'sr':
-      return messages_sr.messages;
-    case 'sr_Latn':
-      return messages_sr_latn.messages;
-    case 'sv':
-      return messages_sv.messages;
-    case 'sw':
-      return messages_sw.messages;
-    case 'ta':
-      return messages_ta.messages;
-    case 'te':
-      return messages_te.messages;
+    case 'en_IE':
+      return messages_en_ie.messages;
+    case 'be':
+      return messages_be.messages;
+    case 'ca':
+      return messages_ca.messages;
     case 'th':
       return messages_th.messages;
-    case 'tl':
-      return messages_tl.messages;
-    case 'tr':
-      return messages_tr.messages;
-    case 'uk':
-      return messages_uk.messages;
-    case 'ur':
-      return messages_ur.messages;
-    case 'uz':
-      return messages_uz.messages;
-    case 'vi':
-      return messages_vi.messages;
-    case 'zh':
-      return messages_zh.messages;
-    case 'zh_CN':
-      return messages_zh_cn.messages;
-    case 'zh_HK':
-      return messages_zh_hk.messages;
-    case 'zh_TW':
-      return messages_zh_tw.messages;
+    case 'pt_PT':
+      return messages_pt_pt.messages;
+    case 'es_DO':
+      return messages_es_do.messages;
+    case 'es_GT':
+      return messages_es_gt.messages;
+    case 'ar_MA':
+      return messages_ar_ma.messages;
     case 'zu':
       return messages_zu.messages;
+    case 'uz':
+      return messages_uz.messages;
+    case 'bs':
+      return messages_bs.messages;
+    case 'lo':
+      return messages_lo.messages;
+    case 'mk':
+      return messages_mk.messages;
+    case 'ne':
+      return messages_ne.messages;
+    case 'fil':
+      return messages_fil.messages;
+    case 'es_HN':
+      return messages_es_hn.messages;
+    case 'bg':
+      return messages_bg.messages;
+    case 'mr':
+      return messages_mr.messages;
+    case 'lv':
+      return messages_lv.messages;
+    case 'af':
+      return messages_af.messages;
+    case 'es_PE':
+      return messages_es_pe.messages;
+    case 'es_PR':
+      return messages_es_pr.messages;
+    case 'ms':
+      return messages_ms.messages;
+    case 'en_GB':
+      return messages_en_gb.messages;
+    case 'ar':
+      return messages_ar.messages;
+    case 'en_SG':
+      return messages_en_sg.messages;
+    case 'tr':
+      return messages_tr.messages;
+    case 'te':
+      return messages_te.messages;
+    case 'as':
+      return messages_as.messages;
+    case 'lt':
+      return messages_lt.messages;
+    case 'vi':
+      return messages_vi.messages;
+    case 'ur':
+      return messages_ur.messages;
+    case 'ta':
+      return messages_ta.messages;
+    case 'es_EC':
+      return messages_es_ec.messages;
+    case 'zh_HK':
+      return messages_zh_hk.messages;
+    case 'nl':
+      return messages_nl.messages;
+    case 'es_PA':
+      return messages_es_pa.messages;
+    case 'zh':
+      return messages_zh.messages;
+    case 'en_IN':
+      return messages_en_in.messages;
+    case 'bn':
+      return messages_bn.messages;
+    case 'en_AU':
+      return messages_en_au.messages;
+    case 'fa':
+      return messages_fa.messages;
+    case 'en_NZ':
+      return messages_en_nz.messages;
+    case 'pl':
+      return messages_pl.messages;
+    case 'sw':
+      return messages_sw.messages;
+    case 'ar_EG':
+      return messages_ar_eg.messages;
+    case 'sv':
+      return messages_sv.messages;
+    case 'el':
+      return messages_el.messages;
+    case 'zh_TW':
+      return messages_zh_tw.messages;
+    case 'ja':
+      return messages_ja.messages;
+    case 'hi':
+      return messages_hi.messages;
+    case 'en_US':
+      return messages_en_us.messages;
+    case 'es_MX':
+      return messages_es_mx.messages;
+    case 'es_VE':
+      return messages_es_ve.messages;
+    case 'es_CR':
+      return messages_es_cr.messages;
+    case 'ru':
+      return messages_ru.messages;
+    case 'sq':
+      return messages_sq.messages;
+    case 'zh_CN':
+      return messages_zh_cn.messages;
+    case 'fr_CH':
+      return messages_fr_ch.messages;
+    case 'ar_JO':
+      return messages_ar_jo.messages;
+    case 'gu':
+      return messages_gu.messages;
+    case 'ka':
+      return messages_ka.messages;
+    case 'sr':
+      return messages_sr.messages;
+    case 'es_UY':
+      return messages_es_uy.messages;
+    case 'fr':
+      return messages_fr.messages;
+    case 'hy':
+      return messages_hy.messages;
     default:
       return null;
   }

--- a/gallery/gallery/lib/l10n/messages_am.dart
+++ b/gallery/gallery/lib/l10n/messages_am.dart
@@ -619,9 +619,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("ግብረመልስ ላክ"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("ብርሃን"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("የአካባቢ"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("የመሣሪያ ስርዓት ሜካኒክ አሰራር"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ar.dart
+++ b/gallery/gallery/lib/l10n/messages_ar.dart
@@ -672,9 +672,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("إرسال التعليقات"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("فاتح"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("اللغة"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("آليات الأنظمة الأساسية"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ar_EG.dart
+++ b/gallery/gallery/lib/l10n/messages_ar_EG.dart
@@ -672,9 +672,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("إرسال التعليقات"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("فاتح"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("اللغة"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("آليات الأنظمة الأساسية"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ar_JO.dart
+++ b/gallery/gallery/lib/l10n/messages_ar_JO.dart
@@ -672,9 +672,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("إرسال التعليقات"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("فاتح"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("اللغة"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("آليات الأنظمة الأساسية"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ar_MA.dart
+++ b/gallery/gallery/lib/l10n/messages_ar_MA.dart
@@ -672,9 +672,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("إرسال التعليقات"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("فاتح"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("اللغة"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("آليات الأنظمة الأساسية"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ar_SA.dart
+++ b/gallery/gallery/lib/l10n/messages_ar_SA.dart
@@ -672,9 +672,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("إرسال التعليقات"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("فاتح"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("اللغة"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("آليات الأنظمة الأساسية"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_as.dart
+++ b/gallery/gallery/lib/l10n/messages_as.dart
@@ -681,9 +681,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("মতামত পঠিয়াওক"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("পাতল"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("ল’কেল"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("প্লেটফ’ৰ্ম মেকানিকসমূহ"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("মন্থৰ গতি"),

--- a/gallery/gallery/lib/l10n/messages_az.dart
+++ b/gallery/gallery/lib/l10n/messages_az.dart
@@ -664,9 +664,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("İşıqlı"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Lokal göstərici"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platforma mexanikası"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_be.dart
+++ b/gallery/gallery/lib/l10n/messages_be.dart
@@ -677,9 +677,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Светлая"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Рэгіянальныя налады"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Механізм платформы"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_bg.dart
+++ b/gallery/gallery/lib/l10n/messages_bg.dart
@@ -670,9 +670,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Изпращане на отзиви"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Светла"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Локал"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Механика на платформата"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_bn.dart
+++ b/gallery/gallery/lib/l10n/messages_bn.dart
@@ -670,9 +670,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("মতামত জানান"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("আলো"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("লোকেল"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("প্ল্যাটফর্ম মেকানিক্স"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("স্লো মোশন"),

--- a/gallery/gallery/lib/l10n/messages_bs.dart
+++ b/gallery/gallery/lib/l10n/messages_bs.dart
@@ -679,9 +679,6 @@ class MessageLookup extends MessageLookupByLibrary {
             "Pošalji povratne informacije"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Svijetla"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Jezik/zemlja"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mehanika platforme"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ca.dart
+++ b/gallery/gallery/lib/l10n/messages_ca.dart
@@ -689,9 +689,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Clar"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuració regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecànica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_cs.dart
+++ b/gallery/gallery/lib/l10n/messages_cs.dart
@@ -673,9 +673,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Světlý"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Národní prostředí"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mechanika platformy"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("Zpomalení"),

--- a/gallery/gallery/lib/l10n/messages_da.dart
+++ b/gallery/gallery/lib/l10n/messages_da.dart
@@ -659,9 +659,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Send feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Lyst"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Landestandard"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platformmekanik"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_de.dart
+++ b/gallery/gallery/lib/l10n/messages_de.dart
@@ -681,9 +681,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Feedback geben"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Hell"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Sprache"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics": MessageLookupByLibrary.simpleMessage(
             "Funktionsweise der Plattform"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("Zeitlupe"),

--- a/gallery/gallery/lib/l10n/messages_de_AT.dart
+++ b/gallery/gallery/lib/l10n/messages_de_AT.dart
@@ -681,9 +681,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Feedback geben"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Hell"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Sprache"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics": MessageLookupByLibrary.simpleMessage(
             "Funktionsweise der Plattform"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("Zeitlupe"),

--- a/gallery/gallery/lib/l10n/messages_de_CH.dart
+++ b/gallery/gallery/lib/l10n/messages_de_CH.dart
@@ -681,9 +681,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Feedback geben"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Hell"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Sprache"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics": MessageLookupByLibrary.simpleMessage(
             "Funktionsweise der Plattform"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("Zeitlupe"),

--- a/gallery/gallery/lib/l10n/messages_el.dart
+++ b/gallery/gallery/lib/l10n/messages_el.dart
@@ -693,9 +693,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Φωτεινό"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Τοπικές ρυθμίσεις"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Μηχανική πλατφόρμας"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_en_AU.dart
+++ b/gallery/gallery/lib/l10n/messages_en_AU.dart
@@ -660,9 +660,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Send feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Light"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Locale"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platform mechanics"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_en_CA.dart
+++ b/gallery/gallery/lib/l10n/messages_en_CA.dart
@@ -660,9 +660,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Send feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Light"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Locale"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platform mechanics"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_en_GB.dart
+++ b/gallery/gallery/lib/l10n/messages_en_GB.dart
@@ -660,9 +660,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Send feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Light"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Locale"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platform mechanics"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_en_IE.dart
+++ b/gallery/gallery/lib/l10n/messages_en_IE.dart
@@ -660,9 +660,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Send feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Light"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Locale"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platform mechanics"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_en_IN.dart
+++ b/gallery/gallery/lib/l10n/messages_en_IN.dart
@@ -660,9 +660,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Send feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Light"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Locale"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platform mechanics"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_en_NZ.dart
+++ b/gallery/gallery/lib/l10n/messages_en_NZ.dart
@@ -660,9 +660,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Send feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Light"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Locale"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platform mechanics"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_en_SG.dart
+++ b/gallery/gallery/lib/l10n/messages_en_SG.dart
@@ -660,9 +660,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Send feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Light"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Locale"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platform mechanics"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_en_US.dart
+++ b/gallery/gallery/lib/l10n/messages_en_US.dart
@@ -674,9 +674,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Send feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Light"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Locale"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platform mechanics"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_en_ZA.dart
+++ b/gallery/gallery/lib/l10n/messages_en_ZA.dart
@@ -660,9 +660,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Send feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Light"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Locale"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platform mechanics"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es.dart
+++ b/gallery/gallery/lib/l10n/messages_es.dart
@@ -694,9 +694,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_419.dart
+++ b/gallery/gallery/lib/l10n/messages_es_419.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_AR.dart
+++ b/gallery/gallery/lib/l10n/messages_es_AR.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_BO.dart
+++ b/gallery/gallery/lib/l10n/messages_es_BO.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_CL.dart
+++ b/gallery/gallery/lib/l10n/messages_es_CL.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_CO.dart
+++ b/gallery/gallery/lib/l10n/messages_es_CO.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_CR.dart
+++ b/gallery/gallery/lib/l10n/messages_es_CR.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_DO.dart
+++ b/gallery/gallery/lib/l10n/messages_es_DO.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_EC.dart
+++ b/gallery/gallery/lib/l10n/messages_es_EC.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_GT.dart
+++ b/gallery/gallery/lib/l10n/messages_es_GT.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_HN.dart
+++ b/gallery/gallery/lib/l10n/messages_es_HN.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_MX.dart
+++ b/gallery/gallery/lib/l10n/messages_es_MX.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_NI.dart
+++ b/gallery/gallery/lib/l10n/messages_es_NI.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_PA.dart
+++ b/gallery/gallery/lib/l10n/messages_es_PA.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_PE.dart
+++ b/gallery/gallery/lib/l10n/messages_es_PE.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_PR.dart
+++ b/gallery/gallery/lib/l10n/messages_es_PR.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_PY.dart
+++ b/gallery/gallery/lib/l10n/messages_es_PY.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_SV.dart
+++ b/gallery/gallery/lib/l10n/messages_es_SV.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_US.dart
+++ b/gallery/gallery/lib/l10n/messages_es_US.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_UY.dart
+++ b/gallery/gallery/lib/l10n/messages_es_UY.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_es_VE.dart
+++ b/gallery/gallery/lib/l10n/messages_es_VE.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración regional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica de la plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_et.dart
+++ b/gallery/gallery/lib/l10n/messages_et.dart
@@ -673,9 +673,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Tagasiside saatmine"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Hele"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Lokaat"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platvormi mehaanika"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("Aegluubis"),

--- a/gallery/gallery/lib/l10n/messages_eu.dart
+++ b/gallery/gallery/lib/l10n/messages_eu.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Argia"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Lurraldeko ezarpenak"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Plataformaren mekanika"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_fa.dart
+++ b/gallery/gallery/lib/l10n/messages_fa.dart
@@ -658,9 +658,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("ارسال بازخورد"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("روشن"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("محلی"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("مکانیک پلتفورم"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_fi.dart
+++ b/gallery/gallery/lib/l10n/messages_fi.dart
@@ -683,9 +683,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Vaalea"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Kieli- ja maa-asetus"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Alustan mekaniikka"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("Hidastus"),

--- a/gallery/gallery/lib/l10n/messages_fil.dart
+++ b/gallery/gallery/lib/l10n/messages_fil.dart
@@ -683,9 +683,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Magpadala ng feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Maliwanag"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Wika"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mechanics ng platform"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_fr.dart
+++ b/gallery/gallery/lib/l10n/messages_fr.dart
@@ -688,9 +688,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Clair"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Paramètres régionaux"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mécanique des plates-formes"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("Ralenti"),

--- a/gallery/gallery/lib/l10n/messages_fr_CA.dart
+++ b/gallery/gallery/lib/l10n/messages_fr_CA.dart
@@ -686,9 +686,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Clair"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Paramètres régionaux"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mécanique des plateformes"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("Ralenti"),

--- a/gallery/gallery/lib/l10n/messages_fr_CH.dart
+++ b/gallery/gallery/lib/l10n/messages_fr_CH.dart
@@ -688,9 +688,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Clair"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Paramètres régionaux"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mécanique des plates-formes"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("Ralenti"),

--- a/gallery/gallery/lib/l10n/messages_gl.dart
+++ b/gallery/gallery/lib/l10n/messages_gl.dart
@@ -688,9 +688,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Configuración rexional"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecánica da plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_gsw.dart
+++ b/gallery/gallery/lib/l10n/messages_gsw.dart
@@ -681,9 +681,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Feedback geben"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Hell"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Sprache"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics": MessageLookupByLibrary.simpleMessage(
             "Funktionsweise der Plattform"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("Zeitlupe"),

--- a/gallery/gallery/lib/l10n/messages_gu.dart
+++ b/gallery/gallery/lib/l10n/messages_gu.dart
@@ -662,9 +662,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("પ્રતિસાદ મોકલો"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("આછી"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("લોકેલ"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("પ્લૅટફૉર્મ મેકૅનિક્સ"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("સ્લો મોશન"),

--- a/gallery/gallery/lib/l10n/messages_he.dart
+++ b/gallery/gallery/lib/l10n/messages_he.dart
@@ -650,9 +650,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("שליחת משוב"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("בהיר"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("לוקאל"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("מכניקה של פלטפורמה"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_hi.dart
+++ b/gallery/gallery/lib/l10n/messages_hi.dart
@@ -661,9 +661,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme":
             MessageLookupByLibrary.simpleMessage("हल्के रंग की थीम"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("स्थान-भाषा"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("प्लैटफ़ॉर्म मैकेनिक"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("स्लो मोशन"),

--- a/gallery/gallery/lib/l10n/messages_hr.dart
+++ b/gallery/gallery/lib/l10n/messages_hr.dart
@@ -677,9 +677,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Svijetlo"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Oznaka zemlje/jezika"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mehanika platforme"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_hu.dart
+++ b/gallery/gallery/lib/l10n/messages_hu.dart
@@ -693,9 +693,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Világos"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Nyelv- és országkód"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platformmechanika"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_hy.dart
+++ b/gallery/gallery/lib/l10n/messages_hy.dart
@@ -676,9 +676,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Բաց"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage(
             "Տարածաշրջանային կարգավորումներ"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Հարթակ"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_id.dart
+++ b/gallery/gallery/lib/l10n/messages_id.dart
@@ -660,9 +660,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Kirimkan masukan"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Terang"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Lokal"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mekanik platform"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_is.dart
+++ b/gallery/gallery/lib/l10n/messages_is.dart
@@ -676,9 +676,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Senda ábendingu"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Ljóst"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Tungumálskóði"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Uppbygging kerfis"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("Hægspilun"),

--- a/gallery/gallery/lib/l10n/messages_it.dart
+++ b/gallery/gallery/lib/l10n/messages_it.dart
@@ -688,9 +688,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Chiaro"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Impostazioni internazionali"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Struttura piattaforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ja.dart
+++ b/gallery/gallery/lib/l10n/messages_ja.dart
@@ -605,9 +605,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("フィードバックを送信"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("ライト"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("言語 / 地域"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("プラットフォームのメカニクス"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("スロー モーション"),

--- a/gallery/gallery/lib/l10n/messages_ka.dart
+++ b/gallery/gallery/lib/l10n/messages_ka.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("გამოხმაურების გაგზავნა"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("ღია"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("ლოკალი"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("პლატფორმის მექანიკა"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_kk.dart
+++ b/gallery/gallery/lib/l10n/messages_kk.dart
@@ -665,9 +665,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Пікір жіберу"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Ашық"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Тіл"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Платформа"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_km.dart
+++ b/gallery/gallery/lib/l10n/messages_km.dart
@@ -678,9 +678,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("ផ្ញើមតិកែលម្អ"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("ភ្លឺ"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("ភាសា"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("មេកានិច​ប្រព័ន្ធ"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("ចលនា​យឺត"),

--- a/gallery/gallery/lib/l10n/messages_kn.dart
+++ b/gallery/gallery/lib/l10n/messages_kn.dart
@@ -690,9 +690,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("ಪ್ರತಿಕ್ರಿಯೆ ಕಳುಹಿಸಿ"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("ಲೈಟ್"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("ಸ್ಥಳೀಯ"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics": MessageLookupByLibrary.simpleMessage(
             "ಪ್ಲ್ಯಾಟ್‌ಫಾರ್ಮ್ ಮೆಕ್ಯಾನಿಕ್ಸ್"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ko.dart
+++ b/gallery/gallery/lib/l10n/messages_ko.dart
@@ -594,9 +594,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("의견 보내기"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("밝게"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("언어"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("플랫폼 메커니즘"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("슬로우 모션"),

--- a/gallery/gallery/lib/l10n/messages_ky.dart
+++ b/gallery/gallery/lib/l10n/messages_ky.dart
@@ -684,9 +684,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Пикир билдирүү"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Жарык"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Тил параметри"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Платформанын механикасы"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_lo.dart
+++ b/gallery/gallery/lib/l10n/messages_lo.dart
@@ -650,9 +650,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("ສົ່ງຄຳຕິຊົມ"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("ແຈ້ງ"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("ພາສາ"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("ໂຄງສ້າງຂອງແພລດຟອມ"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("ສະໂລໂມຊັນ"),

--- a/gallery/gallery/lib/l10n/messages_lt.dart
+++ b/gallery/gallery/lib/l10n/messages_lt.dart
@@ -698,9 +698,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme":
             MessageLookupByLibrary.simpleMessage("Šviesioji tema"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Lokalė"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platformos mechanika"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_lv.dart
+++ b/gallery/gallery/lib/l10n/messages_lv.dart
@@ -671,9 +671,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Sūtīt atsauksmes"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Gaišs"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Lokalizācija"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platformas mehānika"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_mk.dart
+++ b/gallery/gallery/lib/l10n/messages_mk.dart
@@ -672,9 +672,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Светла"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Локален стандард"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Механика на платформа"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ml.dart
+++ b/gallery/gallery/lib/l10n/messages_ml.dart
@@ -694,9 +694,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("ഫീഡ്ബാക്ക് അയയ്ക്കുക"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("പ്രകാശം"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("പ്രാദേശിക ഭാഷ"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("പ്ലാറ്റ്‌ഫോം മെക്കാനിക്‌സ്"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("സ്ലോ മോഷൻ"),

--- a/gallery/gallery/lib/l10n/messages_mn.dart
+++ b/gallery/gallery/lib/l10n/messages_mn.dart
@@ -673,9 +673,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Цайвар"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Хэл болон улсын код"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Андройд"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Платформын механик"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_mr.dart
+++ b/gallery/gallery/lib/l10n/messages_mr.dart
@@ -665,9 +665,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("फीडबॅक पाठवा"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("फिकट"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("लोकॅल"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("प्लॅटफॉर्म यांत्रिकी"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("स्लो मोशन"),

--- a/gallery/gallery/lib/l10n/messages_ms.dart
+++ b/gallery/gallery/lib/l10n/messages_ms.dart
@@ -673,9 +673,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Cerah"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Tempat peristiwa"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mekanik platform"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_my.dart
+++ b/gallery/gallery/lib/l10n/messages_my.dart
@@ -702,9 +702,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("အလင်း"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage(
             "ဘာသာစကားနှင့် နိုင်ငံအသုံးအနှုန်း"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("စနစ် ယန္တရားများ"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_nb.dart
+++ b/gallery/gallery/lib/l10n/messages_nb.dart
@@ -659,9 +659,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Send tilbakemelding"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Lyst"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Lokalitet"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Plattformsfunksjoner"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ne.dart
+++ b/gallery/gallery/lib/l10n/messages_ne.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("प्रतिक्रिया पठाउनुहोस्"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("उज्यालो"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("लोकेल"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("प्लेटफर्मको यान्त्रिकी"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("ढिलो गति"),

--- a/gallery/gallery/lib/l10n/messages_nl.dart
+++ b/gallery/gallery/lib/l10n/messages_nl.dart
@@ -683,9 +683,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Feedback versturen"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Licht"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Land"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platformmechanica"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_or.dart
+++ b/gallery/gallery/lib/l10n/messages_or.dart
@@ -686,9 +686,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("ମତାମତ ପଠାନ୍ତୁ"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("ଲାଇଟ୍"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("ସ୍ଥାନ"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("ପ୍ଲାଟଫର୍ମ ମେକାନିକ୍"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_pa.dart
+++ b/gallery/gallery/lib/l10n/messages_pa.dart
@@ -658,9 +658,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("ਵਿਚਾਰ ਭੇਜੋ"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("ਹਲਕਾ"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("ਲੋਕੇਲ"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("ਪਲੇਟਫਾਰਮ ਮਕੈਨਿਕ"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_pl.dart
+++ b/gallery/gallery/lib/l10n/messages_pl.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Prześlij opinię"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Jasny"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Region"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mechanika platformy"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_pt.dart
+++ b/gallery/gallery/lib/l10n/messages_pt.dart
@@ -682,9 +682,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Enviar feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Localidade"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecânica da plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_pt_BR.dart
+++ b/gallery/gallery/lib/l10n/messages_pt_BR.dart
@@ -682,9 +682,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Enviar feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Localidade"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecânica da plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_pt_PT.dart
+++ b/gallery/gallery/lib/l10n/messages_pt_PT.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Enviar comentários"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Claro"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Local"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecânica da plataforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ro.dart
+++ b/gallery/gallery/lib/l10n/messages_ro.dart
@@ -687,9 +687,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Trimiteți feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Luminoasă"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Cod local"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mecanica platformei"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ru.dart
+++ b/gallery/gallery/lib/l10n/messages_ru.dart
@@ -675,9 +675,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Светлая"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Региональные настройки"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Платформа"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_si.dart
+++ b/gallery/gallery/lib/l10n/messages_si.dart
@@ -676,9 +676,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("ප්‍රතිපෝෂණ යවන්න"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("සැහැල්ලු"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("පෙදෙසිය"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("වේදිකා උපක්‍රම"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_sk.dart
+++ b/gallery/gallery/lib/l10n/messages_sk.dart
@@ -674,9 +674,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Svetlý"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Miestne nastavenie"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mechanika platformy"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_sl.dart
+++ b/gallery/gallery/lib/l10n/messages_sl.dart
@@ -681,9 +681,6 @@ class MessageLookup extends MessageLookupByLibrary {
             "Pošiljanje povratnih informacij"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Svetla"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Jezik"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mehanika okolja"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_sq.dart
+++ b/gallery/gallery/lib/l10n/messages_sq.dart
@@ -682,9 +682,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("E ndriçuar"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Gjuha e përdorimit"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mekanika e platformës"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_sr.dart
+++ b/gallery/gallery/lib/l10n/messages_sr.dart
@@ -684,9 +684,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Пошаљи повратне информације"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Светла"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Локалитет"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Механика платформе"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_sr_Latn.dart
+++ b/gallery/gallery/lib/l10n/messages_sr_Latn.dart
@@ -684,9 +684,6 @@ class MessageLookup extends MessageLookupByLibrary {
             "Pošalji povratne informacije"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Svetla"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Lokalitet"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mehanika platforme"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_sv.dart
+++ b/gallery/gallery/lib/l10n/messages_sv.dart
@@ -658,9 +658,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Skicka feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Ljust"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Språkkod"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Plattformsmekanik"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_sw.dart
+++ b/gallery/gallery/lib/l10n/messages_sw.dart
@@ -668,9 +668,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("Tuma maoni"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Meupe"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Lugha"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Umakanika wa mfumo"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ta.dart
+++ b/gallery/gallery/lib/l10n/messages_ta.dart
@@ -685,9 +685,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("கருத்தை அனுப்பு"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("லைட்"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("மொழி"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("பிளாட்ஃபார்ம் மெக்கானிக்ஸ்"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_te.dart
+++ b/gallery/gallery/lib/l10n/messages_te.dart
@@ -695,9 +695,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("అభిప్రాయాన్ని పంపు"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("కాంతివంతం"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("లొకేల్"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("ప్లాట్‌ఫామ్ మెకానిక్స్"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_th.dart
+++ b/gallery/gallery/lib/l10n/messages_th.dart
@@ -671,9 +671,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("ส่งความคิดเห็น"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("สีสว่าง"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("ภาษา"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("กลไกการทำงานของแพลตฟอร์ม"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_tl.dart
+++ b/gallery/gallery/lib/l10n/messages_tl.dart
@@ -683,9 +683,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Magpadala ng feedback"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Maliwanag"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Wika"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Mechanics ng platform"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_tr.dart
+++ b/gallery/gallery/lib/l10n/messages_tr.dart
@@ -660,9 +660,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Geri bildirim gönder"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Açık"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Yerel ayar"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platform mekaniği"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_uk.dart
+++ b/gallery/gallery/lib/l10n/messages_uk.dart
@@ -677,9 +677,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Надіслати відгук"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Світла"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Мовний код"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Механіка платформи"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_ur.dart
+++ b/gallery/gallery/lib/l10n/messages_ur.dart
@@ -666,9 +666,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("تاثرات بھیجیں"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("ہلکی"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("زبان"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("پلیٹ فارم میکانیات"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("سلو موشن"),

--- a/gallery/gallery/lib/l10n/messages_uz.dart
+++ b/gallery/gallery/lib/l10n/messages_uz.dart
@@ -675,9 +675,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Kunduzgi"),
         "settingsLocale":
             MessageLookupByLibrary.simpleMessage("Hududiy sozlamalar"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Platforma"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_vi.dart
+++ b/gallery/gallery/lib/l10n/messages_vi.dart
@@ -669,9 +669,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Gửi phản hồi"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Sáng"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Ngôn ngữ"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("Cơ chế nền tảng"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/l10n/messages_zh.dart
+++ b/gallery/gallery/lib/l10n/messages_zh.dart
@@ -576,9 +576,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("发送反馈"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("浅色"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("语言区域"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("平台力学"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("慢镜头"),

--- a/gallery/gallery/lib/l10n/messages_zh_CN.dart
+++ b/gallery/gallery/lib/l10n/messages_zh_CN.dart
@@ -576,9 +576,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("发送反馈"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("浅色"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("语言区域"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("平台力学"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("慢镜头"),

--- a/gallery/gallery/lib/l10n/messages_zh_HK.dart
+++ b/gallery/gallery/lib/l10n/messages_zh_HK.dart
@@ -578,9 +578,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("傳送意見"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("淺色"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("語言代碼"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("平台運作方式"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("慢動作"),

--- a/gallery/gallery/lib/l10n/messages_zh_TW.dart
+++ b/gallery/gallery/lib/l10n/messages_zh_TW.dart
@@ -580,9 +580,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "settingsFeedback": MessageLookupByLibrary.simpleMessage("傳送意見回饋"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("淺色"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("語言代碼"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("平台操作"),
         "settingsSlowMotion": MessageLookupByLibrary.simpleMessage("慢動作"),

--- a/gallery/gallery/lib/l10n/messages_zu.dart
+++ b/gallery/gallery/lib/l10n/messages_zu.dart
@@ -701,9 +701,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Thumela impendulo"),
         "settingsLightTheme": MessageLookupByLibrary.simpleMessage("Ukukhanya"),
         "settingsLocale": MessageLookupByLibrary.simpleMessage("Isifunda"),
-        "settingsPlatformAndroid":
-            MessageLookupByLibrary.simpleMessage("I-Android"),
-        "settingsPlatformIOS": MessageLookupByLibrary.simpleMessage("I-iOS"),
         "settingsPlatformMechanics":
             MessageLookupByLibrary.simpleMessage("I-Platform mechanics"),
         "settingsSlowMotion":

--- a/gallery/gallery/lib/main.dart
+++ b/gallery/gallery/lib/main.dart
@@ -17,14 +17,11 @@ import 'package:gallery/pages/settings.dart';
 import 'package:gallery/pages/splash.dart';
 import 'package:gallery/themes/gallery_theme_data.dart';
 
+// TODO: Remove once TargetPlatform includes all desktop platforms.
 void setOverrideForDesktop() {
   if (kIsWeb) return;
 
-  if (Platform.isMacOS) {
-    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-  } else if (Platform.isLinux || Platform.isWindows) {
-    debugDefaultTargetPlatformOverride = TargetPlatform.android;
-  } else if (Platform.isFuchsia) {
+  if (Platform.isLinux || Platform.isWindows) {
     debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
   }
 }

--- a/gallery/gallery/lib/pages/settings.dart
+++ b/gallery/gallery/lib/pages/settings.dart
@@ -222,12 +222,9 @@ class _SettingsPageState extends State<SettingsPage> {
                     GalleryLocalizations.of(context).settingsPlatformMechanics,
                 selectedOption: options.platform,
                 options: LinkedHashMap.of({
-                  TargetPlatform.android: DisplayOption(
-                    GalleryLocalizations.of(context).settingsPlatformAndroid,
-                  ),
-                  TargetPlatform.iOS: DisplayOption(
-                    GalleryLocalizations.of(context).settingsPlatformIOS,
-                  ),
+                  TargetPlatform.android: DisplayOption('Android'),
+                  TargetPlatform.iOS: DisplayOption('iOS'),
+                  TargetPlatform.macOS: DisplayOption('macOS'),
                 }),
                 onOptionChanged: (newPlatform) => GalleryOptions.update(
                   context,


### PR DESCRIPTION
- Adds a platform setting for macOS.
- Removed unnecessary TargetPlatformOverrides, to match defaults in flutter/flutter
- Removed the unnecessary translations for the terms 'Android' and 'iOS'.

Closes material-components/material-components-flutter-gallery/issues/380

TODO: add Linux, Windows platform settings

We'll wait until the change makes it to the Flutter stable channel to merge.

![Simulator Screen Shot - iPhone 11 Pro - 2019-11-28 at 19 05 28](https://user-images.githubusercontent.com/6655696/69826184-4d12a400-1212-11ea-9ff8-d200b126ca9f.png)
