### PR TITLE
changed CupertinoPicker backgroundColor in platform_design

### DIFF
--- a/platform_design/lib/widgets.dart
+++ b/platform_design/lib/widgets.dart
@@ -325,6 +325,7 @@ void showChoices(BuildContext context, List<String> choices) {
           return SizedBox(
             height: 250,
             child: CupertinoPicker(
+              backgroundColor: Colors.white,
               useMagnifier: true,
               magnification: 1.1,
               itemExtent: 40,


### PR DESCRIPTION
The by default `backgroundColor` of `CuperintoPicker` was causing reading issues. Changed the `backgroundColor` to white to increase the readability of items.

Before
<img src="https://user-images.githubusercontent.com/34301187/75432231-203a6e00-5974-11ea-80fd-0c1d5aa5b96d.jpg" width="400">

After
<img src="https://user-images.githubusercontent.com/34301187/75432324-4102c380-5974-11ea-9388-5acf01eee477.jpg" width="400">
