### PR TITLE
[Gallery] Account for safe area for shrine shopping cart on mobile

### DIFF
--- a/gallery/gallery/lib/studies/shrine/expanding_bottom_sheet.dart
+++ b/gallery/gallery/lib/studies/shrine/expanding_bottom_sheet.dart
@@ -388,6 +388,12 @@ class _ExpandingBottomSheetState extends State<ExpandingBottomSheet>
 
   bool get _cartIsVisible => _thumbnailOpacityAnimation.value == 0;
 
+  // We take 16 pts off of the bottom padding to ensure the collapsed shopping
+  // cart is not too tall.
+  double get _bottomSafeArea {
+    return max(MediaQuery.of(context).viewPadding.bottom - 16, 0);
+  }
+
   Widget _buildThumbnails(BuildContext context, int numProducts) {
     final bool isDesktop = isDisplayDesktop(context);
 
@@ -425,7 +431,7 @@ class _ExpandingBottomSheetState extends State<ExpandingBottomSheet>
                 width: min(numProducts, _maxThumbnailCount) *
                         _paddedThumbnailHeight(context) +
                     (numProducts > 0 ? _thumbnailGap : 0),
-                height: _height,
+                height: _height - _bottomSafeArea,
                 padding: const EdgeInsets.symmetric(vertical: 8),
                 child: ProductThumbnailRow(),
               ),
@@ -473,7 +479,7 @@ class _ExpandingBottomSheetState extends State<ExpandingBottomSheet>
     _widthAnimation = _getWidthAnimation(expandedCartWidth);
     _height = isDesktop
         ? _desktopHeightFor(numProducts, context)
-        : _mobileHeightFor(context);
+        : _mobileHeightFor(context) + _bottomSafeArea;
     _heightAnimation = _getHeightAnimation(screenHeight);
     _topStartShapeAnimation = _getShapeTopStartAnimation(context);
     _bottomStartShapeAnimation = _getShapeBottomStartAnimation(context);


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-flutter-gallery/issues/472

**Before:**

![Simulator Screen Shot - iPhone 11 Pro - 2020-01-08 at 16 45 35](https://user-images.githubusercontent.com/2364772/72018810-5db53180-3236-11ea-8eee-ff1d6fc46b9a.png)

**After:**

![Simulator Screen Shot - iPhone 11 Pro - 2020-01-08 at 16 45 13](https://user-images.githubusercontent.com/2364772/72018809-5d1c9b00-3236-11ea-9b55-f90506737c58.png)