### PR TITLE
Configuring travis to build Android.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ git:
 android:
   components:
     - build-tools-28.0.3
-    - build-tools-29.0.2
     - android-28
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ git:
 android:
   components:
     - build-tools-28.0.3
+    - build-tools-29.0.2
     - android-28
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ os:
   - linux
 dist: trusty
 language: android
+
 addons:
   apt:
     sources:
@@ -9,23 +10,35 @@ addons:
     packages:
       - libstdc++6
       - fonts-noto
+
 git:
   depth: 3
+
+android:
+  components:
+    - build-tools-28.0.3
+    - android-28
+
 env:
   - FLUTTER_VERSION=stable
   - FLUTTER_VERSION=beta
+
 jobs:
   allow_failures:
     - env: FLUTTER_VERSION=beta
+
 before_script:
   - git clone https://github.com/flutter/flutter.git -b $FLUTTER_VERSION
   - ./flutter/bin/flutter doctor
   - chmod +x travis_script.sh
+
 script:
   - ./travis_script.sh
+
 cache:
   directories:
     - $HOME/shared/.pub-cache
+
 notifications:
   email:
     brogdon+github@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
-sudo: false
+dist: trusty
+language: android
 addons:
   apt:
     sources:
@@ -13,7 +14,7 @@ git:
 env:
   - FLUTTER_VERSION=stable
   - FLUTTER_VERSION=beta
-matrix:
+jobs:
   allow_failures:
     - env: FLUTTER_VERSION=beta
 before_script:

--- a/add_to_app/android_fullscreen/app/build.gradle
+++ b/add_to_app/android_fullscreen/app/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "dev.flutter.example.androidfullscreen"
         minSdkVersion 19

--- a/add_to_app/android_using_plugin/app/build.gradle
+++ b/add_to_app/android_using_plugin/app/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "dev.flutter.example.androidusingplugin"
         minSdkVersion 19

--- a/add_to_app/android_using_prebuilt_module/app/build.gradle
+++ b/add_to_app/android_using_prebuilt_module/app/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "dev.flutter.example.androidusingprebuiltmodule"
         minSdkVersion 19

