### PR TITLE
[VeggieSeasons] added restore defaults feature

### DIFF
--- a/experimental/veggieseasons/lib/data/preferences.dart
+++ b/experimental/veggieseasons/lib/data/preferences.dart
@@ -50,6 +50,12 @@ class Preferences extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> restoreDefaults() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+    load();
+  }
+
   void load() {
     _loading = _loadFromSharedPrefs();
   }

--- a/experimental/veggieseasons/lib/screens/settings.dart
+++ b/experimental/veggieseasons/lib/screens/settings.dart
@@ -23,7 +23,8 @@ class VeggieCategorySettingsScreen extends StatelessWidget {
 
   static Route<void> _routeBuilder(BuildContext context, Object argument) {
     return CupertinoPageRoute(
-      builder: (context) => VeggieCategorySettingsScreen(restorationId: 'category'),
+      builder: (context) =>
+          VeggieCategorySettingsScreen(restorationId: 'category'),
       title: 'Preferred Categories',
     );
   }
@@ -136,9 +137,10 @@ class CalorieSettingsScreen extends StatelessWidget {
                       label: cals.toString(),
                       icon: SettingsIcon(
                         icon: Styles.checkIcon,
-                        foregroundColor: snapshot.hasData && snapshot.data == cals
-                            ? CupertinoColors.activeBlue
-                            : Styles.transparentColor,
+                        foregroundColor:
+                            snapshot.hasData && snapshot.data == cals
+                                ? CupertinoColors.activeBlue
+                                : Styles.transparentColor,
                         backgroundColor: Styles.transparentColor,
                       ),
                       onPress: snapshot.hasData
@@ -211,6 +213,44 @@ class SettingsScreen extends StatelessWidget {
     );
   }
 
+  SettingsItem _buildRestoreDefaultsItem(
+      BuildContext context, Preferences prefs) {
+    return SettingsItem(
+      label: 'Restore Defaults',
+      icon: SettingsIcon(
+        backgroundColor: Styles.iconRed,
+        icon: Styles.resetIcon,
+      ),
+      content: SettingsNavigationIndicator(),
+      onPress: () {
+        showCupertinoDialog<void>(
+          context: context,
+          builder: (context) => CupertinoAlertDialog(
+            title: Text('Are you sure?'),
+            content: Text(
+              'Are you sure you want to reset the current preferences?',
+            ),
+            actions: <Widget>[
+              CupertinoDialogAction(
+                isDestructiveAction: true,
+                child: Text('Yes'),
+                onPressed: () async {
+                  await prefs.restoreDefaults();
+                  Navigator.pop(context);
+                },
+              ),
+              CupertinoDialogAction(
+                isDefaultAction: true,
+                child: Text('No'),
+                onPressed: () => Navigator.pop(context),
+              )
+            ],
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final prefs = Provider.of<Preferences>(context);
@@ -219,7 +259,8 @@ class SettingsScreen extends StatelessWidget {
       restorationId: restorationId,
       child: CupertinoPageScaffold(
         child: Container(
-          color: Styles.scaffoldBackground(CupertinoTheme.brightnessOf(context)),
+          color:
+              Styles.scaffoldBackground(CupertinoTheme.brightnessOf(context)),
           child: CustomScrollView(
             restorationId: 'list',
             slivers: <Widget>[
@@ -235,6 +276,7 @@ class SettingsScreen extends StatelessWidget {
                         items: [
                           _buildCaloriesItem(context, prefs),
                           _buildCategoriesItem(context, prefs),
+                          _buildRestoreDefaultsItem(context, prefs),
                         ],
                       ),
                     ],

--- a/experimental/veggieseasons/lib/screens/settings.dart
+++ b/experimental/veggieseasons/lib/screens/settings.dart
@@ -218,7 +218,7 @@ class SettingsScreen extends StatelessWidget {
     return SettingsItem(
       label: 'Restore Defaults',
       icon: SettingsIcon(
-        backgroundColor: Styles.iconRed,
+        backgroundColor: CupertinoColors.systemRed,
         icon: Styles.resetIcon,
       ),
       content: SettingsNavigationIndicator(),

--- a/experimental/veggieseasons/lib/screens/settings.dart
+++ b/experimental/veggieseasons/lib/screens/settings.dart
@@ -228,7 +228,7 @@ class SettingsScreen extends StatelessWidget {
           builder: (context) => CupertinoAlertDialog(
             title: Text('Are you sure?'),
             content: Text(
-              'Are you sure you want to reset the current preferences?',
+              'Are you sure you want to reset the current settings?',
             ),
             actions: <Widget>[
               CupertinoDialogAction(

--- a/experimental/veggieseasons/lib/styles.dart
+++ b/experimental/veggieseasons/lib/styles.dart
@@ -216,8 +216,16 @@ abstract class Styles {
 
   static const Color iconGold = Color(0xffdba800);
 
+  static const Color iconRed = Color(0xffFF0000);
+
   static const preferenceIcon = IconData(
     0xf443,
+    fontFamily: CupertinoIcons.iconFont,
+    fontPackage: CupertinoIcons.iconFontPackage,
+  );
+
+  static const resetIcon = IconData(
+    0xf4c4,
     fontFamily: CupertinoIcons.iconFont,
     fontPackage: CupertinoIcons.iconFontPackage,
   );

--- a/experimental/veggieseasons/lib/styles.dart
+++ b/experimental/veggieseasons/lib/styles.dart
@@ -206,7 +206,7 @@ abstract class Styles {
           : CupertinoColors.darkBackgroundGray;
 
   static Color settingsLineation(Brightness brightness) =>
-      brightness == Brightness.light ? Color(0xffbcbbc1) : Color(0xFF4C4B4B);
+      brightness == Brightness.light ? Color(0xffbcbbc1) : Color(0xff4c4b4b);
 
   static const Color settingsBackground = Color(0xffefeff4);
 
@@ -216,7 +216,7 @@ abstract class Styles {
 
   static const Color iconGold = Color(0xffdba800);
 
-  static const Color iconRed = Color(0xffFF0000);
+  static const Color iconRed = Color(0xffff0000);
 
   static const preferenceIcon = IconData(
     0xf443,
@@ -246,5 +246,5 @@ abstract class Styles {
 
   static const ColorFilter desaturatedColorFilter =
       // 222222 is a random color that has low color saturation.
-      ColorFilter.mode(Color(0xFF222222), BlendMode.saturation);
+      ColorFilter.mode(Color(0xff222222), BlendMode.saturation);
 }

--- a/experimental/veggieseasons/lib/styles.dart
+++ b/experimental/veggieseasons/lib/styles.dart
@@ -216,8 +216,6 @@ abstract class Styles {
 
   static const Color iconGold = Color(0xffdba800);
 
-  static const Color iconRed = Color(0xffff0000);
-
   static const preferenceIcon = IconData(
     0xf443,
     fontFamily: CupertinoIcons.iconFont,


### PR DESCRIPTION
## Description

Added the `Restore Defaults` option in the settings menu.  The idea is to incorporate a feature that makes sense for adding a `CupertinoAlertDialog` in the app.

Related Issue #546 

Screenshot: 
![WhatsApp Image 2021-01-06 at 1 35 07 PM](https://user-images.githubusercontent.com/36601970/103744564-04880580-5024-11eb-80e8-b98ee65433f7.jpeg)

