### PR TITLE
Fix Multipleflutters Android Crash When Failed to spawn new JNI connected shell from existing shell

### DIFF
--- a/add_to_app/multiple_flutters/multiple_flutters_android/app/src/main/AndroidManifest.xml
+++ b/add_to_app/multiple_flutters/multiple_flutters_android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
+        android:allowNativeHeapPointerTagging="false"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultipleFlutters">
         <activity android:name=".MainActivity">


### PR DESCRIPTION
Fix multipleflutters android  crash in `Android11 `,

Related issues： 

- https://github.com/flutter/flutter/issues/78389 
- https://github.com/flutter/samples/issues/761

add ` android:allowNativeHeapPointerTagging="false"` can avoid crash when Multipleflutters Android run in targetSDK 30   until Flutter Engine  fix this issue .




Relevant information ： https://source.android.com/devices/tech/debug/tagged-pointers