### PR TITLE
Remove unnecessary url_launcher pubspec entries

### DIFF
--- a/gallery/gallery/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/gallery/gallery/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
-import url_launcher_fde
+import shared_preferences_macos
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/gallery/gallery/pubspec.lock
+++ b/gallery/gallery/pubspec.lock
@@ -378,15 +378,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.4.1"
-  url_launcher_fde:
-    dependency: "direct main"
-    description:
-      path: "plugins/flutter_plugins/url_launcher_fde"
-      ref: a075c245ffdfc17409a3fff12517cf416aa77c87
-      resolved-ref: a075c245ffdfc17409a3fff12517cf416aa77c87
-      url: "git://github.com/google/flutter-desktop-embedding.git"
-    source: git
-    version: "0.0.1"
   url_launcher_macos:
     dependency: transitive
     description:
@@ -402,7 +393,7 @@ packages:
     source: hosted
     version: "1.0.4"
   url_launcher_web:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: url_launcher_web
       url: "https://pub.dartlang.org"

--- a/gallery/gallery/pubspec.yaml
+++ b/gallery/gallery/pubspec.yaml
@@ -21,12 +21,6 @@ dependencies:
   shrine_images: ^1.1.2
   flare_flutter: ^1.6.5
   url_launcher: ^5.1.6
-  url_launcher_web: ^0.1.0
-  url_launcher_fde:
-    git:
-      url: git://github.com/google/flutter-desktop-embedding.git
-      ref: a075c245ffdfc17409a3fff12517cf416aa77c87
-      path: plugins/flutter_plugins/url_launcher_fde
   flutter_localized_countries:
     git:
       url: git://github.com/guidezpl/flutter-localized-countries.git


### PR DESCRIPTION
This PR removes unnecessary url_launcher pubspec entries, now that web and mac support are included in the plugin