### PR TITLE
Run full sample index build when running peanut

### DIFF
--- a/web/_tool/peanut_post_build.dart
+++ b/web/_tool/peanut_post_build.dart
@@ -43,7 +43,7 @@ main(List<String> args) async {
   // Build the sample index and copy the files into this directory
   print('building the sample index...');
   await run('samples_index', 'pub', ['get']);
-  await run('samples_index', 'pub', ['run', 'grinder', 'build-release']);
+  await run('samples_index', 'pub', ['run', 'grinder', 'deploy']);
 
   // Copy the contents of the samples_index/public directory to the build
   // directory

--- a/web/samples_index/tool/grind.dart
+++ b/web/samples_index/tool/grind.dart
@@ -25,9 +25,7 @@ void analyze() {
 @Task('deploy')
 @Depends(analyze, testCli, generate, buildRelease)
 void deploy() {
-  print('All tasks completed. To deploy to Firebase, run:');
-  print('');
-  print('   firebase deploy');
+  print('All tasks completed. ');
   print('');
 }
 


### PR DESCRIPTION
The previous `build-release` task doesn't generate the index file.

Fixes #455