### PR TITLE
Updating maintenance log

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -7,17 +7,16 @@ match any new language/SDK features, etc.).
 | Sample                    | GH username        | Date Updated   |
 | :------------------------ | -----------------: | -------------: |
 | animations                | theacodes          | 10/7/19        |
-| chrome-os-best-practices  |                    |                |
-| experimental              |                    |                |
+| add_to_app                |                    |                |
 | flutter_maps_firestore    |                    |                |
 | infinite_list             | filiph             | 5/13/20        |
 | isolate_example           | johnpryan          | 11/21/19       |
 | jsonexample               | redbrogdon         | 1/3/20         |
-| material_studies/shrine   |                    |                |
 | place_tracker             |                    |                |
+| platform_channels         |                    |                |
 | platform_design           | johnpryan          | 10/7/19        |
 | platform_view_swift       | redbrogdon         | 10/7/19        |
 | provider_counter          | redbrogdon         | 11/21/19       |
 | provider_shopper          | redbrogdon         | 11/21/19       |
+| testing_app               |                    |                |
 | veggieseasons             |                    |                |
-| web                       |                    |                |


### PR DESCRIPTION
* Removes the individual entries for web/ and experimental/ (web is too large, and experimental apps should be getting steady enough contribution that maintenance is handled that way).
* Removes entry for gallery, which is no longer in the repo.
* Adds new lines for samples that have come into the repo since our last maintenance jam.