### PR TITLE
Bump ndk

### DIFF
--- a/add_to_app/android_fullscreen/app/build.gradle
+++ b/add_to_app/android_fullscreen/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    ndkVersion "21.3.6528147"
+    ndkVersion "22.0.7026061"
     compileSdkVersion 28
     defaultConfig {
         applicationId "dev.flutter.example.androidfullscreen"


### PR DESCRIPTION
To fix build issues uncovered in https://github.com/flutter/samples/pull/648 and https://github.com/flutter/samples/pull/647.

This is likely only a short-term fix until the NDK version changes again...