### PR TITLE
Replaced deprecated terms in animations with newer ones

### DIFF
--- a/animations/lib/main.dart
+++ b/animations/lib/main.dart
@@ -117,7 +117,7 @@ class AnimationSamples extends StatelessWidget {
 
 class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
-    final headerStyle = Theme.of(context).textTheme.title;
+    final headerStyle = Theme.of(context).textTheme.headline6;
     return Scaffold(
       appBar: AppBar(
         title: Text('Animation Samples'),

--- a/animations/lib/src/basics/02_page_route_builder.dart
+++ b/animations/lib/src/basics/02_page_route_builder.dart
@@ -42,7 +42,7 @@ class _Page2 extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(),
       body: Center(
-        child: Text('Page 2!', style: Theme.of(context).textTheme.display1),
+        child: Text('Page 2!', style: Theme.of(context).textTheme.headline4),
       ),
     );
   }

--- a/animations/lib/src/basics/03_animation_controller.dart
+++ b/animations/lib/src/basics/03_animation_controller.dart
@@ -62,7 +62,7 @@ class _AnimationControllerDemoState extends State<AnimationControllerDemo>
               constraints: BoxConstraints(maxWidth: 200),
               child: Text(
                 '${controller.value.toStringAsFixed(2)}',
-                style: Theme.of(context).textTheme.display2,
+                style: Theme.of(context).textTheme.headline3,
                 textScaleFactor: 1 + controller.value,
               ),
             ),


### PR DESCRIPTION
Updated deprecated term 'title' in animations/lib/main.dart
Updated deprecated term 'display2' in animations/lib/src/basics/03_animation_controller.dart
Updated deprecated term 'display1' in animations/lib/src/basics/02_page_route_builder.dart
