### PR TITLE
Removing add_to_app redirect file

### DIFF
--- a/experimental/add_to_app/README.md
+++ b/experimental/add_to_app/README.md
@@ -1,6 +1,0 @@
-# Looking for the add-to-app samples?
-
-They've graduated from the `experimental` folder and can now be found in the
-root directory of the repo:
-
-https://github.com/flutter/samples/tree/master/add_to_app


### PR DESCRIPTION
We are several months removed from when the app graduated from experimental, so this can be taken out now.