### PR TITLE
[Animations] Increasing Meterial Button Size And changing beginColor

### DIFF
--- a/animations/lib/src/basics/05_animated_builder.dart
+++ b/animations/lib/src/basics/05_animated_builder.dart
@@ -13,7 +13,7 @@ class AnimatedBuilderDemo extends StatefulWidget {
 
 class _AnimatedBuilderDemoState extends State<AnimatedBuilderDemo>
     with SingleTickerProviderStateMixin {
-  static const Color beginColor = Colors.deepPurple;
+  static const Color beginColor = Colors.indigoAccent;
   static const Color endColor = Colors.deepOrange;
   Duration duration = Duration(milliseconds: 800);
   AnimationController controller;
@@ -46,16 +46,21 @@ class _AnimatedBuilderDemoState extends State<AnimatedBuilderDemo>
         child: AnimatedBuilder(
           animation: animation,
           builder: (context, child) {
-            return MaterialButton(
-              color: animation.value,
-              child: child,
-              onPressed: () {
-                if (controller.status == AnimationStatus.completed) {
-                  controller.reverse();
-                } else {
-                  controller.forward();
-                }
-              },
+            return Container(
+              padding: const EdgeInsets.all(8),
+              height: MediaQuery.of(context).size.height,
+              width: MediaQuery.of(context).size.width,
+              child: MaterialButton(
+                color: animation.value,
+                child: child,
+                onPressed: () {
+                  if (controller.status == AnimationStatus.completed) {
+                    controller.reverse();
+                  } else {
+                    controller.forward();
+                  }
+                },
+              ),
             );
           },
           // AnimatedBuilder can also accept a pre-built child Widget which is useful
@@ -64,7 +69,8 @@ class _AnimatedBuilderDemoState extends State<AnimatedBuilderDemo>
           // when the animation changes.
           child: Text(
             'Change Color',
-            style: TextStyle(color: Colors.white),
+            style: TextStyle(
+                color: Colors.white, fontSize: 26, fontWeight: FontWeight.bold),
           ),
         ),
       ),


### PR DESCRIPTION
# Description

Fixes: #568 

This issue(#568) is made by me because During testing I was trying different colors to see how beautifully flutter changes colors from one to another but I forced to increase the `MaterialButton `size to see Tween Animation more clearly, And this may happen **with other persons as well**. 

I have increased the size Of `MaterialButton `and Gave `Padding `around it and Also have Changed the Color.
also, I have increased `FontSize `of `Text `.

and now it looks like this,

![image](https://user-images.githubusercontent.com/54175432/96219425-706a4d00-0fa4-11eb-8afd-945ee55b9e01.png)


Previously, 

![image](https://user-images.githubusercontent.com/54175432/96219490-909a0c00-0fa4-11eb-8aa2-4fc1a706f5c7.png)




