### PR TITLE
Fix restoration of search page

### DIFF
--- a/experimental/veggieseasons/lib/screens/search.dart
+++ b/experimental/veggieseasons/lib/screens/search.dart
@@ -99,21 +99,24 @@ class _SearchScreenState extends State<SearchScreen> with RestorationMixin {
     final model = Provider.of<AppState>(context);
 
     return UnmanagedRestorationScope(
+      bucket: bucket,
       child: CupertinoTabView(
+        restorationScopeId: 'tabview',
         builder: (context) {
           return AnnotatedRegion<SystemUiOverlayStyle>(
-              value: SystemUiOverlayStyle(
-                  statusBarBrightness:
-                      MediaQuery.platformBrightnessOf(context)),
-              child: SafeArea(
-                bottom: false,
-                child: Stack(
-                  children: [
-                    _buildSearchResults(model.searchVeggies(terms)),
-                    _createSearchBox(),
-                  ],
-                ),
-              ));
+            value: SystemUiOverlayStyle(
+              statusBarBrightness: MediaQuery.platformBrightnessOf(context),
+            ),
+            child: SafeArea(
+              bottom: false,
+              child: Stack(
+                children: [
+                  _buildSearchResults(model.searchVeggies(terms)),
+                  _createSearchBox(),
+                ],
+              ),
+            ),
+          );
         },
       ),
     );

--- a/experimental/veggieseasons/test/restoration_test.dart
+++ b/experimental/veggieseasons/test/restoration_test.dart
@@ -121,6 +121,29 @@ void main() {
     expect(find.text('Tangelo'), findsOneWidget);
     expect(find.text('Tan').hitTestable(), findsOneWidget); // search text
 
+    expect(find.text('Serving info'), findsNothing);
+
+    // Open a details page from search
+    await tester.tap(find.text('Tangelo'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tangelo'), findsOneWidget);
+    expect(find.text('Serving info'), findsOneWidget);
+    
+    // Restores details page
+    await tester.restartAndRestore();
+    expect(find.text('Tangelo'), findsOneWidget);
+    expect(find.text('Serving info'), findsOneWidget);
+
+    // Go back to search page, is also restored
+    tester.state<NavigatorState>(find.byType(Navigator).last).pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Serving info'), findsNothing);
+    expect(find.text('Apples'), findsNothing);
+    expect(find.text('Tangelo'), findsOneWidget);
+    expect(find.text('Tan').hitTestable(), findsOneWidget); // search text
+
     expect(find.text('Calorie Target'), findsNothing);
 
     // Go to "Settings".


### PR DESCRIPTION
Restoration of the search page broke in https://github.com/flutter/samples/pull/433/commits/c7d3f1a55a7606d5442ff4141fb1754ad469d2eb due to a bad merge. Embarrassingly, that part of the search page wasn't covered by the test, so the breakage went unnoticed at the time. This PR fixes the breakage and extends the test so it will hopefully never break again.