### PR TITLE
Removing scheduled run of beta CI workflow

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches: [beta]
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *' # Every day at midnight
 
 defaults:
   run:


### PR DESCRIPTION
Turns out it's not possible to do a nightly cron-job of a workflow for any branch but master, which explains why I've been getting daily emails about our beta CI workflow failing due to errors that only exist in the master branch of the code.