### PR TITLE
let add-to-app ios demo page transitions be animated

### DIFF
--- a/add_to_app/flutter_module/lib/main.dart
+++ b/add_to_app/flutter_module/lib/main.dart
@@ -147,7 +147,6 @@ class Contents extends StatelessWidget {
                 if (showExit) ...[
                   SizedBox(height: 16),
                   RaisedButton(
-                    onPressed: () => SystemNavigator.pop(),
                     onPressed: () => SystemNavigator.pop(animated: true),
                     child: Text('Exit this screen'),
                   ),

--- a/add_to_app/flutter_module/lib/main.dart
+++ b/add_to_app/flutter_module/lib/main.dart
@@ -148,6 +148,7 @@ class Contents extends StatelessWidget {
                   SizedBox(height: 16),
                   RaisedButton(
                     onPressed: () => SystemNavigator.pop(),
+                    onPressed: () => SystemNavigator.pop(animated: true),
                     child: Text('Exit this screen'),
                   ),
                 ],

--- a/add_to_app/ios_fullscreen/IOSFullScreen/ViewController.swift
+++ b/add_to_app/ios_fullscreen/IOSFullScreen/ViewController.swift
@@ -44,7 +44,7 @@ class ViewController: UIViewController {
     @IBAction func buttonWasTapped(_ sender: Any) {
         if let flutterEngine = (UIApplication.shared.delegate as? AppDelegate)?.flutterEngine {
             let flutterViewController = FlutterViewController(engine: flutterEngine, nibName: nil, bundle: nil)
-            self.present(flutterViewController, animated: false, completion: nil)
+            self.present(flutterViewController, animated: true, completion: nil)
         }
     }
 }


### PR DESCRIPTION
Not sure why we left in un-animated originally. API's on stable. 