### PR TITLE
a little change to make the code more readable

### DIFF
--- a/provider_shopper/lib/main.dart
+++ b/provider_shopper/lib/main.dart
@@ -11,9 +11,7 @@ import 'package:provider_shopper/screens/cart.dart';
 import 'package:provider_shopper/screens/catalog.dart';
 import 'package:provider_shopper/screens/login.dart';
 
-void main() {
-  runApp(MyApp());
-}
+main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
   @override


### PR DESCRIPTION
In the previous version 

it was
void main(){
  runApp(MyApp());
}

but 
using fat arrow the code looks good and more readable

main() => runApp(MyApp())