### PR TITLE
isolate_example: Update filenames in README.md

### DIFF
--- a/isolate_example/README.md
+++ b/isolate_example/README.md
@@ -11,18 +11,18 @@ A sample application that demonstrate best practices when using [`isolates`](htt
 
 ## The important bits
 
-### `page_one.dart`
+### `performance_page.dart`
 
 Compares running a large computation on the main isolate with running the same calculation
 on a second isolate. When the main isolate is used, Flutter is unable to render new frames, and
 the `SmoothAnimationWidget`'s animation freezes.
-### `page_two.dart`
+### `infinite_process_page.dart`
 
 Creates an isolate used to run an infinite loop that sums batches of 100M randomly generated
 numbers at a time. Users can start, terminate, pause, and resume the isolate, as well as modify
 how the calculation is performed.
 
-### `page_three.dart`
+### `data_transfer_page.dart`
 
 Demonstrates how expensive it is to move large amounts of data between isolates and a 
 better alternative to move data. This page creates an isolate that can add up a list of numbers


### PR DESCRIPTION
Some files were renamed in f325e685d148
but the rename never made it to the README.