### PR TITLE
[Gallery] Modify desktop layout for crane when running in "Small desktop" size

### DIFF
--- a/gallery/gallery/lib/layout/adaptive.dart
+++ b/gallery/gallery/lib/layout/adaptive.dart
@@ -10,6 +10,7 @@ enum DisplayType {
 }
 
 const _desktopBreakpoint = 700.0;
+const _smallDesktopMaxWidth = 1000.0;
 
 /// Returns the [DisplayType] for the current screen. This app only supports
 /// mobile and desktop layouts, and as such we only have one breakpoint.
@@ -25,4 +26,11 @@ DisplayType displayTypeOf(BuildContext context) {
 /// build adaptive and responsive layouts.
 bool isDisplayDesktop(BuildContext context) {
   return displayTypeOf(context) == DisplayType.desktop;
+}
+
+/// Returns a boolean if we are in a display of [DisplayType.desktop] but less
+/// than 1000 width. Used to build adaptive and responsive layouts.
+bool isDisplaySmallDesktop(BuildContext context) {
+  return isDisplayDesktop(context) &&
+      MediaQuery.of(context).size.width < _smallDesktopMaxWidth;
 }

--- a/gallery/gallery/lib/studies/crane/backdrop.dart
+++ b/gallery/gallery/lib/studies/crane/backdrop.dart
@@ -15,6 +15,7 @@ import 'package:gallery/layout/adaptive.dart';
 import 'package:gallery/studies/crane/border_tab_indicator.dart';
 import 'package:gallery/studies/crane/backlayer.dart';
 import 'package:gallery/studies/crane/colors.dart';
+import 'package:gallery/studies/crane/header_form.dart';
 import 'package:gallery/studies/crane/item_cards.dart';
 
 class _FrontLayer extends StatelessWidget {
@@ -152,7 +153,11 @@ class _BackdropState extends State<Backdrop> with TickerProviderStateMixin {
                   Container(
                     margin: EdgeInsets.only(
                       top: isDesktop
-                          ? 60 + 20 * textScaleFactor / 2
+                          ? (MediaQuery.of(context).size.width <
+                                      twoColumnThreshold
+                                  ? textFieldHeight * 2
+                                  : textFieldHeight) +
+                              20 * textScaleFactor / 2
                           : 175 + 140 * textScaleFactor / 2,
                     ),
                     child: TabBarView(

--- a/gallery/gallery/lib/studies/crane/backdrop.dart
+++ b/gallery/gallery/lib/studies/crane/backdrop.dart
@@ -33,6 +33,8 @@ class _FrontLayer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
+    final isSmallDesktop =
+        MediaQuery.of(context).size.width < smallDesktopThreshold;
 
     return DefaultFocusTraversal(
       policy: ReadingOrderTraversalPolicy(),
@@ -49,7 +51,10 @@ class _FrontLayer extends StatelessWidget {
         ),
         child: ListView(
           padding: isDesktop
-              ? EdgeInsets.symmetric(horizontal: 120, vertical: 22)
+              ? EdgeInsets.symmetric(
+                  horizontal:
+                      isSmallDesktop ? appPaddingSmall : appPaddingLarge,
+                  vertical: 22)
               : EdgeInsets.all(20),
           children: [
             Text(title, style: Theme.of(context).textTheme.subtitle),
@@ -154,7 +159,7 @@ class _BackdropState extends State<Backdrop> with TickerProviderStateMixin {
                     margin: EdgeInsets.only(
                       top: isDesktop
                           ? (MediaQuery.of(context).size.width <
-                                      twoColumnThreshold
+                                      smallDesktopThreshold
                                   ? textFieldHeight * 2
                                   : textFieldHeight) +
                               20 * textScaleFactor / 2
@@ -219,10 +224,15 @@ class _CraneAppBarState extends State<CraneAppBar> {
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
     final textScaleFactor = GalleryOptions.of(context).textScaleFactor(context);
+    final isSmallDesktop =
+        MediaQuery.of(context).size.width < smallDesktopThreshold;
 
     return SafeArea(
       child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: isDesktop ? 120 : 24),
+        padding: EdgeInsets.symmetric(
+          horizontal:
+              isDesktop && !isSmallDesktop ? appPaddingLarge : appPaddingSmall,
+        ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           crossAxisAlignment: CrossAxisAlignment.center,

--- a/gallery/gallery/lib/studies/crane/backdrop.dart
+++ b/gallery/gallery/lib/studies/crane/backdrop.dart
@@ -33,8 +33,7 @@ class _FrontLayer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
-    final isSmallDesktop =
-        MediaQuery.of(context).size.width < smallDesktopThreshold;
+    final isSmallDesktop = isDisplaySmallDesktop(context);
 
     return DefaultFocusTraversal(
       policy: ReadingOrderTraversalPolicy(),
@@ -158,8 +157,7 @@ class _BackdropState extends State<Backdrop> with TickerProviderStateMixin {
                   Container(
                     margin: EdgeInsets.only(
                       top: isDesktop
-                          ? (MediaQuery.of(context).size.width <
-                                      smallDesktopThreshold
+                          ? (isDisplaySmallDesktop(context)
                                   ? textFieldHeight * 2
                                   : textFieldHeight) +
                               20 * textScaleFactor / 2
@@ -223,9 +221,8 @@ class _CraneAppBarState extends State<CraneAppBar> {
   @override
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
+    final isSmallDesktop = isDisplaySmallDesktop(context);
     final textScaleFactor = GalleryOptions.of(context).textScaleFactor(context);
-    final isSmallDesktop =
-        MediaQuery.of(context).size.width < smallDesktopThreshold;
 
     return SafeArea(
       child: Padding(

--- a/gallery/gallery/lib/studies/crane/header_form.dart
+++ b/gallery/gallery/lib/studies/crane/header_form.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:gallery/layout/adaptive.dart';
 import 'package:gallery/studies/crane/colors.dart';
 
-const smallDesktopThreshold = 1000.0;
 const textFieldHeight = 60.0;
 const appPaddingLarge = 120.0;
 const appPaddingSmall = 24.0;
@@ -27,8 +26,7 @@ class HeaderForm extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
-    final isSmallDesktop =
-        MediaQuery.of(context).size.width < smallDesktopThreshold;
+    final isSmallDesktop = isDisplaySmallDesktop(context);
     return Padding(
       padding: EdgeInsets.symmetric(
         horizontal:
@@ -36,10 +34,7 @@ class HeaderForm extends StatelessWidget {
       ),
       child: isDesktop
           ? LayoutBuilder(builder: (context, constraints) {
-              var crossAxisCount =
-                  MediaQuery.of(context).size.width < smallDesktopThreshold
-                      ? 2
-                      : 4;
+              var crossAxisCount = isSmallDesktop ? 2 : 4;
               if (fields.length < crossAxisCount) {
                 crossAxisCount = fields.length;
               }

--- a/gallery/gallery/lib/studies/crane/header_form.dart
+++ b/gallery/gallery/lib/studies/crane/header_form.dart
@@ -6,8 +6,10 @@ import 'package:flutter/material.dart';
 import 'package:gallery/layout/adaptive.dart';
 import 'package:gallery/studies/crane/colors.dart';
 
-const twoColumnThreshold = 1000.0;
+const smallDesktopThreshold = 1000.0;
 const textFieldHeight = 60.0;
+const appPaddingLarge = 120.0;
+const appPaddingSmall = 24.0;
 
 class HeaderFormField {
   final IconData iconData;
@@ -25,12 +27,17 @@ class HeaderForm extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
+    final isSmallDesktop =
+        MediaQuery.of(context).size.width < smallDesktopThreshold;
     return Padding(
-      padding: EdgeInsets.symmetric(horizontal: isDesktop ? 120 : 24),
+      padding: EdgeInsets.symmetric(
+        horizontal:
+            isDesktop && !isSmallDesktop ? appPaddingLarge : appPaddingSmall,
+      ),
       child: isDesktop
           ? LayoutBuilder(builder: (context, constraints) {
               var crossAxisCount =
-                  MediaQuery.of(context).size.width < twoColumnThreshold
+                  MediaQuery.of(context).size.width < smallDesktopThreshold
                       ? 2
                       : 4;
               if (fields.length < crossAxisCount) {

--- a/gallery/gallery/lib/studies/crane/header_form.dart
+++ b/gallery/gallery/lib/studies/crane/header_form.dart
@@ -47,6 +47,7 @@ class HeaderForm extends StatelessWidget {
               return GridView.count(
                 crossAxisCount: crossAxisCount,
                 childAspectRatio: itemWidth / textFieldHeight,
+                physics: NeverScrollableScrollPhysics(),
                 children: [
                   for (final field in fields)
                     Padding(

--- a/gallery/gallery/lib/studies/crane/header_form.dart
+++ b/gallery/gallery/lib/studies/crane/header_form.dart
@@ -6,6 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:gallery/layout/adaptive.dart';
 import 'package:gallery/studies/crane/colors.dart';
 
+const twoColumnThreshold = 1000.0;
+const textFieldHeight = 60.0;
+
 class HeaderFormField {
   final IconData iconData;
   final String title;
@@ -22,21 +25,30 @@ class HeaderForm extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
-
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: isDesktop ? 120 : 24),
       child: isDesktop
-          ? Row(
-              children: [
-                for (final field in fields)
-                  Flexible(
-                    child: Padding(
+          ? LayoutBuilder(builder: (context, constraints) {
+              var crossAxisCount =
+                  MediaQuery.of(context).size.width < twoColumnThreshold
+                      ? 2
+                      : 4;
+              if (fields.length < crossAxisCount) {
+                crossAxisCount = fields.length;
+              }
+              final itemWidth = constraints.maxWidth / crossAxisCount;
+              return GridView.count(
+                crossAxisCount: crossAxisCount,
+                childAspectRatio: itemWidth / textFieldHeight,
+                children: [
+                  for (final field in fields)
+                    Padding(
                       padding: const EdgeInsetsDirectional.only(end: 16),
                       child: _HeaderTextField(field: field),
-                    ),
-                  )
-              ],
-            )
+                    )
+                ],
+              );
+            })
           : Column(
               mainAxisSize: MainAxisSize.min,
               children: [


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-flutter-gallery/issues/137

This change:
* Define `isSmallDesktop` for Crane to be isDesktop + less than 1000 width
* Modifies textfield layout to use two columns when `isSmallDesktop`
* Modifies crane padding when `isSmallDesktop` to use the mobile padding instead.

<img width="1422" alt="Screen Shot 2020-01-29 at 2 26 55 PM" src="https://user-images.githubusercontent.com/2364772/73390603-6da7ba80-42a4-11ea-9e33-1cb92c998859.png">
<img width="979" alt="Screen Shot 2020-01-29 at 2 26 59 PM" src="https://user-images.githubusercontent.com/2364772/73390604-6da7ba80-42a4-11ea-9aae-f23ba80266c6.png">
<img width="709" alt="Screen Shot 2020-01-29 at 2 27 04 PM" src="https://user-images.githubusercontent.com/2364772/73390605-6e405100-42a4-11ea-8425-4712476f096d.png">

