### PR TITLE
Fix Crane example searchbar margin

### DIFF
--- a/gallery/lib/studies/crane/backdrop.dart
+++ b/gallery/lib/studies/crane/backdrop.dart
@@ -168,8 +168,8 @@ class _BackdropState extends State<Backdrop> with TickerProviderStateMixin {
                     margin: EdgeInsets.only(
                       top: isDesktop
                           ? (isDisplaySmallDesktop(context)
-                                  ? textFieldHeight * 2
-                                  : textFieldHeight) +
+                                  ? textFieldHeight * 3
+                                  : textFieldHeight * 2) +
                               20 * textScaleFactor / 2
                           : 175 + 140 * textScaleFactor / 2,
                     ),


### PR DESCRIPTION
closes #349 

Fixed screenshot:
![image](https://user-images.githubusercontent.com/6723574/75869845-07401b80-5dbf-11ea-8177-3a20aee369ab.png)
