### PR TITLE
Fixes broken Android build settings for android_fullscreen

### DIFF
--- a/add_to_app/fullscreen/android_fullscreen/app/build.gradle
+++ b/add_to_app/fullscreen/android_fullscreen/app/build.gradle
@@ -5,7 +5,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    ndkVersion "21.3.6528147"
     compileSdkVersion 28
     defaultConfig {
         applicationId "dev.flutter.example.androidfullscreen"


### PR DESCRIPTION
Removes the hardcoded NDK version. If this doesn't work, I'll bump it to the most recent available one instead.