### PR TITLE
[Gallery] Add padding to demo appBar

### DIFF
--- a/gallery/gallery/lib/pages/demo.dart
+++ b/gallery/gallery/lib/pages/demo.dart
@@ -179,6 +179,7 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
     final colorScheme = Theme.of(context).colorScheme;
     final iconColor = colorScheme.onSurface;
     final selectedIconColor = colorScheme.primary;
+    final appBarPadding = 20.0;
 
     final appBar = AppBar(
       backgroundColor: Colors.transparent,
@@ -190,6 +191,7 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
         },
       ),
       actions: [
+        SizedBox(width: appBarPadding),
         if (_hasOptions)
           IconButton(
             icon: FeatureDiscovery(
@@ -245,6 +247,7 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
                 _state == _DemoState.fullscreen ? selectedIconColor : iconColor,
             onPressed: () => _handleTap(_DemoState.fullscreen),
           ),
+        SizedBox(width: appBarPadding),
       ],
     );
 

--- a/gallery/gallery/lib/pages/demo.dart
+++ b/gallery/gallery/lib/pages/demo.dart
@@ -179,7 +179,7 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
     final colorScheme = Theme.of(context).colorScheme;
     final iconColor = colorScheme.onSurface;
     final selectedIconColor = colorScheme.primary;
-    final appBarPadding = 20.0;
+    final appBarPadding = isDesktop ? 20.0 : 0.0;
 
     final appBar = AppBar(
       backgroundColor: Colors.transparent,

--- a/gallery/gallery/lib/pages/demo.dart
+++ b/gallery/gallery/lib/pages/demo.dart
@@ -179,7 +179,6 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
     final colorScheme = Theme.of(context).colorScheme;
     final iconColor = colorScheme.onSurface;
     final selectedIconColor = colorScheme.primary;
-    final appBarPadding = 20.0;
 
     final appBar = AppBar(
       backgroundColor: Colors.transparent,
@@ -191,7 +190,6 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
         },
       ),
       actions: [
-        SizedBox(width: appBarPadding),
         if (_hasOptions)
           IconButton(
             icon: FeatureDiscovery(
@@ -247,7 +245,7 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
                 _state == _DemoState.fullscreen ? selectedIconColor : iconColor,
             onPressed: () => _handleTap(_DemoState.fullscreen),
           ),
-        SizedBox(width: appBarPadding),
+        SizedBox(width: 20),
       ],
     );
 

--- a/gallery/gallery/lib/pages/demo.dart
+++ b/gallery/gallery/lib/pages/demo.dart
@@ -179,15 +179,19 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
     final colorScheme = Theme.of(context).colorScheme;
     final iconColor = colorScheme.onSurface;
     final selectedIconColor = colorScheme.primary;
+    final appBarPadding = 20.0;
 
     final appBar = AppBar(
       backgroundColor: Colors.transparent,
-      leading: IconButton(
-        icon: const BackButtonIcon(),
-        tooltip: MaterialLocalizations.of(context).backButtonTooltip,
-        onPressed: () {
-          Navigator.maybePop(context);
-        },
+      leading: Padding(
+        padding: EdgeInsetsDirectional.only(start: appBarPadding),
+        child: IconButton(
+          icon: const BackButtonIcon(),
+          tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+          onPressed: () {
+            Navigator.maybePop(context);
+          },
+        ),
       ),
       actions: [
         if (_hasOptions)
@@ -245,7 +249,7 @@ class _DemoPageState extends State<DemoPage> with TickerProviderStateMixin {
                 _state == _DemoState.fullscreen ? selectedIconColor : iconColor,
             onPressed: () => _handleTap(_DemoState.fullscreen),
           ),
-        SizedBox(width: 20),
+        SizedBox(width: appBarPadding),
       ],
     );
 


### PR DESCRIPTION
This adds a bit of padding after the actions for the last ripple to be visible

Closes https://github.com/material-components/material-components-flutter-gallery/issues/208

<img width="1175" alt="Screen Shot 2020-01-28 at 3 28 12 PM" src="https://user-images.githubusercontent.com/6655696/73272645-0118b700-41e3-11ea-8965-70fcd4c65360.png">
<img width="460" alt="Screen Shot 2020-01-28 at 3 45 24 PM" src="https://user-images.githubusercontent.com/6655696/73274074-3d4d1700-41e5-11ea-9c9f-b00895cbb3ac.png">
