### PR TITLE
[Gallery] Remove top safe area from demo screen for desktop layout

### DIFF
--- a/gallery/gallery/lib/pages/demo.dart
+++ b/gallery/gallery/lib/pages/demo.dart
@@ -477,9 +477,13 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
 
     // Add the splash page functionality for desktop.
     if (isDesktop) {
-      page = SplashPage(
-        isAnimated: false,
-        child: page,
+      page = MediaQuery.removePadding(
+        removeTop: true,
+        context: context,
+        child: SplashPage(
+          isAnimated: false,
+          child: page,
+        ),
       );
     }
 


### PR DESCRIPTION
Since the desktop layout includes the black flutter banner, we don't need to include the top safe area.

Closes https://github.com/material-components/material-components-flutter-gallery/issues/522

**Before:**

![Simulator Screen Shot - iPad (7th generation) - 2020-01-07 at 15 08 05](https://user-images.githubusercontent.com/2364772/71926127-9551aa00-3160-11ea-94e6-afeffa7117ef.png)

**After:**

![Simulator Screen Shot - iPad (7th generation) - 2020-01-07 at 15 07 50](https://user-images.githubusercontent.com/2364772/71926131-997dc780-3160-11ea-88c2-cb15997ed9d6.png)
