### PR TITLE
[Gallery] Modify grinder script to use preferred ordered locales

### DIFF
--- a/gallery/gallery/tool/grind.dart
+++ b/gallery/gallery/tool/grind.dart
@@ -37,6 +37,7 @@ Future<void> generateLocalizations() async {
     '--template-arb-file=intl_en_US.arb',
     '--output-localization-file=gallery_localizations.dart',
     '--output-class=GalleryLocalizations',
+    '--preferred-supported-locales=["en_US"]'
   ]);
   await format(path: path.join('lib', 'l10n'));
 }


### PR DESCRIPTION
This defaults the script to set 'en_US' for the default locale for the gallery application.

Related to https://github.com/flutter/flutter/pull/47845