### PR TITLE
Update link in README.md of web/particle_background

### DIFF
--- a/web/particle_background/README.md
+++ b/web/particle_background/README.md
@@ -4,4 +4,4 @@ Flutter app demonstrating
 Contributed by Felix Blaschke.
 
 One of a series of samples
-[published here](https://github.com/felixblaschke/simple_animations_example_app).
+[published here](https://github.com/felixblaschke/simple_animations/tree/2.4.2/example).


### PR DESCRIPTION
Refer #708 
Owner of the [simple_animations](https://github.com/felixblaschke/simple_animations) repository said that the example has now moved 
to https://github.com/felixblaschke/simple_animations/tree/2.4.2/example.
I have changed the link in README.md .