### PR TITLE
Removing gallery redirect

### DIFF
--- a/gallery/README.md
+++ b/gallery/README.md
@@ -1,7 +1,0 @@
-The Flutter Gallery has moved to its own repo! You can find the source at:
-
-https://github.com/flutter/gallery
-
-To see a compiled Gallery running in your browser, use this link: 
-
-https://gallery.flutter.dev


### PR DESCRIPTION
Removes the README file that used to direct people from the Flutter Gallery's old location in this repo to the new location in flutter/gallery.

The gallery remains reachable from the visual samples index, which is the intended point of discovery for all samples.