### PR TITLE
Remove extra ios_books in bash code

### DIFF
--- a/add_to_app/books/README.md
+++ b/add_to_app/books/README.md
@@ -73,7 +73,7 @@ you're building for both iOS and Android, with both toolchains installed):
   # For iOS builds:
   cd ../ios_books
   pod install
-  open ios_books/IosBooks.xcworkspace
+  open IosBooks.xcworkspace
 ```
 
 ## Requirements


### PR DESCRIPTION
Hi, it seems this folder is extra and it's not needed in the bash script. 