### PR TITLE
Enable State Restoration for iOS

### DIFF
--- a/experimental/veggieseasons/ios/Runner/Base.lproj/Main.storyboard
+++ b/experimental/veggieseasons/ios/Runner/Base.lproj/Main.storyboard
@@ -8,7 +8,7 @@
         <!--Flutter View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="FlutterViewController" sceneMemberID="viewController">
+                <viewController restorationIdentifier="main" id="BYZ-38-t0r" customClass="FlutterViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>


### PR DESCRIPTION
Feature was implemented in https://github.com/flutter/engine/pull/23495.

This enables it for the veggie seasons app according to the instructions to be published in https://github.com/flutter/flutter/pull/73585.

To test state restoration on iOS:

1. Open `ios/Runner.xcworkspace/` in xcode.
2. (iOS 14+ only): Switch to build in profile or release mode (launching an app from the home screen is not supported in debug mode), see screenshots in https://github.com/flutter/flutter/issues/51673#issuecomment-597215128.
2. Press the Play button in xcode to build and run the app.
3. Create some in-memory state in the app on the phone, e.g. by navigating to a different screen.
4. Background the app on the phone, e.g. by goign back to the home screen.
5. Press the Stop button in xcode to terminate the app while running in the background.
6. Open the app again on the phone (not via xcode), it will restart and restore its state.