### PR TITLE
[platform_design]Fix problems in dark mode

### DIFF
--- a/platform_design/lib/main.dart
+++ b/platform_design/lib/main.dart
@@ -20,6 +20,7 @@ class MyAdaptingApp extends StatelessWidget {
         // Use the green theme for Material widgets.
         primarySwatch: Colors.green,
       ),
+      darkTheme: ThemeData.dark(),
       builder: (context, child) {
         return CupertinoTheme(
           // Instead of letting Cupertino widgets auto-adapt to the Material

--- a/platform_design/lib/news_tab.dart
+++ b/platform_design/lib/news_tab.dart
@@ -96,7 +96,6 @@ class _NewsTabState extends State<NewsTab> {
         title: Text(NewsTab.title),
       ),
       body: Container(
-        color: Colors.grey[100],
         child: ListView.builder(
           itemBuilder: _listBuilder,
         ),
@@ -108,7 +107,6 @@ class _NewsTabState extends State<NewsTab> {
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(),
       child: Container(
-        color: Colors.grey[100],
         child: ListView.builder(
           itemBuilder: _listBuilder,
         ),

--- a/platform_design/lib/news_tab.dart
+++ b/platform_design/lib/news_tab.dart
@@ -106,10 +106,8 @@ class _NewsTabState extends State<NewsTab> {
   Widget _buildIos(BuildContext context) {
     return CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(),
-      child: Container(
-        child: ListView.builder(
-          itemBuilder: _listBuilder,
-        ),
+      child: ListView.builder(
+        itemBuilder: _listBuilder,
       ),
     );
   }

--- a/platform_design/lib/widgets.dart
+++ b/platform_design/lib/widgets.dart
@@ -222,7 +222,7 @@ class SongPlaceholderTile extends StatelessWidget {
         child: Row(
           children: [
             Container(
-              color: Colors.grey[400],
+              color: Theme.of(context).disabledColor,
               width: 130,
             ),
             Padding(
@@ -235,27 +235,27 @@ class SongPlaceholderTile extends StatelessWidget {
                   Container(
                     height: 9,
                     margin: EdgeInsets.only(right: 60),
-                    color: Colors.grey[300],
+                    color: Theme.of(context).disabledColor,
                   ),
                   Container(
                     height: 9,
                     margin: EdgeInsets.only(right: 20, top: 8),
-                    color: Colors.grey[300],
+                    color: Theme.of(context).disabledColor,
                   ),
                   Container(
                     height: 9,
                     margin: EdgeInsets.only(right: 40, top: 8),
-                    color: Colors.grey[300],
+                    color: Theme.of(context).disabledColor,
                   ),
                   Container(
                     height: 9,
                     margin: EdgeInsets.only(right: 80, top: 8),
-                    color: Colors.grey[300],
+                    color: Theme.of(context).disabledColor,
                   ),
                   Container(
                     height: 9,
                     margin: EdgeInsets.only(right: 50, top: 8),
-                    color: Colors.grey[300],
+                    color: Theme.of(context).disabledColor,
                   ),
                 ],
               ),
@@ -325,6 +325,7 @@ void showChoices(BuildContext context, List<String> choices) {
           return SizedBox(
             height: 250,
             child: CupertinoPicker(
+              backgroundColor: Theme.of(context).canvasColor,
               useMagnifier: true,
               magnification: 1.1,
               itemExtent: 40,

--- a/platform_design/lib/widgets.dart
+++ b/platform_design/lib/widgets.dart
@@ -222,7 +222,7 @@ class SongPlaceholderTile extends StatelessWidget {
         child: Row(
           children: [
             Container(
-              color: Theme.of(context).disabledColor,
+              color: Theme.of(context).textTheme.body1.color,
               width: 130,
             ),
             Padding(
@@ -235,27 +235,27 @@ class SongPlaceholderTile extends StatelessWidget {
                   Container(
                     height: 9,
                     margin: EdgeInsets.only(right: 60),
-                    color: Theme.of(context).disabledColor,
+                    color: Theme.of(context).textTheme.body1.color,
                   ),
                   Container(
                     height: 9,
                     margin: EdgeInsets.only(right: 20, top: 8),
-                    color: Theme.of(context).disabledColor,
+                    color: Theme.of(context).textTheme.body1.color,
                   ),
                   Container(
                     height: 9,
                     margin: EdgeInsets.only(right: 40, top: 8),
-                    color: Theme.of(context).disabledColor,
+                    color: Theme.of(context).textTheme.body1.color,
                   ),
                   Container(
                     height: 9,
                     margin: EdgeInsets.only(right: 80, top: 8),
-                    color: Theme.of(context).disabledColor,
+                    color: Theme.of(context).textTheme.body1.color,
                   ),
                   Container(
                     height: 9,
                     margin: EdgeInsets.only(right: 50, top: 8),
-                    color: Theme.of(context).disabledColor,
+                    color: Theme.of(context).textTheme.body1.color,
                   ),
                 ],
               ),


### PR DESCRIPTION
I've fixed all the problems related to dark mode in #376.
I've simply changed the color property of the problem causing widgets to grab from the current theme.

Please have a look @RedBrogdon @johnpryan.

iOS:
<img src="https://user-images.githubusercontent.com/30566863/76840069-9720a380-685c-11ea-990f-18143205bdeb.gif" width="300">

Android:
<img src="https://user-images.githubusercontent.com/30566863/76847992-f5538380-6868-11ea-842a-c2c408448305.gif" width="300">

