### PR TITLE
Resolve conflicts caused when trying to merge testing_sample into master

### DIFF
--- a/platform_channels/lib/main.dart
+++ b/platform_channels/lib/main.dart
@@ -4,9 +4,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:platform_channels/src/add_pet_details.dart';
+import 'package:platform_channels/src/pet_list_screen.dart';
 import 'package:platform_channels/src/event_channel_demo.dart';
 import 'package:platform_channels/src/method_channel_demo.dart';
-import 'package:platform_channels/src/pet_list_screen.dart';
 import 'package:platform_channels/src/platform_image_demo.dart';
 
 void main() {


### PR DESCRIPTION
Actually, the imports in `platform_channels/lib/main.dart` weren't sorted in `master`. So, I was accepting the current change. It was totally out of my mind that it would again cause a conflict when merging back to `master`.

@domesticmouse, it should probably work now =)