### PR TITLE
Sorting imports in federated_plugin and others

### DIFF
--- a/experimental/federated_plugin/federated_plugin/test/federated_plugin_test.dart
+++ b/experimental/federated_plugin/federated_plugin/test/federated_plugin_test.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:federated_plugin/federated_plugin.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:federated_plugin/federated_plugin.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/flutter_maps_firestore/lib/main.dart
+++ b/flutter_maps_firestore/lib/main.dart
@@ -3,11 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:google_maps_webservice/places.dart';
+
 import 'api_key.dart';
 
 // Center of the Google Map

--- a/jsonexample/test/widget_tests_test.dart
+++ b/jsonexample/test/widget_tests_test.dart
@@ -4,8 +4,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:jsonexample/dart_convert/converted_simple_object.dart';
 import 'package:jsonexample/dart_convert/converted_complex_object.dart';
+import 'package:jsonexample/dart_convert/converted_simple_object.dart';
 import 'package:jsonexample/widgets.dart';
 
 void main() {

--- a/platform_channels/lib/main.dart
+++ b/platform_channels/lib/main.dart
@@ -4,9 +4,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:platform_channels/src/add_pet_details.dart';
-import 'package:platform_channels/src/pet_list_screen.dart';
 import 'package:platform_channels/src/event_channel_demo.dart';
 import 'package:platform_channels/src/method_channel_demo.dart';
+import 'package:platform_channels/src/pet_list_screen.dart';
 import 'package:platform_channels/src/platform_image_demo.dart';
 
 void main() {

--- a/platform_channels/test/home_page_test.dart
+++ b/platform_channels/test/home_page_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_channels/main.dart';
 
 void main() {

--- a/platform_design/lib/widgets.dart
+++ b/platform_design/lib/widgets.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// A simple widget that builds different things on different platforms.

--- a/platform_design/test/widget_test.dart
+++ b/platform_design/test/widget_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
The dev channel's analyzer caught some poorly sorted imports, and was complaining. This should fix the dev channel tests and be a no-op for stable and beta.