### PR TITLE
Remove back button from demo appbars

### DIFF
--- a/gallery/gallery/lib/demos/cupertino/cupertino_activity_indicator_demo.dart
+++ b/gallery/gallery/lib/demos/cupertino/cupertino_activity_indicator_demo.dart
@@ -12,6 +12,7 @@ class CupertinoProgressIndicatorDemo extends StatelessWidget {
   Widget build(BuildContext context) {
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
+        automaticallyImplyLeading: false,
         middle: Text(
           GalleryLocalizations.of(context).demoCupertinoActivityIndicatorTitle,
         ),

--- a/gallery/gallery/lib/demos/cupertino/cupertino_slider_demo.dart
+++ b/gallery/gallery/lib/demos/cupertino/cupertino_slider_demo.dart
@@ -21,6 +21,7 @@ class _CupertinoSliderDemoState extends State<CupertinoSliderDemo> {
   Widget build(BuildContext context) {
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
+        automaticallyImplyLeading: false,
         middle: Text(GalleryLocalizations.of(context).demoCupertinoSliderTitle),
       ),
       child: DefaultTextStyle(

--- a/gallery/gallery/lib/demos/cupertino/cupertino_switch_demo.dart
+++ b/gallery/gallery/lib/demos/cupertino/cupertino_switch_demo.dart
@@ -20,6 +20,7 @@ class _CupertinoSwitchDemoState extends State<CupertinoSwitchDemo> {
   Widget build(BuildContext context) {
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
+        automaticallyImplyLeading: false,
         middle: Text(
           GalleryLocalizations.of(context).demoSelectionControlsSwitchTitle,
         ),

--- a/gallery/gallery/lib/demos/material/bottom_app_bar_demo.dart
+++ b/gallery/gallery/lib/demos/material/bottom_app_bar_demo.dart
@@ -39,6 +39,7 @@ class _BottomAppBarDemoState extends State<BottomAppBarDemo> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: Text(GalleryLocalizations.of(context).demoBottomAppBarTitle),
       ),
       body: ListView(

--- a/gallery/gallery/lib/demos/material/progress_indicator_demo.dart
+++ b/gallery/gallery/lib/demos/material/progress_indicator_demo.dart
@@ -93,6 +93,7 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo>
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: Text(_title),
       ),
       body: Center(


### PR DESCRIPTION
Forgot to do this for recently added demos now that they aren't separate MaterialApps