### PR TITLE
Change router examples to use SynchronousFuture

### DIFF
--- a/navigation_and_routing/lib/router/router.dart
+++ b/navigation_and_routing/lib/router/router.dart
@@ -5,6 +5,7 @@
 /// Full sample that shows a custom RouteInformationParser and RouterDelegate
 /// parsing named routes and declaratively building the stack of pages for the
 /// [Navigator].
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -26,7 +27,7 @@ class BooksApp extends StatefulWidget {
 class _BooksAppState extends State<BooksApp> {
   BookRouterDelegate _routerDelegate = BookRouterDelegate();
   BookRouteInformationParser _routeInformationParser =
-  BookRouteInformationParser();
+      BookRouteInformationParser();
 
   @override
   Widget build(BuildContext context) {
@@ -41,24 +42,25 @@ class _BooksAppState extends State<BooksApp> {
 class BookRouteInformationParser extends RouteInformationParser<BookRoutePath> {
   @override
   Future<BookRoutePath> parseRouteInformation(
-      RouteInformation routeInformation) async {
+    RouteInformation routeInformation,
+  ) {
     final uri = Uri.parse(routeInformation.location);
     // Handle '/'
     if (uri.pathSegments.length == 0) {
-      return BookRoutePath.home();
+      return SynchronousFuture(BookRoutePath.home());
     }
 
     // Handle '/book/:id'
-    if (uri.pathSegments.length == 2) {
-      if (uri.pathSegments[0] != 'book') return BookRoutePath.unknown();
+    if (uri.pathSegments.length == 2 && uri.pathSegments[0] == 'book') {
       var remaining = uri.pathSegments[1];
       var id = int.tryParse(remaining);
-      if (id == null) return BookRoutePath.unknown();
-      return BookRoutePath.details(id);
+      if (id != null) {
+        return SynchronousFuture(BookRoutePath.details(id));
+      }
     }
 
     // Handle unknown routes
-    return BookRoutePath.unknown();
+    return SynchronousFuture(BookRoutePath.unknown());
   }
 
   @override
@@ -133,17 +135,17 @@ class BookRouterDelegate extends RouterDelegate<BookRoutePath>
   }
 
   @override
-  Future<void> setNewRoutePath(BookRoutePath path) async {
+  Future<void> setNewRoutePath(BookRoutePath path) {
     if (path.isUnknown) {
       _selectedBook = null;
       show404 = true;
-      return;
+      return SynchronousFuture<void>(null);
     }
 
     if (path.isDetailsPage) {
       if (path.id < 0 || path.id > books.length - 1) {
         show404 = true;
-        return;
+        return SynchronousFuture<void>(null);
       }
 
       _selectedBook = books[path.id];
@@ -152,6 +154,7 @@ class BookRouterDelegate extends RouterDelegate<BookRoutePath>
     }
 
     show404 = false;
+    return SynchronousFuture<void>(null);
   }
 
   void _handleBookTapped(Book book) {

--- a/navigation_and_routing/lib/router_advanced/nested_router.dart
+++ b/navigation_and_routing/lib/router_advanced/nested_router.dart
@@ -6,6 +6,7 @@
 /// [BottomNavigationBar] can be used to select the route of the outer
 /// RouterDelegate, and additional routes can be pushed onto the inner
 /// RouterDelegate / Navigator.
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -90,18 +91,19 @@ class BooksAppState extends ChangeNotifier {
 class BookRouteInformationParser extends RouteInformationParser<BookRoutePath> {
   @override
   Future<BookRoutePath> parseRouteInformation(
-      RouteInformation routeInformation) async {
+    RouteInformation routeInformation,
+  ) {
     final uri = Uri.parse(routeInformation.location);
 
     if (uri.pathSegments.isNotEmpty && uri.pathSegments.first == 'settings') {
-      return BooksSettingsPath();
+      return SynchronousFuture(BooksSettingsPath());
     } else {
-      if (uri.pathSegments.length >= 2) {
-        if (uri.pathSegments[0] == 'book') {
-          return BooksDetailsPath(int.tryParse(uri.pathSegments[1]));
-        }
+      if (uri.pathSegments.length >= 2 && uri.pathSegments[0] == 'book') {
+        return SynchronousFuture(
+          BooksDetailsPath(int.tryParse(uri.pathSegments[1])),
+        );
       }
-      return BooksListPath();
+      return SynchronousFuture(BooksListPath());
     }
   }
 
@@ -166,7 +168,7 @@ class BookRouterDelegate extends RouterDelegate<BookRoutePath>
   }
 
   @override
-  Future<void> setNewRoutePath(BookRoutePath path) async {
+  Future<void> setNewRoutePath(BookRoutePath path) {
     if (path is BooksListPath) {
       appState.selectedIndex = 0;
       appState.selectedBook = null;
@@ -175,6 +177,7 @@ class BookRouterDelegate extends RouterDelegate<BookRoutePath>
     } else if (path is BooksDetailsPath) {
       appState.setSelectedBookById(path.id);
     }
+    return SynchronousFuture<void>(null);
   }
 }
 
@@ -304,10 +307,11 @@ class InnerRouterDelegate extends RouterDelegate<BookRoutePath>
   }
 
   @override
-  Future<void> setNewRoutePath(BookRoutePath path) async {
+  Future<void> setNewRoutePath(BookRoutePath path) {
     // This is not required for inner router delegate because it does not
     // parse route
     assert(false);
+    return SynchronousFuture<void>(null);
   }
 
   void _handleBookTapped(Book book) {

--- a/navigation_and_routing/lib/router_advanced/transition_delegate.dart
+++ b/navigation_and_routing/lib/router_advanced/transition_delegate.dart
@@ -6,6 +6,7 @@
 /// transition animations are shown. (For example, [when two routes are popped
 /// off the stack](https://github.com/flutter/flutter/issues/12146), however the
 /// default TransitionDelegate will handle this if you are using Router)
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -27,7 +28,7 @@ class BooksApp extends StatefulWidget {
 class _BooksAppState extends State<BooksApp> {
   BookRouterDelegate _routerDelegate = BookRouterDelegate();
   BookRouteInformationParser _routeInformationParser =
-  BookRouteInformationParser();
+      BookRouteInformationParser();
 
   @override
   Widget build(BuildContext context) {
@@ -42,14 +43,15 @@ class _BooksAppState extends State<BooksApp> {
 class BookRouteInformationParser extends RouteInformationParser<BookRoutePath> {
   @override
   Future<BookRoutePath> parseRouteInformation(
-      RouteInformation routeInformation) async {
+    RouteInformation routeInformation,
+  ) {
     final uri = Uri.parse(routeInformation.location);
 
     if (uri.pathSegments.length >= 2) {
       var remaining = uri.pathSegments[1];
-      return BookRoutePath.details(int.tryParse(remaining));
+      return SynchronousFuture(BookRoutePath.details(int.tryParse(remaining)));
     } else {
-      return BookRoutePath.home();
+      return SynchronousFuture(BookRoutePath.home());
     }
   }
 
@@ -113,10 +115,11 @@ class BookRouterDelegate extends RouterDelegate<BookRoutePath>
   }
 
   @override
-  Future<void> setNewRoutePath(BookRoutePath path) async {
+  Future<void> setNewRoutePath(BookRoutePath path) {
     if (path.isDetailsPage) {
       _selectedBook = books[path.id];
     }
+    return SynchronousFuture<void>(null);
   }
 
   void _handleBookTapped(Book book) {
@@ -213,9 +216,9 @@ class NoAnimationTransitionDelegate extends TransitionDelegate<void> {
   Iterable<RouteTransitionRecord> resolve({
     List<RouteTransitionRecord> newPageRouteHistory,
     Map<RouteTransitionRecord, RouteTransitionRecord>
-    locationToExitingPageRoute,
+        locationToExitingPageRoute,
     Map<RouteTransitionRecord, List<RouteTransitionRecord>>
-    pageRouteToPagelessRoutes,
+        pageRouteToPagelessRoutes,
   }) {
     final results = <RouteTransitionRecord>[];
 

--- a/navigation_and_routing/pubspec.lock
+++ b/navigation_and_routing/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,21 +73,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,55 +99,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0 <2.11.0"
+  dart: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Some methods of the Router API support asynchronous processing. However, if the information is available synchronously, it's best to just return a SynchronousFuture to indicate that (also documented, e.g. here: https://master-api.flutter.dev/flutter/widgets/RouterDelegate/setNewRoutePath.html). 

What's the difference? Let's say we link directly to `/book/1`. When `parseRouteInformation` is async, the Router will render for one frame the home page `/` because the Future returned by `parseRouteInformation` with the correct route information will not complete until the next frame. When the future then complete in the next frame, `/book/1` is rendered as expected.

When `parseRouteInformation` returns a SynchronousFuture, the information that `/book/1` should be rendered is available in the first frame and the Router can render `/book/1` correctly even for the first frame.