### PR TITLE
Remove ndkVersion and buildToolsVersion version from add_to_app/android_view

### DIFF
--- a/add_to_app/android_view/app/build.gradle
+++ b/add_to_app/android_view/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    ndkVersion "21.3.6528147"
+    ndkVersion "21.4.7075529"
     compileSdkVersion 30
     buildToolsVersion "30.0.3"
 

--- a/add_to_app/android_view/app/build.gradle
+++ b/add_to_app/android_view/app/build.gradle
@@ -4,9 +4,7 @@ plugins {
 }
 
 android {
-    ndkVersion "21.4.7075529"
     compileSdkVersion 30
-    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "dev.flutter.example.androidView"


### PR DESCRIPTION
> No version of NDK matched the requested version 21.3.6528147. Versions available locally: 21.4.7075529, 21.4.7075529, 21.4.7075529

https://github.com/flutter/samples/pull/677/checks?check_run_id=1923183048#step:5:430

Looks like the migration to GitHub actions made hardcoding these unnecessary in CI.

Fixes https://github.com/flutter/samples/issues/737