### PR TITLE
Update README.md

### DIFF
--- a/add_to_app/multiple_flutters/README.md
+++ b/add_to_app/multiple_flutters/README.md
@@ -13,7 +13,7 @@ For Android instructions, see:
 
 ## Requirements
 
-* Flutter -- after version 1991216543eb74e07c2de3746ca07c92071b19ac
+* Flutter -- after Flutter v2
 * Android
   * Android Studio
 * iOS


### PR DESCRIPTION
Hey @gaaclarke, using a flutter hash as the required version is a tad baroque. Can we just say Flutter v2 is the minimum?