### PR TITLE
Unmasking CI error codes from iOS

### DIFF
--- a/tool/ios_ci_script.sh
+++ b/tool/ios_ci_script.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail # Necessary so xcpretty won't mask xcodebuild failures later.
 
 echo "Pre-caching ios artifacts, such as the Flutter.framework"
 flutter precache --no-web --no-linux --no-windows --no-fuchsia --no-android --no-macos

--- a/tool/ios_ci_script.sh
+++ b/tool/ios_ci_script.sh
@@ -22,11 +22,6 @@ pushd add_to_app/fullscreen/flutter_module
 flutter packages get
 popd
 
-echo "Fetching dependencies and building 'multiple_flutters/multiple_flutters_module'."
-pushd add_to_app/multiple_flutters/multiple_flutters_module
-flutter packages get
-popd
-
 echo "== Testing 'add_to_app/fullscreen/ios_fullscreen' on Flutter's $FLUTTER_VERSION channel =="
 pushd "add_to_app/fullscreen/ios_fullscreen"
 
@@ -76,24 +71,5 @@ COMPILER_INDEX_STORE_ENABLE=NO CONFIGURATION=Release \
 -destination generic/platform=iOS | xcpretty
 
 popd
-
-echo "== Testing 'add_to_app/multiple_flutters/multiple_flutters_ios' on Flutter's $FLUTTER_VERSION channel =="
-pushd "add_to_app/multiple_flutters/multiple_flutters_ios"
-
-pod install
-
-xcodebuild -workspace "MultipleFluttersIos.xcworkspace" \
--scheme "MultipleFluttersIos" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
-CODE_SIGN_IDENTITY=- EXPANDED_CODE_SIGN_IDENTITY=- \
-COMPILER_INDEX_STORE_ENABLE=NO CONFIGURATION=Debug | xcpretty
-
-xcodebuild -workspace "MultipleFluttersIos.xcworkspace" \
--scheme "MultipleFluttersIos" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
-CODE_SIGN_IDENTITY=- EXPANDED_CODE_SIGN_IDENTITY=- \
-COMPILER_INDEX_STORE_ENABLE=NO CONFIGURATION=Release \
--destination generic/platform=iOS | xcpretty
-
-popd
-
 
 echo "-- Success --"


### PR DESCRIPTION
The `xcpretty` gem used to prettyprint the output of `xcodebuild` has been masking error codes and causing tests to pass even when builds fail. This PR sets `pipefail` in the iOS CI script, fixing the issue.