### PR TITLE
[Gallery] Exclude semantics for logo and change to hint for products on Shrine

### DIFF
--- a/gallery/gallery/lib/studies/shrine/login.dart
+++ b/gallery/gallery/lib/studies/shrine/login.dart
@@ -85,18 +85,20 @@ class _ShrineLogo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Image.asset(
-          'packages/shrine_images/diamond.png',
-          excludeFromSemantics: true,
-        ),
-        const SizedBox(height: 16),
-        Text(
-          'SHRINE',
-          style: Theme.of(context).textTheme.headline,
-        ),
-      ],
+    return ExcludeSemantics(
+      child: Column(
+        children: [
+          Image.asset(
+            'packages/shrine_images/diamond.png',
+            excludeFromSemantics: true,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'SHRINE',
+            style: Theme.of(context).textTheme.headline,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/gallery/gallery/lib/studies/shrine/login.dart
+++ b/gallery/gallery/lib/studies/shrine/login.dart
@@ -88,10 +88,7 @@ class _ShrineLogo extends StatelessWidget {
     return ExcludeSemantics(
       child: Column(
         children: [
-          Image.asset(
-            'packages/shrine_images/diamond.png',
-            excludeFromSemantics: true,
-          ),
+          Image.asset('packages/shrine_images/diamond.png'),
           const SizedBox(height: 16),
           Text(
             'SHRINE',

--- a/gallery/gallery/lib/studies/shrine/supplemental/product_card.dart
+++ b/gallery/gallery/lib/studies/shrine/supplemental/product_card.dart
@@ -77,7 +77,7 @@ Widget _buildProductCard({
   return ScopedModelDescendant<AppStateModel>(
     builder: (context, child, model) {
       return Semantics(
-        onTapHint:
+        hint:
             GalleryLocalizations.of(context).shrineScreenReaderProductAddToCart,
         child: GestureDetector(
           onTap: () {


### PR DESCRIPTION
- We do not need to read out the Shrine logo for screen readers (from the a11y talk on Flutter Interact: https://youtu.be/bWbBgbmAdQs?t=849).
- On VoiceOver we do not read onTapHint, so I changed it to hint.

Closes https://github.com/material-components/material-components-flutter-gallery/issues/483