### PR TITLE
[Gallery] Close Shrine cart on back button press for android

### DIFF
--- a/gallery/gallery/lib/studies/shrine/app.dart
+++ b/gallery/gallery/lib/studies/shrine/app.dart
@@ -78,7 +78,7 @@ class _ShrineAppState extends State<ShrineApp> with TickerProviderStateMixin {
     );
   }
 
-  // Closes the bottom sheet if it is open (this should only be relevant for Android).
+  // Closes the bottom sheet if it is open.
   Future<bool> _onWillPop() async {
     final status = _expandingController.status;
     if (status == AnimationStatus.completed ||

--- a/gallery/gallery/lib/studies/shrine/app.dart
+++ b/gallery/gallery/lib/studies/shrine/app.dart
@@ -78,6 +78,18 @@ class _ShrineAppState extends State<ShrineApp> with TickerProviderStateMixin {
     );
   }
 
+  // Closes the bottom sheet if it is open (this should only be relevant for Android).
+  Future<bool> _onWillPop() async {
+    final status = _expandingController.status;
+    if (status == AnimationStatus.completed ||
+        status == AnimationStatus.forward) {
+      _expandingController.reverse();
+      return false;
+    }
+
+    return true;
+  }
+
   @override
   Widget build(BuildContext context) {
     final bool isDesktop = isDisplayDesktop(context);
@@ -86,34 +98,37 @@ class _ShrineAppState extends State<ShrineApp> with TickerProviderStateMixin {
 
     return ScopedModel<AppStateModel>(
       model: _model,
-      child: MaterialApp(
-        navigatorKey: widget.navigatorKey,
-        title: 'Shrine',
-        debugShowCheckedModeBanner: false,
-        home: LayoutCache(
-          layouts: _layouts,
-          child: PageStatus(
-            menuController: _controller,
-            cartController: _expandingController,
-            child: HomePage(
-              backdrop: backdrop,
-              scrim: Scrim(controller: _expandingController),
-              expandingBottomSheet: ExpandingBottomSheet(
-                hideController: _controller,
-                expandingController: _expandingController,
+      child: WillPopScope(
+        onWillPop: _onWillPop,
+        child: MaterialApp(
+          navigatorKey: widget.navigatorKey,
+          title: 'Shrine',
+          debugShowCheckedModeBanner: false,
+          home: LayoutCache(
+            layouts: _layouts,
+            child: PageStatus(
+              menuController: _controller,
+              cartController: _expandingController,
+              child: HomePage(
+                backdrop: backdrop,
+                scrim: Scrim(controller: _expandingController),
+                expandingBottomSheet: ExpandingBottomSheet(
+                  hideController: _controller,
+                  expandingController: _expandingController,
+                ),
               ),
             ),
           ),
+          initialRoute: '/login',
+          onGenerateRoute: _getRoute,
+          theme: shrineTheme.copyWith(
+            platform: GalleryOptions.of(context).platform,
+          ),
+          // L10n settings.
+          localizationsDelegates: GalleryLocalizations.localizationsDelegates,
+          supportedLocales: GalleryLocalizations.supportedLocales,
+          locale: GalleryOptions.of(context).locale,
         ),
-        initialRoute: '/login',
-        onGenerateRoute: _getRoute,
-        theme: shrineTheme.copyWith(
-          platform: GalleryOptions.of(context).platform,
-        ),
-        // L10n settings.
-        localizationsDelegates: GalleryLocalizations.localizationsDelegates,
-        supportedLocales: GalleryLocalizations.supportedLocales,
-        locale: GalleryOptions.of(context).locale,
       ),
     );
   }

--- a/gallery/gallery/lib/studies/shrine/expanding_bottom_sheet.dart
+++ b/gallery/gallery/lib/studies/shrine/expanding_bottom_sheet.dart
@@ -2,11 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:scoped_model/scoped_model.dart';
 
@@ -51,11 +49,11 @@ double _paddedThumbnailHeight(BuildContext context) {
 }
 
 class ExpandingBottomSheet extends StatefulWidget {
-  const ExpandingBottomSheet(
-      {Key key,
-      @required this.hideController,
-      @required this.expandingController})
-      : assert(hideController != null),
+  const ExpandingBottomSheet({
+    Key key,
+    @required this.hideController,
+    @required this.expandingController,
+  })  : assert(hideController != null),
         assert(expandingController != null),
         super(key: key);
 
@@ -551,18 +549,6 @@ class _ExpandingBottomSheetState extends State<ExpandingBottomSheet>
     }
   }
 
-  // Closes the cart if the cart is open, otherwise exits the app (this should
-  // only be relevant for Android).
-  Future<bool> _onWillPop() async {
-    if (!_isOpen) {
-      await SystemNavigator.pop();
-      return true;
-    }
-
-    close();
-    return true;
-  }
-
   @override
   Widget build(BuildContext context) {
     return AnimatedSize(
@@ -571,16 +557,13 @@ class _ExpandingBottomSheetState extends State<ExpandingBottomSheet>
       curve: Curves.easeInOut,
       vsync: this,
       alignment: AlignmentDirectional.topStart,
-      child: WillPopScope(
-        onWillPop: _onWillPop,
-        child: AnimatedBuilder(
-          animation: widget.hideController,
-          builder: (context, child) => AnimatedBuilder(
-            animation: widget.expandingController,
-            builder: (context, child) => ScopedModelDescendant<AppStateModel>(
-              builder: (context, child, model) =>
-                  _buildSlideAnimation(context, _buildCart(context)),
-            ),
+      child: AnimatedBuilder(
+        animation: widget.hideController,
+        builder: (context, child) => AnimatedBuilder(
+          animation: widget.expandingController,
+          builder: (context, child) => ScopedModelDescendant<AppStateModel>(
+            builder: (context, child, model) =>
+                _buildSlideAnimation(context, _buildCart(context)),
           ),
         ),
       ),


### PR DESCRIPTION
Move up `WillPopScope` above `MaterialApp` to make sure that when the expanding bottom sheet (cart) is open, it will close the sheet instead of going back when pressing the back button on Android.

Closes https://github.com/material-components/material-components-flutter-gallery/issues/519