### PR TITLE
[web_dashboard] add logout

### DIFF
--- a/experimental/web_dashboard/lib/src/app.dart
+++ b/experimental/web_dashboard/lib/src/app.dart
@@ -77,13 +77,17 @@ class _DashboardAppState extends State<DashboardApp> {
   void _handleSignIn(User user, BuildContext context, AppState appState) {
     appState.api = widget.apiBuilder(user);
 
-    _showPage(HomePage(), context);
+    _showPage(HomePage(onLogout: _handleLogout), context);
   }
 
   /// Navigates to the home page using a fade transition.
   void _showPage(Widget page, BuildContext context) {
     var route = _fadeRoute(page);
     Navigator.of(context).pushReplacement(route);
+  }
+
+  void _handleLogout() {
+
   }
 
   /// Creates a [Route] that shows [newPage] using a fade transition.

--- a/experimental/web_dashboard/lib/src/app.dart
+++ b/experimental/web_dashboard/lib/src/app.dart
@@ -65,10 +65,11 @@ class _DashboardAppState extends State<DashboardApp> {
     return Provider.value(
       value: _appState,
       child: MaterialApp(
-          home: SignInSwitcher(
-        appState: _appState,
-        apiBuilder: widget.apiBuilder,
-      )),
+        home: SignInSwitcher(
+          appState: _appState,
+          apiBuilder: widget.apiBuilder,
+        ),
+      ),
     );
   }
 }

--- a/experimental/web_dashboard/lib/src/app.dart
+++ b/experimental/web_dashboard/lib/src/app.dart
@@ -23,7 +23,9 @@ class AppState {
   AppState(this.auth);
 }
 
-/// Creates a [DashboardApi] when the user is logged in.
+/// Creates a [DashboardApi] for the given user. This allows users of this
+/// widget to specify whether [MockDashboardApi] or [ApiBuilder] should be
+/// created when the user logs in.
 typedef DashboardApi ApiBuilder(User user);
 
 /// An app that displays a personalized dashboard.
@@ -63,45 +65,61 @@ class _DashboardAppState extends State<DashboardApp> {
     return Provider.value(
       value: _appState,
       child: MaterialApp(
-        home: Builder(
-          builder: (context) => SignInPage(
-            auth: _appState.auth,
-            onSuccess: (user) => _handleSignIn(user, context, _appState),
-          ),
-        ),
-      ),
+          home: SignInSwitcher(
+        appState: _appState,
+        apiBuilder: widget.apiBuilder,
+      )),
+    );
+  }
+}
+
+/// Switches between showing the [SignInPage] or [HomePage], depending on
+/// whether or not the user is signed in.
+class SignInSwitcher extends StatefulWidget {
+  final AppState appState;
+  final ApiBuilder apiBuilder;
+
+  SignInSwitcher({
+    this.appState,
+    this.apiBuilder,
+  });
+
+  @override
+  _SignInSwitcherState createState() => _SignInSwitcherState();
+}
+
+class _SignInSwitcherState extends State<SignInSwitcher> {
+  bool _isSignedIn = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeOut,
+      duration: Duration(milliseconds: 200),
+      child: _isSignedIn
+          ? HomePage(
+              onSignOut: _handleSignOut,
+            )
+          : SignInPage(
+              auth: widget.appState.auth,
+              onSuccess: _handleSignIn,
+            ),
     );
   }
 
