### PR TITLE
Disable dark mode for Veggieseasons

### DIFF
--- a/veggieseasons/lib/main.dart
+++ b/veggieseasons/lib/main.dart
@@ -23,6 +23,9 @@ void main() {
       child: ScopedModel<Preferences>(
         model: Preferences()..load(),
         child: CupertinoApp(
+          theme: CupertinoThemeData(
+            brightness: Brightness.light,
+          ),
           debugShowCheckedModeBanner: false,
           color: Styles.appBackground,
           home: HomeScreen(),


### PR DESCRIPTION
We still have plenty of work to do for #322, so this PR is a stopgap. It hardcodes the brightness level in `CupertinoApp` to light, effectively ignoring the OS dark mode setting.

This isn't a great state to be in, and work on #322 should still be prioritized. 