### PR TITLE
Misleading color translation to Russian

### DIFF
--- a/gallery/gallery/lib/l10n/intl_ru.arb
+++ b/gallery/gallery/lib/l10n/intl_ru.arb
@@ -466,7 +466,7 @@
   "colorsIndigo": "ИНДИГО",
   "colorsBlue": "СИНИЙ",
   "colorsLightBlue": "СВЕТЛО-ГОЛУБОЙ",
-  "colorsCyan": "БИРЮЗОВЫЙ",
+  "colorsCyan": "ЦИАН",
   "dialogAddAccount": "Добавить аккаунт",
   "Gallery": "Галерея",
   "Categories": "Категории",

--- a/gallery/gallery/lib/l10n/messages_ru.dart
+++ b/gallery/gallery/lib/l10n/messages_ru.dart
@@ -116,7 +116,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "colorsBlue": MessageLookupByLibrary.simpleMessage("СИНИЙ"),
         "colorsBlueGrey": MessageLookupByLibrary.simpleMessage("СИНЕ-СЕРЫЙ"),
         "colorsBrown": MessageLookupByLibrary.simpleMessage("КОРИЧНЕВЫЙ"),
-        "colorsCyan": MessageLookupByLibrary.simpleMessage("БИРЮЗОВЫЙ"),
+        "colorsCyan": MessageLookupByLibrary.simpleMessage("ЦИАН"),
         "colorsDeepOrange":
             MessageLookupByLibrary.simpleMessage("НАСЫЩЕННЫЙ ОРАНЖЕВЫЙ"),
         "colorsDeepPurple":


### PR DESCRIPTION
Translate "cyan" as "циан" (to be able to distinguish from "teal").