### PR TITLE
Follow best practice of ProxyProvider updating

### DIFF
--- a/provider_shopper/lib/main.dart
+++ b/provider_shopper/lib/main.dart
@@ -27,9 +27,11 @@ class MyApp extends StatelessWidget {
         // of ChangeNotifierProvider. Moreover, CartModel depends
         // on CatalogModel, so a ProxyProvider is needed.
         ChangeNotifierProxyProvider<CatalogModel, CartModel>(
-          create: (context) => CartModel.empty(),
-          update: (context, catalog, previousCart) =>
-              CartModel(catalog, previousCart),
+          create: (context) => CartModel(),
+          update: (context, catalog, cart) {
+            cart.catalog = catalog;
+            return cart;
+          },
         ),
       ],
       child: MaterialApp(

--- a/provider_shopper/lib/models/cart.dart
+++ b/provider_shopper/lib/models/cart.dart
@@ -6,25 +6,25 @@ import 'package:flutter/foundation.dart';
 import 'package:provider_shopper/models/catalog.dart';
 
 class CartModel extends ChangeNotifier {
-  /// The current catalog. Used to construct items from numeric ids.
-  final CatalogModel _catalog;
+  /// The private field backing [catalog].
+  CatalogModel _catalog;
 
   /// Internal, private state of the cart. Stores the ids of each item.
-  final List<int> _itemIds;
+  final List<int> _itemIds = [];
 
-  /// Construct a CartModel instance that is backed by a [CatalogModel] and
-  /// an optional previous state of the cart.
-  ///
-  /// If [previous] is not `null`, its items are copied to the newly
-  /// constructed instance.
-  CartModel(this._catalog, CartModel previous)
-      : assert(_catalog != null),
-        _itemIds = previous?._itemIds ?? [];
+  /// The current catalog. Used to construct items from numeric ids.
+  CatalogModel get catalog => _catalog;
 
-  /// An empty cart with no Catalog.
-  CartModel.empty()
-      : _catalog = null,
-        _itemIds = [];
+  set catalog(CatalogModel newCatalog) {
+    assert(newCatalog != null);
+    assert(_itemIds.every((id) => newCatalog.getById(id) != null),
+        'The catalog $newCatalog does not have one of $_itemIds in it.');
+    _catalog = newCatalog;
+    // Notify listeners, in case the new catalog provides information
+    // different from the previous one. For example, availability of an item
+    // might have changed.
+    notifyListeners();
+  }
 
   /// List of items in the cart.
   List<Item> get items => _itemIds.map((id) => _catalog.getById(id)).toList();

--- a/provider_shopper/pubspec.lock
+++ b/provider_shopper/pubspec.lock
@@ -88,6 +88,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.8"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   path:
     dependency: transitive
     description:
@@ -115,7 +122,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.2"
   quiver:
     dependency: transitive
     description:
@@ -193,3 +200,4 @@ packages:
     version: "3.5.0"
 sdks:
   dart: ">=2.5.0 <3.0.0"
+  flutter: ">=1.12.1"

--- a/provider_shopper/pubspec.yaml
+++ b/provider_shopper/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   # Import the provider package.
-  provider: ^3.1.0
+  provider: ^4.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The addresses feedback from https://github.com/flutter/samples/issues/245. Instead of constructing a new `CartModel`, we merely update the `catalog` field.

We no longer need a fancy constructor, and `CartModel._catalog` cannot be final any more.

This change also upgrades to `pkg:provider` 4.0.2, just to stay on top of things (it's was a no-op in the case of this sample).