### PR TITLE
[Gallery] Remove extra semantic node from shrine app bar

### DIFF
--- a/gallery/gallery/lib/studies/shrine/backdrop.dart
+++ b/gallery/gallery/lib/studies/shrine/backdrop.dart
@@ -142,38 +142,35 @@ class _BackdropTitle extends AnimatedWidget {
         ),
         // Here, we do a custom cross fade between backTitle and frontTitle.
         // This makes a smooth animation between the two texts.
-        Semantics(
-          container: true,
-          child: Stack(
-            children: [
-              Opacity(
-                opacity: CurvedAnimation(
-                  parent: ReverseAnimation(animation),
-                  curve: const Interval(0.5, 1),
-                ).value,
-                child: FractionalTranslation(
-                  translation: Tween<Offset>(
-                    begin: Offset.zero,
-                    end: Offset(0.5 * textDirectionScalar, 0),
-                  ).evaluate(animation),
-                  child: backTitle,
-                ),
+        Stack(
+          children: [
+            Opacity(
+              opacity: CurvedAnimation(
+                parent: ReverseAnimation(animation),
+                curve: const Interval(0.5, 1),
+              ).value,
+              child: FractionalTranslation(
+                translation: Tween<Offset>(
+                  begin: Offset.zero,
+                  end: Offset(0.5 * textDirectionScalar, 0),
+                ).evaluate(animation),
+                child: backTitle,
               ),
-              Opacity(
-                opacity: CurvedAnimation(
-                  parent: animation,
-                  curve: const Interval(0.5, 1),
-                ).value,
-                child: FractionalTranslation(
-                  translation: Tween<Offset>(
-                    begin: Offset(-0.25 * textDirectionScalar, 0),
-                    end: Offset.zero,
-                  ).evaluate(animation),
-                  child: frontTitle,
-                ),
+            ),
+            Opacity(
+              opacity: CurvedAnimation(
+                parent: animation,
+                curve: const Interval(0.5, 1),
+              ).value,
+              child: FractionalTranslation(
+                translation: Tween<Offset>(
+                  begin: Offset(-0.25 * textDirectionScalar, 0),
+                  end: Offset.zero,
+                ).evaluate(animation),
+                child: frontTitle,
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ]),
     );

--- a/gallery/gallery/macos/Podfile.lock
+++ b/gallery/gallery/macos/Podfile.lock
@@ -1,0 +1,38 @@
+PODS:
+  - FlutterMacOS (1.0.0)
+  - shared_preferences (0.0.1)
+  - shared_preferences_macos (0.0.1):
+    - FlutterMacOS
+  - url_launcher (0.0.1)
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - FlutterMacOS (from `Flutter/ephemeral/.symlinks/flutter/darwin-x64-release`)
+  - shared_preferences (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences/macos`)
+  - shared_preferences_macos (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos`)
+  - url_launcher (from `Flutter/ephemeral/.symlinks/plugins/url_launcher/macos`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
+
+EXTERNAL SOURCES:
+  FlutterMacOS:
+    :path: Flutter/ephemeral/.symlinks/flutter/darwin-x64-release
+  shared_preferences:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences/macos
+  shared_preferences_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos
+  url_launcher:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher/macos
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
+
+SPEC CHECKSUMS:
+  FlutterMacOS: 15bea8a44d2fa024068daa0140371c020b4b6ff9
+  shared_preferences: 9fec34d1bd906196a4da48fcf6c3ad521cc00b8d
+  shared_preferences_macos: 5e5c2839894accb56b7d23328905b757f2bafaf6
+  url_launcher: af78307ef9bafff91273b34f1c6c0c86a0004fd7
+  url_launcher_macos: 76867a28e24e0b6b98bfd65f157b64108e6d477a
+
+PODFILE CHECKSUM: d8ba9b3e9e93c62c74a660b46c6fcb09f03991a7
+
+COCOAPODS: 1.7.5


### PR DESCRIPTION
App bar semantics in Shrine:

**Before:**

* heading
* close menu button
* shrine
* search button
* settings button

**After:**

* shrine heading
* close menu button
* search button
* settings button

Closes https://github.com/material-components/material-components-flutter-gallery/issues/485

I also included the macos Podfile.lock since git kept showing it as a diff anytime you build for macOS.