### PR TITLE
[testing_app] Change scrolling approach for perf_test

### DIFF
--- a/testing_app/lib/models/favorites.dart
+++ b/testing_app/lib/models/favorites.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-/// The [Favorites] class holds list of favorite items saved by the user.
+/// The [Favorites] class holds a list of favorite items saved by the user.
 class Favorites extends ChangeNotifier {
   final List<int> _favoriteItems = [];
 

--- a/testing_app/lib/screens/home.dart
+++ b/testing_app/lib/screens/home.dart
@@ -27,7 +27,8 @@ class HomePage extends StatelessWidget {
         ],
       ),
       body: ListView.builder(
-        itemCount: 50,
+        itemCount: 100,
+        cacheExtent: 20.0,
         padding: const EdgeInsets.symmetric(vertical: 16),
         itemBuilder: (context, index) => ItemTile(index),
       ),

--- a/testing_app/test_driver/perf_test.dart
+++ b/testing_app/test_driver/perf_test.dart
@@ -24,33 +24,17 @@ void main() {
     test('Scrolling test', () async {
       // Create Finders that are used multiple times.
       final listFinder = find.byType('ListView');
-      final firstItem = find.byValueKey('text_0');
-      final lastItem = find.byValueKey('text_49');
 
       // Record a performance profile as the app scrolls through
       // the list of items.
       final scrollingTimeline = await driver.traceAction(() async {
-        // Scroll until the item to be found appears.
+        // Quickly scroll all the way down.
         // Use dxScroll to scroll horizontally and dyScroll
         // to scroll vertically.
-        await driver.scrollUntilVisible(
-          listFinder,
-          lastItem,
-          dyScroll: -500.0,
-        );
+        await driver.scroll(listFinder, 0, -7000, Duration(seconds: 1));
 
-        // Check if the item contains the correct text.
-        expect(await driver.getText(lastItem), 'Item 49');
-
-        // Scroll back up all the way.
-        await driver.scrollUntilVisible(
-          listFinder,
-          firstItem,
-          dyScroll: 500.0,
-        );
-
-        // Check if the item contains the correct text.
-        expect(await driver.getText(firstItem), 'Item 0');
+        // Quickly scroll back up all the way.
+        await driver.scroll(listFinder, 0, 7000, Duration(seconds: 1));
       });
 
       // Convert the Timeline into a TimelineSummary that's easier to


### PR DESCRIPTION
@CareF,
As mentioned in #500, I've made the following changes to improve the scrolling perf test:

- Increased `itemCount` from `50` to `100` in the `ListView`
- Set `cacheExtent` to `20`
- Used `scroll()` to scroll down and back up with `dy` : `-7000` and `7000` and duration of `1` second

Let me know if anything needs to be changed. I'm able to make changes faster and in an easier way here.

/cc: @domesticmouse