--- a/add_to_app/flutter_module/lib/main.dart
+++ b/add_to_app/flutter_module/lib/main.dart
@@ -15,7 +15,7 @@ void main() {
   final model = CounterModel();
 
   runApp(
-    ChangeNotifierProvider<CounterModel>.value(
+    ChangeNotifierProvider.value(
       value: model,
       child: MyApp(),
     ),

--- a/add_to_app/flutter_module/lib/main.dart
+++ b/add_to_app/flutter_module/lib/main.dart
@@ -22,8 +22,8 @@ void main() {
   );
 }
 
-/// An implementation of [CounterModel] that uses a [MethodChannel] as the
-/// source of truth for the state of the counter.
+/// A simple model that uses a [MethodChannel] as the source of truth for the
+/// state of a counter.
 ///
 /// Rather than storing app state data within the Flutter module itself (where
 /// the native portions of the app can't access it), this module passes messages

--- a/add_to_app/flutter_module/lib/main.dart
+++ b/add_to_app/flutter_module/lib/main.dart
@@ -12,25 +12,31 @@ void main() {
   // MethodChannel-based model.
   WidgetsFlutterBinding.ensureInitialized();
 
-  final model = CounterModel();
+  final model = ChannelBackedCounterModel();
 
   runApp(
-    ChangeNotifierProvider.value(
+    ChangeNotifierProvider<CounterModel>.value(
       value: model,
       child: MyApp(),
     ),
   );
 }
 
-/// A simple model that uses a [MethodChannel] as the source of truth for the
-/// state of the counter.
+/// A simple model that keeps track of a counter value.
+abstract class CounterModel extends ChangeNotifier {
+  int get count;
+  void increment();
+}
+
+/// An implementation of [CounterModel] that uses a [MethodChannel] as the
+/// source of truth for the state of the counter.
 ///
 /// Rather than storing app state data within the Flutter module itself (where
 /// the native portions of the app can't access it), this module passes messages
 /// back to the containing app whenever it needs to increment or retrieve the
 /// value of the counter.
-class CounterModel extends ChangeNotifier {
-  CounterModel() {
+class ChannelBackedCounterModel extends CounterModel {
+  ChannelBackedCounterModel() {
     _channel.setMethodCallHandler(_handleMessage);
     _channel.invokeMethod('requestCounter');
   }

--- a/add_to_app/flutter_module/lib/main.dart
+++ b/add_to_app/flutter_module/lib/main.dart
@@ -12,7 +12,7 @@ void main() {
   // MethodChannel-based model.
   WidgetsFlutterBinding.ensureInitialized();
 
-  final model = ChannelBackedCounterModel();
+  final model = CounterModel();
 
   runApp(
     ChangeNotifierProvider<CounterModel>.value(
@@ -22,12 +22,6 @@ void main() {
   );
 }
 
-/// A simple model that keeps track of a counter value.
-abstract class CounterModel extends ChangeNotifier {
-  int get count;
-  void increment();
-}
-
 /// An implementation of [CounterModel] that uses a [MethodChannel] as the
 /// source of truth for the state of the counter.
 ///
@@ -35,8 +29,8 @@ abstract class CounterModel extends ChangeNotifier {
 /// the native portions of the app can't access it), this module passes messages
 /// back to the containing app whenever it needs to increment or retrieve the
 /// value of the counter.
-class ChannelBackedCounterModel extends CounterModel {
-  ChannelBackedCounterModel() {
+class CounterModel extends ChangeNotifier {
+  CounterModel() {
     _channel.setMethodCallHandler(_handleMessage);
     _channel.invokeMethod('requestCounter');
   }

--- a/add_to_app/flutter_module/test/widget_test.dart
+++ b/add_to_app/flutter_module/test/widget_test.dart
@@ -11,7 +11,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_module/main.dart';
 import 'package:provider/provider.dart';
 
-class MockCounterModel extends CounterModel {
+class MockCounterModel extends ChangeNotifier
+    implements CounterModel {
   int _count = 0;
 
   int get count => _count;

--- a/add_to_app/flutter_module/test/widget_test.dart
+++ b/add_to_app/flutter_module/test/widget_test.dart
@@ -9,13 +9,28 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_module/main.dart';
+import 'package:provider/provider.dart';
+
+class MockCounterModel extends CounterModel {
+  int _count = 0;
+
+  int get count => _count;
+
+  void increment() {
+    _count++;
+    notifyListeners();
+  }
+}
 
 void main() {
   testWidgets('MiniView smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(
       MaterialApp(
-        home: Contents(),
+        home: ChangeNotifierProvider<CounterModel>.value(
+          value: MockCounterModel(),
+          child: Contents(),
+        ),
       ),
     );
 

--- a/add_to_app/flutter_module/test/widget_test.dart
+++ b/add_to_app/flutter_module/test/widget_test.dart
@@ -11,8 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_module/main.dart';
 import 'package:provider/provider.dart';
 
-class MockCounterModel extends ChangeNotifier
-    implements CounterModel {
+class MockCounterModel extends ChangeNotifier implements CounterModel {
   int _count = 0;
 
   int get count => _count;

--- a/add_to_app/flutter_module_using_plugin/lib/main.dart
+++ b/add_to_app/flutter_module_using_plugin/lib/main.dart
@@ -23,8 +23,8 @@ void main() {
   );
 }
 
-/// An implementation of [CounterModel] that uses a [MethodChannel] as the
-/// source of truth for the state of the counter.
+/// A simple model that uses a [MethodChannel] as the source of truth for the
+/// state of a counter.
 ///
 /// Rather than storing app state data within the Flutter module itself (where
 /// the native portions of the app can't access it), this module passes messages

--- a/add_to_app/flutter_module_using_plugin/lib/main.dart
+++ b/add_to_app/flutter_module_using_plugin/lib/main.dart
@@ -13,7 +13,7 @@ void main() {
   // MethodChannel-based model.
   WidgetsFlutterBinding.ensureInitialized();
 
-  final model = CounterModel();
+  final model = ChannelBackedCounterModel();
 
   runApp(
     ChangeNotifierProvider.value(
@@ -23,15 +23,21 @@ void main() {
   );
 }
 
-/// A simple model that uses a [MethodChannel] as the source of truth for the
-/// state of the counter.
+/// A simple model that keeps track of a counter value.
+abstract class CounterModel extends ChangeNotifier {
+  int get count;
+  void increment();
+}
+
+/// An implementation of [CounterModel] that uses a [MethodChannel] as the
+/// source of truth for the state of the counter.
 ///
 /// Rather than storing app state data within the Flutter module itself (where
 /// the native portions of the app can't access it), this module passes messages
 /// back to the containing app whenever it needs to increment or retrieve the
 /// value of the counter.
-class CounterModel extends ChangeNotifier {
-  CounterModel() {
+class ChannelBackedCounterModel extends CounterModel {
+  ChannelBackedCounterModel() {
     _channel.setMethodCallHandler(_handleMessage);
     _channel.invokeMethod('requestCounter');
   }

--- a/add_to_app/flutter_module_using_plugin/lib/main.dart
+++ b/add_to_app/flutter_module_using_plugin/lib/main.dart
@@ -13,7 +13,7 @@ void main() {
   // MethodChannel-based model.
   WidgetsFlutterBinding.ensureInitialized();
 
-  final model = ChannelBackedCounterModel();
+  final model = CounterModel();
 
   runApp(
     ChangeNotifierProvider.value(
@@ -23,12 +23,6 @@ void main() {
   );
 }
 
-/// A simple model that keeps track of a counter value.
-abstract class CounterModel extends ChangeNotifier {
-  int get count;
-  void increment();
-}
-
 /// An implementation of [CounterModel] that uses a [MethodChannel] as the
 /// source of truth for the state of the counter.
 ///
@@ -36,8 +30,8 @@ abstract class CounterModel extends ChangeNotifier {
 /// the native portions of the app can't access it), this module passes messages
 /// back to the containing app whenever it needs to increment or retrieve the
 /// value of the counter.
-class ChannelBackedCounterModel extends CounterModel {
-  ChannelBackedCounterModel() {
+class CounterModel extends ChangeNotifier {
+  CounterModel() {
     _channel.setMethodCallHandler(_handleMessage);
     _channel.invokeMethod('requestCounter');
   }

--- a/add_to_app/flutter_module_using_plugin/test/widget_test.dart
+++ b/add_to_app/flutter_module_using_plugin/test/widget_test.dart
@@ -9,13 +9,28 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_module_using_plugin/main.dart';
+import 'package:provider/provider.dart';
+
+class MockCounterModel extends CounterModel {
+  int _count = 0;
+
+  int get count => _count;
+
+  void increment() {
+    _count++;
+    notifyListeners();
+  }
+}
 
 void main() {
   testWidgets('MiniView smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(
       MaterialApp(
-        home: Contents(),
+        home: ChangeNotifierProvider<CounterModel>.value(
+          value: MockCounterModel(),
+          child: Contents(),
+        ),
       ),
     );
 

--- a/add_to_app/flutter_module_using_plugin/test/widget_test.dart
+++ b/add_to_app/flutter_module_using_plugin/test/widget_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_module_using_plugin/main.dart';
 import 'package:provider/provider.dart';
 
-class MockCounterModel extends CounterModel {
+class MockCounterModel extends ChangeNotifier implements CounterModel {
   int _count = 0;
 
   int get count => _count;

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -1,12 +1,13 @@
 set -e
 
-# Backs up one directory at a time, looking for one called "flutter".
+# Backs up one directory at a time, looking for one called "flutter". Once it
+# finds that directory, an absolute path to it is returned.
 function getFlutterPath() {
     local path=".."
     local counter=0
 
     while [[ "${counter}" -lt 10 ]]; do
-        [ -d "${path}/flutter" ] && echo "${path}/flutter" && return 0
+        [ -d "${path}/flutter" ] && echo "$(pwd)/${path}/flutter" && return 0
         let counter++
         path="${path}/.."
     done

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -17,13 +17,15 @@ localSdkPath=$(getFlutterPath)
 
 if [ -z "$localSdkPath" ]
 then
-    echo "Failed to find Flutter SDK!."
+    echo "Failed to find the Flutter SDK!."
     exit 1
 fi
 
 echo "Flutter SDK found at ${localSdkPath}"
 
 declare -a PROJECT_NAMES=(
+    "add_to_app/flutter_module" \
+    "add_to_app/flutter_module_using_plugin" \
     "animations" \
     "chrome-os-best-practices" \
     "gallery/gallery" \
@@ -55,16 +57,9 @@ do
     popd
 done
 
-
-echo "Initializing 'flutter_module'."
+echo "Building the aar files for 'flutter_module'."
 pushd add_to_app/flutter_module
-"${localSdkPath}/bin/flutter" packages get
 "${localSdkPath}/bin/flutter" build aar
-popd
-
-echo "Initializing 'flutter_module_using_plugin'."
-pushd add_to_app/flutter_module_using_plugin
-"${localSdkPath}/bin/flutter" packages get
 popd
 
 declare -a ANDROID_PROJECT_NAMES=(

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -3,13 +3,13 @@ set -e
 # Backs up one directory at a time, looking for one called "flutter". Once it
 # finds that directory, an absolute path to it is returned.
 function getFlutterPath() {
-    local path=".."
+    local path=""
     local counter=0
 
     while [[ "${counter}" -lt 10 ]]; do
-        [ -d "${path}/flutter" ] && echo "$(pwd)/${path}/flutter" && return 0
+        [ -d "${path}flutter" ] && echo "$(pwd)/${path}flutter" && return 0
         let counter++
-        path="${path}/.."
+        path="${path}../"
     done
 }
 
@@ -20,6 +20,8 @@ then
     echo "Failed to find Flutter SDK!."
     exit 1
 fi
+
+echo "Flutter SDK found at ${localSdkPath}"
 
 declare -a  PROJECT_NAMES=(
     "animations" \

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -38,22 +38,22 @@ declare -a  PROJECT_NAMES=(
     "veggieseasons" \
 )
 
-for PROJECT_NAME in "${PROJECT_NAMES[@]}"
-do
-    echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
-    pushd "${PROJECT_NAME}"
+# for PROJECT_NAME in "${PROJECT_NAMES[@]}"
+# do
+#     echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
+#     pushd "${PROJECT_NAME}"
 
-    # Run the analyzer to find any static analysis issues.
-    "${localSdkPath}/bin/flutter" analyze
+#     # Run the analyzer to find any static analysis issues.
+#     "${localSdkPath}/bin/flutter" analyze
 
-    # Run the formatter on all the dart files to make sure everything's linted.
-    "${localSdkPath}/bin/flutter" format -n --set-exit-if-changed .
+#     # Run the formatter on all the dart files to make sure everything's linted.
+#     "${localSdkPath}/bin/flutter" format -n --set-exit-if-changed .
 
-    # Run the actual tests.
-    "${localSdkPath}/bin/flutter" test
+#     # Run the actual tests.
+#     "${localSdkPath}/bin/flutter" test
 
-    popd
-done
+#     popd
+# done
 
 
 echo "Initializing 'flutter_module'."

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -59,12 +59,12 @@ declare -a PROJECT_NAMES=(
 echo "Initializing 'flutter_module'."
 pushd add_to_app/flutter_module
 "${localSdkPath}/bin/flutter" packages get
+"${localSdkPath}/bin/flutter" build aar
 popd
 
 echo "Initializing 'flutter_module_using_plugin'."
 pushd add_to_app/flutter_module_using_plugin
 "${localSdkPath}/bin/flutter" packages get
-"${localSdkPath}/bin/flutter" build aar
 popd
 
 declare -a ANDROID_PROJECT_NAMES=(

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -38,22 +38,22 @@ declare -a PROJECT_NAMES=(
     "veggieseasons" \
 )
 
-# for PROJECT_NAME in "${PROJECT_NAMES[@]}"
-# do
-#     echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
-#     pushd "${PROJECT_NAME}"
+for PROJECT_NAME in "${PROJECT_NAMES[@]}"
+do
+    echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
+    pushd "${PROJECT_NAME}"
 
-#     # Run the analyzer to find any static analysis issues.
-#     "${localSdkPath}/bin/flutter" analyze
+    # Run the analyzer to find any static analysis issues.
+    "${localSdkPath}/bin/flutter" analyze
 
-#     # Run the formatter on all the dart files to make sure everything's linted.
-#     "${localSdkPath}/bin/flutter" format -n --set-exit-if-changed .
+    # Run the formatter on all the dart files to make sure everything's linted.
+    "${localSdkPath}/bin/flutter" format -n --set-exit-if-changed .
 
-#     # Run the actual tests.
-#     "${localSdkPath}/bin/flutter" test
+    # Run the actual tests.
+    "${localSdkPath}/bin/flutter" test
 
-#     popd
-# done
+    popd
+done
 
 
 echo "Initializing 'flutter_module'."

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -67,14 +67,19 @@ pushd add_to_app/flutter_module_using_plugin
 "${localSdkPath}/bin/flutter" build aar
 popd
 
-declare -a ADD_TO_APP_PROJECT_NAMES=(
+declare -a ANDROID_PROJECT_NAMES=(
     "add_to_app/android_fullscreen" \
+    "add_to_app/android_using_plugin" \
+    "add_to_app/android_using_prebuilt_module" \
 )
 
-for PROJECT_NAME in "${ADD_TO_APP_PROJECT_NAMES[@]}"
+for PROJECT_NAME in "$ANDROID_PROJECT_NAMES[@]}"
 do
     echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
     pushd "${PROJECT_NAME}"
+
+    ./gradlew build
+
     popd
 done
 

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -33,9 +33,9 @@ do
     pushd "${PROJECT_NAME}"
 
     localSdkPath=$(getFlutterPath)
-    
+
     if [ -z "$localSdkPath" ]
-    then 
+    then
         echo "Failed to find Flutter SDK for '${PROJECT_NAME}'."
         exit 1
     fi

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -12,6 +12,14 @@ function getFlutterPath() {
     done
 }
 
+localSdkPath=$(getFlutterPath)
+
+if [ -z "$localSdkPath" ]
+then
+    echo "Failed to find Flutter SDK!."
+    exit 1
+fi
+
 declare -a  PROJECT_NAMES=(
     "animations" \
     "chrome-os-best-practices" \
@@ -32,14 +40,6 @@ do
     echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
     pushd "${PROJECT_NAME}"
 
-    localSdkPath=$(getFlutterPath)
-
-    if [ -z "$localSdkPath" ]
-    then
-        echo "Failed to find Flutter SDK for '${PROJECT_NAME}'."
-        exit 1
-    fi
-
     # Run the analyzer to find any static analysis issues.
     "${localSdkPath}/bin/flutter" analyze
 
@@ -49,6 +49,29 @@ do
     # Run the actual tests.
     "${localSdkPath}/bin/flutter" test
 
+    popd
+done
+
+
+echo "Initializing 'flutter_module'."
+pushd add_to_app/flutter_module
+"${localSdkPath}/bin/flutter" packages get
+popd
+
+echo "Initializing 'flutter_module_using_plugin'."
+pushd add_to_app/flutter_module_using_plugin
+"${localSdkPath}/bin/flutter" packages get
+flutter build aar
+popd
+
+declare -a ADD_TO_APP_PROJECT_NAMES=(
+    "add_to_app/android_fullscreen" \
+)
+
+for PROJECT_NAME in "${ADD_TO_APP_PROJECT_NAMES[@]}"
+do
+    echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
+    pushd "${PROJECT_NAME}"
     popd
 done
 

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -78,7 +78,8 @@ do
     echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
     pushd "${PROJECT_NAME}"
 
-    ./gradlew build
+    ./gradlew assembleDebug
+    ./gradlew assembleRelease
 
     popd
 done

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -23,7 +23,7 @@ fi
 
 echo "Flutter SDK found at ${localSdkPath}"
 
-declare -a  PROJECT_NAMES=(
+declare -a PROJECT_NAMES=(
     "animations" \
     "chrome-os-best-practices" \
     "gallery/gallery" \
@@ -73,7 +73,7 @@ declare -a ANDROID_PROJECT_NAMES=(
     "add_to_app/android_using_prebuilt_module" \
 )
 
-for PROJECT_NAME in "$ANDROID_PROJECT_NAMES[@]}"
+for PROJECT_NAME in "${ANDROID_PROJECT_NAMES[@]}"
 do
     echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
     pushd "${PROJECT_NAME}"

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -64,7 +64,7 @@ popd
 echo "Initializing 'flutter_module_using_plugin'."
 pushd add_to_app/flutter_module_using_plugin
 "${localSdkPath}/bin/flutter" packages get
-flutter build aar
+"${localSdkPath}/bin/flutter" build aar
 popd
 
 declare -a ADD_TO_APP_PROJECT_NAMES=(


### PR DESCRIPTION
Updates our Travis-based CI setup to:

* Format, analyze, and test the two add-to-app flutter modules.
* Build all three Android add-to-app projects in debug and release modes to verify that they actually build.

This has put some additional work into our tests, which is slowing them down. It may be possible to parallelize things more than what's done here, but that's fodder for another PR.

No iOS/Xcode testing is being done here, either, so that's a task still outstanding.