### PR TITLE
[Gallery] Preserve demo state, simplify demo width calculations on desktop

### DIFF
--- a/gallery/gallery/lib/pages/demo.dart
+++ b/gallery/gallery/lib/pages/demo.dart
@@ -345,7 +345,6 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
       demoContent = Semantics(
         label: MaterialLocalizations.of(context).modalBarrierDismissLabel,
         child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
           onTap: () {
             if (_state != _DemoState.normal) {
               setStateAndUpdate(() {

--- a/gallery/gallery/lib/pages/demo.dart
+++ b/gallery/gallery/lib/pages/demo.dart
@@ -256,12 +256,14 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
         appBar.preferredSize.height;
     final maxSectionHeight = isDesktop ? contentHeight : contentHeight - 64;
     final horizontalPadding = isDesktop ? mediaQuery.size.width * 0.12 : 0.0;
+    final maxSectionWidth = 420.0;
 
     Widget section;
     switch (_state) {
       case _DemoState.options:
         section = _DemoSectionOptions(
           maxHeight: maxSectionHeight,
+          maxWidth: maxSectionWidth,
           configurations: widget.demo.configurations,
           configIndex: _configIndex,
           onConfigChanged: (index) {
@@ -277,6 +279,7 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
       case _DemoState.info:
         section = _DemoSectionInfo(
           maxHeight: maxSectionHeight,
+          maxWidth: maxSectionWidth,
           title: _currentConfig.title,
           description: _currentConfig.description,
         );
@@ -314,46 +317,6 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
       buildRoute: _currentConfig.buildRoute,
     );
     if (isDesktop) {
-      // If the available width is not very wide, reduce the amount of space
-      // between the demo content and the selected section.
-      const reducedMiddleSpaceWidth = 48.0;
-
-      // Width of the space between the section and the demo content
-      // when the code is NOT displayed.
-      final nonCodePageMiddleSpaceWidth = mediaQuery.size.width > 900
-          ? horizontalPadding
-          : reducedMiddleSpaceWidth;
-
-      // Width of the space between the section and the demo content
-      // when the code is displayed.
-      final codePageMiddleSpaceWidth =
-          min(reducedMiddleSpaceWidth, nonCodePageMiddleSpaceWidth);
-
-      // Width of the space between the section and the demo content
-      final middleSpaceWidth = _state == _DemoState.code
-          ? codePageMiddleSpaceWidth
-          : nonCodePageMiddleSpaceWidth;
-
-      // Width for demo content.
-      // It is calculated in this way because the code demands more space.
-      final demoContentWidth = (mediaQuery.size.width -
-              horizontalPadding * 2 -
-              nonCodePageMiddleSpaceWidth) /
-          2;
-
-      final Widget sectionAndDemo = (_state == _DemoState.fullscreen)
-          ? demoContent
-          : Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(child: section),
-                SizedBox(width: middleSpaceWidth),
-                Container(
-                  width: demoContentWidth,
-                  child: demoContent,
-                ),
-              ],
-            );
 
       body = SafeArea(
         child: Padding(
@@ -494,12 +457,14 @@ class _DemoSectionOptions extends StatelessWidget {
   const _DemoSectionOptions({
     Key key,
     this.maxHeight,
+    this.maxWidth,
     this.configurations,
     this.configIndex,
     this.onConfigChanged,
   }) : super(key: key);
 
   final double maxHeight;
+  final double maxWidth;
   final List<GalleryDemoConfiguration> configurations;
   final int configIndex;
   final ValueChanged<int> onConfigChanged;
@@ -509,49 +474,52 @@ class _DemoSectionOptions extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
     final colorScheme = Theme.of(context).colorScheme;
 
-    return Container(
-      constraints: BoxConstraints(maxHeight: maxHeight),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Padding(
-            padding: const EdgeInsetsDirectional.only(
-              start: 24,
-              top: 12,
-              end: 24,
-            ),
-            child: Text(
-              GalleryLocalizations.of(context).demoOptionsTooltip,
-              style: textTheme.display1.apply(
-                color: colorScheme.onSurface,
-                fontSizeDelta:
-                    isDisplayDesktop(context) ? desktopDisplay1FontDelta : 0,
+    return Align(
+      alignment: AlignmentDirectional.topStart,
+      child: Container(
+        constraints: BoxConstraints(maxHeight: maxHeight, maxWidth: maxWidth),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsetsDirectional.only(
+                start: 24,
+                top: 12,
+                end: 24,
+              ),
+              child: Text(
+                GalleryLocalizations.of(context).demoOptionsTooltip,
+                style: textTheme.display1.apply(
+                  color: colorScheme.onSurface,
+                  fontSizeDelta:
+                      isDisplayDesktop(context) ? desktopDisplay1FontDelta : 0,
+                ),
               ),
             ),
-          ),
-          Divider(
-            thickness: 1,
-            height: 16,
-            color: colorScheme.onSurface,
-          ),
-          Flexible(
-            child: ListView(
-              shrinkWrap: true,
-              children: [
-                for (final configuration in configurations)
-                  _DemoSectionOptionsItem(
-                    title: configuration.title,
-                    isSelected: configuration == configurations[configIndex],
-                    onTap: () {
-                      onConfigChanged(configurations.indexOf(configuration));
-                    },
-                  ),
-              ],
+            Divider(
+              thickness: 1,
+              height: 16,
+              color: colorScheme.onSurface,
             ),
-          ),
-          SizedBox(height: 12),
-        ],
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  for (final configuration in configurations)
+                    _DemoSectionOptionsItem(
+                      title: configuration.title,
+                      isSelected: configuration == configurations[configIndex],
+                      onTap: () {
+                        onConfigChanged(configurations.indexOf(configuration));
+                      },
+                    ),
+                ],
+              ),
+            ),
+            SizedBox(height: 12),
+          ],
+        ),
       ),
     );
   }
@@ -597,11 +565,13 @@ class _DemoSectionInfo extends StatelessWidget {
   const _DemoSectionInfo({
     Key key,
     this.maxHeight,
+    this.maxWidth,
     this.title,
     this.description,
   }) : super(key: key);
 
   final double maxHeight;
+  final double maxWidth;
   final String title;
   final String description;
 
@@ -610,33 +580,36 @@ class _DemoSectionInfo extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
     final colorScheme = Theme.of(context).colorScheme;
 
-    return Container(
-      padding: const EdgeInsetsDirectional.only(
-        start: 24,
-        top: 12,
-        end: 24,
-        bottom: 32,
-      ),
-      constraints: BoxConstraints(maxHeight: maxHeight),
-      child: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              title,
-              style: textTheme.display1.apply(
-                color: colorScheme.onSurface,
-                fontSizeDelta:
-                    isDisplayDesktop(context) ? desktopDisplay1FontDelta : 0,
+    return Align(
+      alignment: AlignmentDirectional.topStart,
+      child: Container(
+        padding: const EdgeInsetsDirectional.only(
+          start: 24,
+          top: 12,
+          end: 24,
+          bottom: 32,
+        ),
+        constraints: BoxConstraints(maxHeight: maxHeight, maxWidth: maxWidth),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                title,
+                style: textTheme.display1.apply(
+                  color: colorScheme.onSurface,
+                  fontSizeDelta:
+                      isDisplayDesktop(context) ? desktopDisplay1FontDelta : 0,
+                ),
               ),
-            ),
-            SizedBox(height: 12),
-            Text(
-              description,
-              style: textTheme.body1.apply(color: colorScheme.onSurface),
-            ),
-          ],
+              SizedBox(height: 12),
+              Text(
+                description,
+                style: textTheme.body1.apply(color: colorScheme.onSurface),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/gallery/gallery/lib/pages/demo.dart
+++ b/gallery/gallery/lib/pages/demo.dart
@@ -371,20 +371,23 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
       );
 
       // Add a tap gesture to collapse the currently opened section.
-      if (_state != _DemoState.normal) {
-        demoContent = Semantics(
-          label: MaterialLocalizations.of(context).modalBarrierDismissLabel,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: () {
+      demoContent = Semantics(
+        label: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () {
+            if (_state != _DemoState.normal) {
               setStateAndUpdate(() {
                 _state = _DemoState.normal;
               });
-            },
-            child: ExcludeSemantics(child: demoContent),
+            }
+          },
+          child: Semantics(
+            excludeSemantics: _state != _DemoState.normal,
+            child: demoContent,
           ),
-        );
-      }
+        ),
+      );
 
       body = SafeArea(
         bottom: false,

--- a/gallery/gallery/lib/pages/demo.dart
+++ b/gallery/gallery/lib/pages/demo.dart
@@ -317,6 +317,15 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
       buildRoute: _currentConfig.buildRoute,
     );
     if (isDesktop) {
+      final isFullScreen = _state == _DemoState.fullscreen;
+      final Widget sectionAndDemo = Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (!isFullScreen) Expanded(child: section),
+          SizedBox(width: !isFullScreen ? 48.0 : 0),
+          Expanded(child: demoContent),
+        ],
+      );
 
       body = SafeArea(
         child: Padding(

--- a/gallery/gallery/lib/pages/demo.dart
+++ b/gallery/gallery/lib/pages/demo.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:io' show Platform;
-import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';


### PR DESCRIPTION
TLDR: Fixes a bugs on both desktop and mobile which caused demo state to be reset. 
This was caused by rendering different trees; on mobile: based on whether the options/info panels were open; on desktop, based on whether the demo was in fullscreen. Additionally on desktop, it seemed that conditionally rendering the sized box (or container) preceding the demoContent caused the demoContent widget to be fully rebuilt. Instead, I always specify its width.

This PR also removes width calculations, instead specifying a max width for info and options panes. This incidentally causes the demoContent to remain the same width regardless of the chosen section on desktop. The demoContent grows with the screen size, as before. The section on the left grows until the specified max width.

<img width="1771" alt="Screen Shot 2020-01-28 at 11 57 23 AM" src="https://user-images.githubusercontent.com/6655696/73258962-0d8f1680-41c7-11ea-8482-2d88070b39fc.png">
<img width="1771" alt="Screen Shot 2020-01-28 at 11 57 27 AM" src="https://user-images.githubusercontent.com/6655696/73258963-0d8f1680-41c7-11ea-8c55-660ee44015bd.png">
<img width="1771" alt="Screen Shot 2020-01-28 at 11 57 29 AM" src="https://user-images.githubusercontent.com/6655696/73258964-0d8f1680-41c7-11ea-8af9-cefc03025ccf.png">
<img width="963" alt="Screen Shot 2020-01-28 at 11 57 39 AM" src="https://user-images.githubusercontent.com/6655696/73258965-0d8f1680-41c7-11ea-9a10-b1f9d1d90e86.png">


Closes https://github.com/material-components/material-components-flutter-gallery/issues/312