### PR TITLE
Fix minor warnings

### DIFF
--- a/experimental/web_dashboard/lib/src/widgets/third_party/adaptive_scaffold.dart
+++ b/experimental/web_dashboard/lib/src/widgets/third_party/adaptive_scaffold.dart
@@ -140,7 +140,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
           ...widget.destinations.map(
             (d) => BottomNavigationBarItem(
               icon: Icon(d.icon),
-              title: Text(d.title),
+              label: d.title,
             ),
           ),
         ],

--- a/navigation_and_routing/lib/nav_1/on_generate_route.dart
+++ b/navigation_and_routing/lib/nav_1/on_generate_route.dart
@@ -57,7 +57,7 @@ class HomeScreen extends StatelessWidget {
 }
 
 class DetailScreen extends StatelessWidget {
-  String id;
+  final String id;
 
   DetailScreen({
     this.id,


### PR DESCRIPTION
I've fixed the following warnings
1. In `/experimental/web_dashboard/lib/src/widgets/third_party/adaptive_scaffold.dart` -> title parameter is depricated after v1.19.0
2. In `/navigation_and_routing/lib/nav_1/on_generate_route.dart` -> all fields of the `DetailScreen` class should be marked as final

Hope these changes would be helpful, :) 