-  /// Sets the DashboardApi on AppState and navigates to the home page.
-  void _handleSignIn(User user, BuildContext context, AppState appState) {
-    appState.api = widget.apiBuilder(user);
+  void _handleSignIn(User user) {
+    widget.appState.api = widget.apiBuilder(user);
 
-    _showPage(HomePage(onLogout: _handleLogout), context);
+    setState(() {
+      _isSignedIn = true;
+    });
   }
 
-  /// Navigates to the home page using a fade transition.
-  void _showPage(Widget page, BuildContext context) {
-    var route = _fadeRoute(page);
-    Navigator.of(context).pushReplacement(route);
-  }
-
-  void _handleLogout() {
-
-  }
-
-  /// Creates a [Route] that shows [newPage] using a fade transition.
-  Route<FadeTransition> _fadeRoute(Widget newPage) {
-    return PageRouteBuilder<FadeTransition>(
-      pageBuilder: (context, animation, secondaryAnimation) {
-        return newPage;
-      },
-      transitionsBuilder: (context, animation, secondaryAnimation, child) {
-        return FadeTransition(
-          opacity: animation.drive(CurveTween(curve: Curves.ease)),
-          child: child,
-        );
-      },
-    );
+  Future _handleSignOut() async {
+    await widget.appState.auth.signOut();
+    setState(() {
+      _isSignedIn = false;
+    });
   }
 }

--- a/experimental/web_dashboard/lib/src/auth/auth.dart
+++ b/experimental/web_dashboard/lib/src/auth/auth.dart
@@ -11,3 +11,5 @@ abstract class Auth {
 abstract class User {
   String get uid;
 }
+
+class SignInException implements Exception {}

--- a/experimental/web_dashboard/lib/src/auth/auth.dart
+++ b/experimental/web_dashboard/lib/src/auth/auth.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 abstract class Auth {
+  Future<bool> isSignedIn();
   Future<User> signIn();
   Future signOut();
 }

--- a/experimental/web_dashboard/lib/src/auth/auth.dart
+++ b/experimental/web_dashboard/lib/src/auth/auth.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 abstract class Auth {
-  Future<bool> isSignedIn();
+  Future<bool> get isSignedIn;
   Future<User> signIn();
   Future signOut();
 }

--- a/experimental/web_dashboard/lib/src/auth/firebase.dart
+++ b/experimental/web_dashboard/lib/src/auth/firebase.dart
@@ -11,9 +11,13 @@ class FirebaseAuthService implements Auth {
   final GoogleSignIn _googleSignIn = GoogleSignIn();
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
+  Future<bool> isSignedIn() {
+    return _googleSignIn.isSignedIn();
+  }
+
   Future<User> signIn() async {
     GoogleSignInAccount googleUser;
-    if (await _googleSignIn.isSignedIn()) {
+    if (await isSignedIn()) {
       googleUser = await _googleSignIn.signInSilently();
     } else {
       googleUser = await _googleSignIn.signIn();

--- a/experimental/web_dashboard/lib/src/auth/firebase.dart
+++ b/experimental/web_dashboard/lib/src/auth/firebase.dart
@@ -34,7 +34,10 @@ class FirebaseAuthService implements Auth {
   }
 
   Future<void> signOut() async {
-    await _auth.signOut();
+    await Future.wait([
+      _auth.signOut(),
+      _googleSignIn.signOut(),
+    ]);
   }
 }
 

--- a/experimental/web_dashboard/lib/src/auth/firebase.dart
+++ b/experimental/web_dashboard/lib/src/auth/firebase.dart
@@ -11,13 +11,11 @@ class FirebaseAuthService implements Auth {
   final GoogleSignIn _googleSignIn = GoogleSignIn();
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
-  Future<bool> isSignedIn() {
-    return _googleSignIn.isSignedIn();
-  }
+  Future<bool> get isSignedIn => _googleSignIn.isSignedIn();
 
   Future<User> signIn() async {
     GoogleSignInAccount googleUser;
-    if (await isSignedIn()) {
+    if (await isSignedIn) {
       googleUser = await _googleSignIn.signInSilently();
     } else {
       googleUser = await _googleSignIn.signIn();

--- a/experimental/web_dashboard/lib/src/auth/firebase.dart
+++ b/experimental/web_dashboard/lib/src/auth/firebase.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:flutter/services.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:firebase_auth/firebase_auth.dart' hide FirebaseUser;
 
@@ -14,6 +15,15 @@ class FirebaseAuthService implements Auth {
   Future<bool> get isSignedIn => _googleSignIn.isSignedIn();
 
   Future<User> signIn() async {
+    try {
+      return await _signIn();
+    } on PlatformException catch (e) {
+      print('Unable to sign in: $e');
+      throw SignInException();
+    }
+  }
+
+  Future<User> _signIn() async {
     GoogleSignInAccount googleUser;
     if (await isSignedIn) {
       googleUser = await _googleSignIn.signInSilently();
@@ -44,3 +54,5 @@ class _FirebaseUser implements User {
 
   _FirebaseUser(this.uid);
 }
+
+class SignInException implements Exception {}

--- a/experimental/web_dashboard/lib/src/auth/firebase.dart
+++ b/experimental/web_dashboard/lib/src/auth/firebase.dart
@@ -55,4 +55,3 @@ class _FirebaseUser implements User {
   _FirebaseUser(this.uid);
 }
 
-class SignInException implements Exception {}

--- a/experimental/web_dashboard/lib/src/auth/mock.dart
+++ b/experimental/web_dashboard/lib/src/auth/mock.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:math';
+
 import 'auth.dart';
 
 class MockAuthService implements Auth {
@@ -9,6 +11,11 @@ class MockAuthService implements Auth {
 
   @override
   Future<User> signIn() async {
+    // Sign in will randomly fail 25% of the time.
+    var random = Random();
+    if (random.nextInt(4) == 0)  {
+      throw SignInException();
+    }
     return MockUser();
   }
 

--- a/experimental/web_dashboard/lib/src/auth/mock.dart
+++ b/experimental/web_dashboard/lib/src/auth/mock.dart
@@ -5,6 +5,8 @@
 import 'auth.dart';
 
 class MockAuthService implements Auth {
+  Future<bool> isSignedIn() async => false;
+
   @override
   Future<User> signIn() async {
     return MockUser();

--- a/experimental/web_dashboard/lib/src/auth/mock.dart
+++ b/experimental/web_dashboard/lib/src/auth/mock.dart
@@ -5,7 +5,7 @@
 import 'auth.dart';
 
 class MockAuthService implements Auth {
-  Future<bool> isSignedIn() async => false;
+  Future<bool> get isSignedIn async => false;
 
   @override
   Future<User> signIn() async {

--- a/experimental/web_dashboard/lib/src/pages/home.dart
+++ b/experimental/web_dashboard/lib/src/pages/home.dart
@@ -10,10 +10,10 @@ import 'dashboard.dart';
 import 'entries.dart';
 
 class HomePage extends StatefulWidget {
-  final VoidCallback onLogout;
+  final VoidCallback onSignOut;
 
   HomePage({
-    @required this.onLogout,
+    @required this.onSignOut,
   });
 
   @override
@@ -32,8 +32,8 @@ class _HomePageState extends State<HomePage> {
           padding: const EdgeInsets.all(8.0),
           child: FlatButton(
             textColor: Colors.white,
-            onPressed: () => _handleLogout(),
-            child: Text('Logout'),
+            onPressed: () => _handleSignOut(),
+            child: Text('Sign Out'),
           ),
         )
       ],
@@ -84,11 +84,11 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  Future<void> _handleLogout() async {
-    var shouldLogout = await showDialog<bool>(
+  Future<void> _handleSignOut() async {
+    var shouldSignOut = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text('Are you sure you want to log out?'),
+        title: Text('Are you sure you want to sign out?'),
         actions: [
           FlatButton(
             child: Text('No'),
@@ -106,11 +106,11 @@ class _HomePageState extends State<HomePage> {
       ),
     );
 
-    if (!shouldLogout) {
+    if (!shouldSignOut) {
       return;
     }
 
-    widget.onLogout();
+    widget.onSignOut();
   }
 
   static Widget _pageAtIndex(int index) {

--- a/experimental/web_dashboard/lib/src/pages/home.dart
+++ b/experimental/web_dashboard/lib/src/pages/home.dart
@@ -10,6 +10,12 @@ import 'dashboard.dart';
 import 'entries.dart';
 
 class HomePage extends StatefulWidget {
+  final VoidCallback onLogout;
+
+  HomePage({
+    @required this.onLogout,
+  });
+
   @override
   _HomePageState createState() => _HomePageState();
 }
@@ -20,6 +26,17 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return AdaptiveScaffold(
+      title: Text('Dashboard App'),
+      actions: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: FlatButton(
+            textColor: Colors.white,
+            onPressed: () => _handleLogout(),
+            child: Text('Logout'),
+          ),
+        )
+      ],
       currentIndex: _pageIndex,
       destinations: [
         AdaptiveScaffoldDestination(title: 'Home', icon: Icons.home),
@@ -67,7 +84,36 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  Widget _pageAtIndex(int index) {
+  Future<void> _handleLogout() async {
+    var shouldLogout = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Are you sure you want to log out?'),
+        actions: [
+          FlatButton(
+            child: Text('No'),
+            onPressed: () {
+              Navigator.of(context).pop(false);
+            },
+          ),
+          FlatButton(
+            child: Text('Yes'),
+            onPressed: () {
+              Navigator.of(context).pop(true);
+            },
+          ),
+        ],
+      ),
+    );
+
+    if (!shouldLogout) {
+      return;
+    }
+
+    widget.onLogout();
+  }
+
+  static Widget _pageAtIndex(int index) {
     if (index == 0) {
       return DashboardPage();
     }

--- a/experimental/web_dashboard/lib/src/pages/sign_in.dart
+++ b/experimental/web_dashboard/lib/src/pages/sign_in.dart
@@ -3,11 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:web_dashboard/src/auth/firebase.dart';
 
 import '../auth/auth.dart';
 
-class SignInPage extends StatefulWidget {
+class SignInPage extends StatelessWidget {
   final Auth auth;
   final ValueChanged<User> onSuccess;
 
@@ -17,10 +16,29 @@ class SignInPage extends StatefulWidget {
   });
 
   @override
-  _SignInPageState createState() => _SignInPageState();
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: SignInButton(auth: auth, onSuccess: onSuccess),
+      ),
+    );
+  }
 }
 
-class _SignInPageState extends State<SignInPage> {
+class SignInButton extends StatefulWidget {
+  final Auth auth;
+  final ValueChanged<User> onSuccess;
+
+  SignInButton({
+    @required this.auth,
+    @required this.onSuccess,
+  });
+
+  @override
+  _SignInButtonState createState() => _SignInButtonState();
+}
+
+class _SignInButtonState extends State<SignInButton> {
   Future<bool> _checkSignInFuture;
 
   @override
@@ -52,31 +70,27 @@ class _SignInPageState extends State<SignInPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: FutureBuilder<bool>(
-          future: _checkSignInFuture,
-          builder: (context, snapshot) {
-            // If signed in, or the future is incomplete, show a circular
-            // progress indicator.
-            var alreadySignedIn = snapshot.data;
-            if (snapshot.connectionState != ConnectionState.done ||
-                alreadySignedIn == true) {
-              return CircularProgressIndicator();
-            }
+    return FutureBuilder<bool>(
+      future: _checkSignInFuture,
+      builder: (context, snapshot) {
+        // If signed in, or the future is incomplete, show a circular
+        // progress indicator.
+        var alreadySignedIn = snapshot.data;
+        if (snapshot.connectionState != ConnectionState.done ||
+            alreadySignedIn == true) {
+          return CircularProgressIndicator();
+        }
 
-            // If sign in failed, show toast and the login button
-            if (snapshot.hasError) {
-              _showError();
-            }
+        // If sign in failed, show toast and the login button
+        if (snapshot.hasError) {
+          _showError();
+        }
 
-            return RaisedButton(
-              child: Text('Sign In with Google'),
-              onPressed: () => _signIn(),
-            );
-          },
-        ),
-      ),
+        return RaisedButton(
+          child: Text('Sign In with Google'),
+          onPressed: () => _signIn(),
+        );
+      },
     );
   }
 

--- a/experimental/web_dashboard/lib/src/pages/sign_in.dart
+++ b/experimental/web_dashboard/lib/src/pages/sign_in.dart
@@ -32,7 +32,7 @@ class _SignInPageState extends State<SignInPage> {
 // example, if they signed in and refreshed the page), invoke the `onSuccess`
 // callback right away.
   Future<bool> _checkIfSignedIn() async {
-    var alreadySignedIn = await widget.auth.isSignedIn();
+    var alreadySignedIn = await widget.auth.isSignedIn;
     if (alreadySignedIn) {
       var user = await widget.auth.signIn();
       widget.onSuccess(user);

--- a/experimental/web_dashboard/lib/src/pages/sign_in.dart
+++ b/experimental/web_dashboard/lib/src/pages/sign_in.dart
@@ -20,7 +20,7 @@ class SignInPage extends StatefulWidget {
 }
 
 class _SignInPageState extends State<SignInPage> {
-  Future<void> _checkSignInFuture;
+  Future<bool> _checkSignInFuture;
 
   @override
   void initState() {
@@ -31,12 +31,13 @@ class _SignInPageState extends State<SignInPage> {
 // Check if the user is signed in. If the user is already signed in (for
 // example, if they signed in and refreshed the page), invoke the `onSuccess`
 // callback right away.
-  Future<void> _checkIfSignedIn() async {
+  Future<bool> _checkIfSignedIn() async {
     var alreadySignedIn = await widget.auth.isSignedIn();
     if (alreadySignedIn) {
       var user = await widget.auth.signIn();
       widget.onSuccess(user);
     }
+    return alreadySignedIn;
   }
 
   Future<void> _signIn() async {
@@ -48,15 +49,17 @@ class _SignInPageState extends State<SignInPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: FutureBuilder<void>(
+        child: FutureBuilder<bool>(
           future: _checkSignInFuture,
           builder: (context, snapshot) {
-            if (snapshot.connectionState != ConnectionState.done) {
+            var alreadySignedIn = snapshot.data;
+            if (snapshot.connectionState != ConnectionState.done ||
+                alreadySignedIn == true) {
               return CircularProgressIndicator();
             }
 
             return RaisedButton(
-              child: Text('Sign In'),
+              child: Text('Sign In with Google'),
               onPressed: () => _signIn(),
             );
           },

--- a/experimental/web_dashboard/lib/src/pages/sign_in.dart
+++ b/experimental/web_dashboard/lib/src/pages/sign_in.dart
@@ -20,24 +20,45 @@ class SignInPage extends StatefulWidget {
 }
 
 class _SignInPageState extends State<SignInPage> {
+  Future<void> _checkSignInFuture;
+
   @override
   void initState() {
     super.initState();
+    _checkSignInFuture = _checkIfSignedIn();
+  }
+
+// Check if the user is signed in. If the user is already signed in (for
+// example, if they signed in and refreshed the page), invoke the `onSuccess`
+// callback right away.
+  Future<void> _checkIfSignedIn() async {
+    var alreadySignedIn = await widget.auth.isSignedIn();
+    if (alreadySignedIn) {
+      var user = await widget.auth.signIn();
+      widget.onSuccess(user);
+    }
+  }
+
+  Future<void> _signIn() async {
+    var user = await widget.auth.signIn();
+    widget.onSuccess(user);
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: RaisedButton(
-          child: Text('Sign In'),
-          onPressed: () async {
-            var user = await widget.auth.signIn();
-            if (user != null) {
-              widget.onSuccess(user);
-            } else {
-              throw ('Unable to sign in');
+        child: FutureBuilder<void>(
+          future: _checkSignInFuture,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState != ConnectionState.done) {
+              return CircularProgressIndicator();
             }
+
+            return RaisedButton(
+              child: Text('Sign In'),
+              onPressed: () => _signIn(),
+            );
           },
         ),
       ),

--- a/experimental/web_dashboard/lib/src/widgets/third_party/adaptive_scaffold.dart
+++ b/experimental/web_dashboard/lib/src/widgets/third_party/adaptive_scaffold.dart
@@ -28,6 +28,7 @@ class AdaptiveScaffoldDestination {
 /// defined in the [destinations] parameter.
 class AdaptiveScaffold extends StatefulWidget {
   final Widget title;
+  final List<Widget> actions;
   final Widget body;
   final int currentIndex;
   final List<AdaptiveScaffoldDestination> destinations;
@@ -37,6 +38,7 @@ class AdaptiveScaffold extends StatefulWidget {
   AdaptiveScaffold({
     this.title,
     this.body,
+    this.actions = const [],
     @required this.currentIndex,
     @required this.destinations,
     this.onNavigationIndexChange,
@@ -80,7 +82,9 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
           ),
           Expanded(
             child: Scaffold(
-              appBar: AppBar(),
+              appBar: AppBar(
+                actions: widget.actions,
+              ),
               body: widget.body,
               floatingActionButton: widget.floatingActionButton,
             ),
@@ -94,6 +98,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
       return Scaffold(
         appBar: AppBar(
           title: widget.title,
+          actions: widget.actions,
         ),
         body: Row(
           children: [
@@ -126,7 +131,10 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
     // Show a bottom app bar
     return Scaffold(
       body: widget.body,
-      appBar: AppBar(title: widget.title),
+      appBar: AppBar(
+        title: widget.title,
+        actions: widget.actions,
+      ),
       bottomNavigationBar: BottomNavigationBar(
         items: [
           ...widget.destinations.map(


### PR DESCRIPTION
This adds a logout button, a widget to switch between the login page and app page, and makes the the sign in screen call the `onSuccess` callback immediately if the user is already signed in (for example if they sign in and refresh the page, they are taken directly to the app and not asked to click the sign in button.)

The `MockAuthService`'s method,  `isSignedIn`, always returns false, so the sign in button needs to be pressed each time the app loads if using this configuration.