### PR TITLE
Update link of code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-_See also: [Flutter's code of conduct](https://flutter.io/design-principles/#code-of-conduct)_
+_See also: [Flutter's code of conduct](https://github.com/flutter/flutter/blob/master/CODE_OF_CONDUCT.md)_
 
 Want to contribute to the Flutter sample ecosystem? Great! First, read this
 page (including the small print at the end).


### PR DESCRIPTION
Hello, I found out that the link of **Flutter's code of conduct** in [CONTRIBUTING.md](https://github.com/flutter/samples/blob/master/CONTRIBUTING.md)  leads to style guide for Flutter repo.
This PR updates the link to use the correct URL.