### PR TITLE
Don't remove SettingsListItem content from tree

### DIFF
--- a/gallery/gallery/lib/pages/settings_list_item.dart
+++ b/gallery/gallery/lib/pages/settings_list_item.dart
@@ -227,25 +227,23 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
     return AnimatedBuilder(
       animation: _controller.view,
       builder: _buildHeaderWithChildren,
-      child: closed
-          ? null
-          : Container(
-              margin: const EdgeInsetsDirectional.only(start: 24, bottom: 40),
-              decoration: BoxDecoration(
-                border: BorderDirectional(
-                  start: BorderSide(
-                    width: 2,
-                    color: theme.colorScheme.background,
-                  ),
-                ),
-              ),
-              child: ListView.builder(
-                shrinkWrap: true,
-                physics: NeverScrollableScrollPhysics(),
-                itemBuilder: (context, index) => optionsList[index],
-                itemCount: optionsList.length,
-              ),
+      child: Container(
+        margin: const EdgeInsetsDirectional.only(start: 24, bottom: 40),
+        decoration: BoxDecoration(
+          border: BorderDirectional(
+            start: BorderSide(
+              width: 2,
+              color: theme.colorScheme.background,
             ),
+          ),
+        ),
+        child: ListView.builder(
+          shrinkWrap: true,
+          physics: NeverScrollableScrollPhysics(),
+          itemBuilder: (context, index) => optionsList[index],
+          itemCount: optionsList.length,
+        ),
+      ),
     );
   }
 }

--- a/gallery/gallery/lib/pages/settings_list_item.dart
+++ b/gallery/gallery/lib/pages/settings_list_item.dart
@@ -185,7 +185,6 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
   @override
   Widget build(BuildContext context) {
     _handleExpansion();
-    final closed = !widget.isExpanded && _controller.isDismissed;
     final theme = Theme.of(context);
 
     final optionsList = <Widget>[];


### PR DESCRIPTION
Small change that causes SettingsListItem content not to be removed unnecessarily from the tree based on whether it should be visible

## Related issues
https://github.com/material-components/material-components-flutter-gallery/issues/346