### PR TITLE
Sharding travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-os:
-  - linux
+os: linux
 dist: trusty
-language: android
 
 addons:
   apt:
@@ -19,21 +17,31 @@ android:
     - build-tools-28.0.3
     - android-28
 
-env:
-  - FLUTTER_VERSION=stable
-  - FLUTTER_VERSION=beta
-
 jobs:
+  include:
+    - name: "Android tests, stable channel"
+      language: android
+      script: ./tool/travis_android_script.sh
+      env: FLUTTER_VERSION=stable
+    - name: "Flutter tests, stable channel"
+      language: ruby
+      script: ./tool/travis_flutter_script.sh
+      env: FLUTTER_VERSION=stable
+    - name: "Android tests, beta channel"
+      language: android
+      script: ./tool/travis_android_script.sh
+      env: FLUTTER_VERSION=beta
+    - name: "Flutter tests, beta channel"
+      language: ruby
+      script: ./tool/travis_flutter_script.sh
+      env: FLUTTER_VERSION=beta
   allow_failures:
     - env: FLUTTER_VERSION=beta
 
 before_script:
   - git clone https://github.com/flutter/flutter.git -b $FLUTTER_VERSION
   - ./flutter/bin/flutter doctor
-  - chmod +x travis_script.sh
-
-script:
-  - ./travis_script.sh
+  - chmod +x tool/travis_*_script.sh
 
 cache:
   directories:
@@ -43,6 +51,7 @@ notifications:
   email:
     brogdon+github@gmail.com
 
-# Only building master means that we don't run two builds for each pull request.
+# Building master alone means that we don't run two builds for
+# each pull request.
 branches:
   only: [master]

--- a/tool/travis_android_script.sh
+++ b/tool/travis_android_script.sh
@@ -45,8 +45,8 @@ do
     echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
     pushd "${PROJECT_NAME}"
 
-    ./gradlew assembleDebug
-    ./gradlew assembleRelease
+    ./gradlew --stacktrace assembleDebug
+    ./gradlew --stacktrace assembleRelease
 
     popd
 done

--- a/tool/travis_android_script.sh
+++ b/tool/travis_android_script.sh
@@ -1,0 +1,54 @@
+set -e
+
+# Backs up one directory at a time, looking for one called "flutter". Once it
+# finds that directory, an absolute path to it is returned.
+function getFlutterPath() {
+    local path=""
+    local counter=0
+
+    while [[ "${counter}" -lt 10 ]]; do
+        [ -d "${path}flutter" ] && echo "$(pwd)/${path}flutter" && return 0
+        let counter++
+        path="${path}../"
+    done
+}
+
+localSdkPath=$(getFlutterPath)
+
+if [ -z "$localSdkPath" ]
+then
+    echo "Failed to find the Flutter SDK!."
+    exit 1
+fi
+
+echo "Flutter SDK found at ${localSdkPath}"
+
+echo "Fetching dependencies and building 'flutter_module'."
+pushd add_to_app/flutter_module
+"${localSdkPath}/bin/flutter" packages get
+"${localSdkPath}/bin/flutter" build aar
+popd
+
+echo "Fetching dependencies for 'flutter_module_using_plugin'."
+pushd add_to_app/flutter_module
+"${localSdkPath}/bin/flutter" packages get
+popd
+
+declare -a ANDROID_PROJECT_NAMES=(
+    "add_to_app/android_fullscreen" \
+    "add_to_app/android_using_plugin" \
+    "add_to_app/android_using_prebuilt_module" \
+)
+
+for PROJECT_NAME in "${ANDROID_PROJECT_NAMES[@]}"
+do
+    echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
+    pushd "${PROJECT_NAME}"
+
+    ./gradlew assembleDebug
+    ./gradlew assembleRelease
+
+    popd
+done
+
+echo "-- Success --"

--- a/tool/travis_android_script.sh
+++ b/tool/travis_android_script.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 # Backs up one directory at a time, looking for one called "flutter". Once it
@@ -30,7 +32,7 @@ pushd add_to_app/flutter_module
 popd
 
 echo "Fetching dependencies for 'flutter_module_using_plugin'."
-pushd add_to_app/flutter_module
+pushd add_to_app/flutter_module_using_plugin
 "${localSdkPath}/bin/flutter" packages get
 popd
 

--- a/tool/travis_flutter_script.sh
+++ b/tool/travis_flutter_script.sh
@@ -57,31 +57,11 @@ do
     popd
 done
 
+# Test that the code segment widgets that get displayed in the Flutter Material
+# gallery have been generated using the latest gallery code.
 echo "Run code segments check for 'gallery/gallery'."
 pushd gallery/gallery
 "${localSdkPath}/bin/flutter" pub run grinder verify-code-segments
 popd
-
-echo "Building the aar files for 'flutter_module'."
-pushd add_to_app/flutter_module
-"${localSdkPath}/bin/flutter" build aar
-popd
-
-declare -a ANDROID_PROJECT_NAMES=(
-    "add_to_app/android_fullscreen" \
-    "add_to_app/android_using_plugin" \
-    "add_to_app/android_using_prebuilt_module" \
-)
-
-for PROJECT_NAME in "${ANDROID_PROJECT_NAMES[@]}"
-do
-    echo "== Testing '${PROJECT_NAME}' on Flutter's $FLUTTER_VERSION channel =="
-    pushd "${PROJECT_NAME}"
-
-    ./gradlew assembleDebug
-    ./gradlew assembleRelease
-
-    popd
-done
 
 echo "-- Success --"

--- a/tool/travis_flutter_script.sh
+++ b/tool/travis_flutter_script.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 # Backs up one directory at a time, looking for one called "flutter". Once it


### PR DESCRIPTION
* Creates a top-level tool directory.
* Moves the travis script into it.
* Forks travis script into two, one for pure Flutter, one for Android app builds.
  - These will be joined by a third for iOS stuff.
* Updates `.travis.yml` to use 2x2 jobs, with channel and script type as the dimensions.