### PR TITLE
Fix <base href="/"> tags in hosted samples, if required.

### DIFF
--- a/web/_tool/build_ci.dart
+++ b/web/_tool/build_ci.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'common.dart';
+import 'fix_base_tags.dart';
 
 final ignoredDirectories = ['_tool', 'samples_index'];
 
@@ -40,6 +41,9 @@ main() async {
     await _run(directory, 'flutter', ['build', 'web']);
     await _run(directory, 'mv', [sourceBuildDir, targetDirectory]);
   }
+
+  // Update the <base href> tags in each index.html file
+  await fixBaseTags();
 }
 
 // Invokes run() and exits if the sub-process failed.

--- a/web/_tool/fix_base_tags.dart
+++ b/web/_tool/fix_base_tags.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+Future<void> main() async {
+  await fixBaseTags();
+}
+
+/// Changes each sample's `<base href="/">` tag in index.html to
+/// `<base href="/samples/web/<SAMPLE_DIR_NAME>/">`
+///
+/// For example, after building using `build_ci.dart,
+/// `../samples_index/public/web/navigation_and_routing/index.html` should
+/// contain `<base href="/samples/web/navigation_and_routing/">
+Future<void> fixBaseTags() async {
+  print('currentDir = ${Directory.current.path}');
+  var builtSamplesDir = Directory(p.joinAll([
+    // Parent directory
+    ...p.split(Directory.current.path),
+    // path to built samples
+    ...p.split('samples_index/public/web')
+  ]));
+  if (!await builtSamplesDir.exists()) {
+    print('${builtSamplesDir.path} does not exist.');
+    exit(1);
+  }
+
+  await for (var builtSample in builtSamplesDir.list()) {
+    if (builtSample is Directory) {
+      var index = File(p.join(builtSample.path, 'index.html'));
+      if (!await index.exists()) {
+        throw ('no index.html file found in ${builtSample.path}');
+      }
+
+      var sampleDirName = p
+          .split(builtSample.path)
+          .last;
+
+      if (await index.exists()) {
+        final regex = RegExp('<base href="(.*)">');
+        var contents = await index.readAsString();
+        if (!contents.contains(regex)) {
+          continue;
+        }
+        var newContents = contents.replaceFirst(
+            regex, '<base href="/samples/web/$sampleDirName">');
+        await index.writeAsString(newContents);
+      }
+    }
+  }
+}

--- a/web/_tool/fix_base_tags.dart
+++ b/web/_tool/fix_base_tags.dart
@@ -42,7 +42,7 @@ Future<void> fixBaseTags() async {
           continue;
         }
         var newContents = contents.replaceFirst(
-            regex, '<base href="/samples/web/$sampleDirName">');
+            regex, '<base href="/samples/web/$sampleDirName/">');
         await index.writeAsString(newContents);
       }
     }

--- a/web/charts/pubspec.lock
+++ b/web/charts/pubspec.lock
@@ -54,7 +54,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:

--- a/web/filipino_cuisine/pubspec.lock
+++ b/web/filipino_cuisine/pubspec.lock
@@ -75,7 +75,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:

--- a/web/github_dataviz/pubspec.lock
+++ b/web/github_dataviz/pubspec.lock
@@ -54,7 +54,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -110,4 +110,4 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Each sample's `<base>` tag needs to point to the path the app is being hosted at. This creates a tool that runs after each sample is built to fix these tags.

This is currently causing the [navigation_and_routing](https://flutter.github.io/samples/navigation_and_routing.html) sample to break