### PR TITLE
[samples_index] Fix search bug when using filters

### DIFF
--- a/web/samples_index/lib/src/search.dart
+++ b/web/samples_index/lib/src/search.dart
@@ -9,6 +9,17 @@ bool matchesQuery(String query, String sampleAttributes) {
   var queryWords = query.split(' ')..removeWhere((s) => s.isEmpty);
   var attributes = sampleAttributes.split(' ')..removeWhere((s) => s.isEmpty);
 
+  // Test for type filter
+  // This will check whether a type parameter is present in the
+  // search query, and return false if the self type mismatches
+  // the query type
+  for (var word in queryWords) {
+    if ((word.contains('type:') && !attributes.contains(word)) ||
+        (word.contains('platform:') && !attributes.contains('type:demo'))) {
+      return false;
+    }
+  }
+
   // Test for exact matches
   if (attributes.contains(query)) {
     return true;

--- a/web/samples_index/test/samples_index_test.dart
+++ b/web/samples_index/test/samples_index_test.dart
@@ -107,7 +107,8 @@ void main() {
           'widget:AnimatedBuilder '
           'widget:FutureBuilder '
           'package:json_serializable '
-          'package:path';
+          'package:path '
+          'type:sample';
 
       // Test if various queries match these attributes
       expect(matchesQuery('foo', attributes), false);
@@ -124,6 +125,11 @@ void main() {
       expect(matchesQuery('kitten tag:cats', attributes), true);
       expect(matchesQuery('tag:beginner dogs', attributes), false);
       expect(matchesQuery('asdf ', attributes), false);
+
+      // Test if queries match by type
+      expect(matchesQuery('type:sample', attributes), true);
+      expect(matchesQuery('type:cookbook', attributes), false);
+      expect(matchesQuery('kittens type:cookbook', attributes), false);
     });
   });
 

--- a/web/samples_index/tool/grind.dart
+++ b/web/samples_index/tool/grind.dart
@@ -33,7 +33,10 @@ void deploy() {
 @Depends(createThumbnails)
 Future buildRelease() async {
   var app = PubApp.local('build_runner');
-  await app.runAsync('build --release --output web:public --delete-conflicting-outputs'.split(' ').toList());
+  await app.runAsync(
+      'build --release --output web:public --delete-conflicting-outputs'
+          .split(' ')
+          .toList());
 }
 
 @DefaultTask('Build the project.')

--- a/web/samples_index/web/description.dart
+++ b/web/samples_index/web/description.dart
@@ -5,6 +5,5 @@ import 'package:mdc_web/mdc_web.dart';
 InputElement searchInput;
 
 void main() {
- querySelectorAll('.mdc-card__primary-action')
-      .forEach((el) => MDCRipple(el));
+  querySelectorAll('.mdc-card__primary-action').forEach((el) => MDCRipple(el));
 }


### PR DESCRIPTION
Fixes #392 

Currently, the search results are inaccurate when type filters are used. I've fixed this by adding an additional type check before the current checks. This loop will check whether a type parameter is present in the search query, and return false if the current self type mismatches the query type. Hope this helps :)

I've tested this against a set of custom queries, and the following is a screenshot when tested against the query mentioned in the issue.
`?search=ios&type=cookbook`

![sample_index](https://user-images.githubusercontent.com/32796120/99288395-89934180-2861-11eb-8c6c-f35179c8d0ef.png)