### PR TITLE
Code of other files depends on `headline1`

### DIFF
--- a/provider_shopper/lib/common/theme.dart
+++ b/provider_shopper/lib/common/theme.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 final appTheme = ThemeData(
   primarySwatch: Colors.yellow,
   textTheme: TextTheme(
-    headline2: TextStyle(
+    headline1: TextStyle(
       fontFamily: 'Corben',
       fontWeight: FontWeight.w700,
       fontSize: 24,


### PR DESCRIPTION
Code of other files depends on `headline1`, but there's only `headline2` defined in the **theme.dart** file.