### PR TITLE
fix: added headers

### DIFF
--- a/ios_app_clip/test/widget_test.dart
+++ b/ios_app_clip/test/widget_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 // This is a basic Flutter widget test.
 //
 // To perform an interaction with a widget in your test, use the WidgetTester

--- a/place_tracker/lib/main.dart
+++ b/place_tracker/lib/main.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 

--- a/place_tracker/lib/place.dart
+++ b/place_tracker/lib/place.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 

--- a/place_tracker/lib/place_details.dart
+++ b/place_tracker/lib/place_details.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/place_tracker/lib/place_list.dart
+++ b/place_tracker/lib/place_list.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 

--- a/place_tracker/lib/place_map.dart
+++ b/place_tracker/lib/place_map.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:math';
 

--- a/place_tracker/lib/place_tracker_app.dart
+++ b/place_tracker/lib/place_tracker_app.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:provider/provider.dart';

--- a/place_tracker/lib/stub_data.dart
+++ b/place_tracker/lib/stub_data.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import 'place.dart';

--- a/place_tracker/test/widget_test.dart
+++ b/place_tracker/test/widget_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 // This is a basic Flutter widget test.
 // To perform an interaction with a widget in your test, use the WidgetTester utility that Flutter
 // provides. For example, you can send tap and scroll gestures. You can also use WidgetTester to

--- a/platform_design/lib/main.dart
+++ b/platform_design/lib/main.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 

--- a/platform_design/lib/news_tab.dart
+++ b/platform_design/lib/news_tab.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/platform_design/lib/profile_tab.dart
+++ b/platform_design/lib/profile_tab.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 

--- a/platform_design/lib/settings_tab.dart
+++ b/platform_design/lib/settings_tab.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 

--- a/platform_design/lib/song_detail_tab.dart
+++ b/platform_design/lib/song_detail_tab.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 

--- a/platform_design/lib/songs_tab.dart
+++ b/platform_design/lib/songs_tab.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/platform_design/lib/utils.dart
+++ b/platform_design/lib/utils.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:math';
 
 import 'package:english_words/english_words.dart';

--- a/platform_design/lib/widgets.dart
+++ b/platform_design/lib/widgets.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/platform_design/test/widget_test.dart
+++ b/platform_design/test/widget_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';


### PR DESCRIPTION
Fixes: #649 

I have added the headers that were missing in the files. Also, most of the apps in [web](https://github.com/flutter/samples/tree/master/web) are having their own licenses. So, I have not added this header in the files of those apps. Let me know if is is required I will fix that up also. 

Please review and suggest changes @ditman @johnpryan :)