### PR TITLE
Revert "Bump ndk"

### DIFF
--- a/add_to_app/android_fullscreen/app/build.gradle
+++ b/add_to_app/android_fullscreen/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    ndkVersion "22.0.7026061"
+    ndkVersion "21.3.6528147"
     compileSdkVersion 28
     defaultConfig {
         applicationId "dev.flutter.example.androidfullscreen"


### PR DESCRIPTION
Reverts flutter/samples#662

Looks like the Github Action platform has reverted the available NDK version: https://github.com/flutter/samples/pull/668/checks?check_run_id=1746329483#step:5:418