### PR TITLE
Update mockito in form_app

### DIFF
--- a/form_app/lib/src/http/mock_client.dart
+++ b/form_app/lib/src/http/mock_client.dart
@@ -9,12 +9,14 @@ import 'package:mockito/mockito.dart';
 
 class MockClient extends Mock implements http.Client {
   MockClient() {
-    when(post('https://example.com/signin', body: anyNamed('body')))
+    when(post('https://example.com/signin',
+            body: anyNamed('body'), headers: anyNamed('headers')))
         .thenAnswer((answering) {
       dynamic body = answering.namedArguments[const Symbol('body')];
 
       if (body != null && body is String) {
-        var decodedJson = json.decode(body) as Map<String, String>;
+        var decodedJson = Map<String, dynamic>.from(
+            json.decode(body) as Map<String, dynamic>);
 
         if (decodedJson['email'] == 'root' &&
             decodedJson['password'] == 'password') {

--- a/form_app/lib/src/sign_in_http.dart
+++ b/form_app/lib/src/sign_in_http.dart
@@ -4,8 +4,8 @@
 
 import 'dart:convert';
 
-import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import 'package:json_annotation/json_annotation.dart';
 
 part 'sign_in_http.g.dart';

--- a/form_app/lib/src/sign_in_http.dart
+++ b/form_app/lib/src/sign_in_http.dart
@@ -86,7 +86,7 @@ class _SignInHttpDemoState extends State<SignInHttpDemo> {
                           headers: {'content-type': 'application/json'});
 
                       if (result.statusCode == 200) {
-                        _showDialog('Succesfully signed in.');
+                        _showDialog('Successfully signed in.');
                       } else if (result.statusCode == 401) {
                         _showDialog('Unable to sign in.');
                       } else {

--- a/form_app/lib/src/validation.dart
+++ b/form_app/lib/src/validation.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:english_words/english_words.dart' as english_words;
+import 'package:flutter/material.dart';
 
 class FormValidationDemo extends StatefulWidget {
   const FormValidationDemo({Key key}) : super(key: key);

--- a/form_app/pubspec.lock
+++ b/form_app/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "14.0.0"
+    version: "22.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.41.2"
+    version: "1.7.2"
   args:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.3"
   build_config:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.3"
+    version: "1.5.4"
   build_runner:
     dependency: "direct dev"
     description:
@@ -105,7 +105,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.12"
+    version: "1.3.14"
   english_words:
     dependency: "direct main"
     description:
@@ -276,14 +276,14 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "4.0.1"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.1"
+    version: "4.0.2"
   lints:
     dependency: transitive
     description:
@@ -311,7 +311,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -325,14 +325,14 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1+1"
+    version: "5.0.7"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "2.0.2"
   path:
     dependency: transitive
     description:
@@ -442,7 +442,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   timing:
     dependency: transitive
     description:

--- a/form_app/pubspec.yaml
+++ b/form_app/pubspec.yaml
@@ -10,17 +10,17 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.0
-  intl: any
+  intl: ^0.17.0
   http: ^0.12.0
-  mockito: ^4.1.1
-  json_annotation: ^3.0.0
+  mockito: ^5.0.0
+  json_annotation: any
   english_words: ^3.1.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  json_serializable: ^3.0.0
-  build_runner: ^1.10.0
+  json_serializable: ^4.0.0
+  build_runner: ^1.11.0
   flutter_lints: ^1.0.0
 
 flutter:

--- a/form_app/test/form_app_test.dart
+++ b/form_app/test/form_app_test.dart
@@ -16,6 +16,7 @@ void main() {
     expect(find.text('Unable to sign in.'), findsNothing);
     expect(find.text('Successfully signed in.'), findsOneWidget);
   });
+
   testWidgets('sign in with bad password', (tester) async {
     await _signIn(tester, 'admin','pw');
     expect(find.byType(AlertDialog), findsOneWidget);
@@ -30,6 +31,7 @@ Future<void> _signIn(WidgetTester tester, String email, String password) async {
       httpClient: httpClient,
     ),
   ));
+
   var textFormField = find.byType(TextFormField);
   expect(textFormField, findsNWidgets(2));
 
@@ -43,7 +45,6 @@ Future<void> _signIn(WidgetTester tester, String email, String password) async {
   var button = find.byType(TextButton);
   expect(button, findsOneWidget);
   await tester.tap(button);
-
 
   // Wait for dialog
   await tester.pumpAndSettle();

--- a/form_app/test/form_app_test.dart
+++ b/form_app/test/form_app_test.dart
@@ -1,0 +1,51 @@
+// Copyright 2021, the Flutter project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:form_app/src/http/mock_client.dart';
+import 'package:form_app/src/sign_in_http.dart';
+import 'package:http/http.dart' as http;
+
+final http.Client httpClient = MockClient();
+
+void main() {
+  testWidgets('sign in', (tester) async {
+    await _signIn(tester, 'root','password');
+    expect(find.text('Unable to sign in.'), findsNothing);
+    expect(find.text('Successfully signed in.'), findsOneWidget);
+  });
+  testWidgets('sign in with bad password', (tester) async {
+    await _signIn(tester, 'admin','pw');
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.text('Unable to sign in.'), findsOneWidget);
+    expect(find.text('Successfully signed in.'), findsNothing);
+  });
+}
+
+Future<void> _signIn(WidgetTester tester, String email, String password) async {
+  await tester.pumpWidget(MaterialApp(
+    home: SignInHttpDemo(
+      httpClient: httpClient,
+    ),
+  ));
+  var textFormField = find.byType(TextFormField);
+  expect(textFormField, findsNWidgets(2));
+
+  // Enter email / password
+  var emailField = textFormField.at(0);
+  var passwordField = textFormField.at(1);
+  await tester.enterText(emailField, email);
+  await tester.enterText(passwordField, password);
+
+  // Sign in
+  var button = find.byType(TextButton);
+  expect(button, findsOneWidget);
+  await tester.tap(button);
+
+
+  // Wait for dialog
+  await tester.pumpAndSettle();
+  expect(find.byType(AlertDialog), findsOneWidget);
+}


### PR DESCRIPTION
- form_app now uses `mockito ^5.0.0`.
- fix MockClient implementation.  The Mock definition was missing the named parameter 'headers', so the mock response wasn't returned.
- Add a test for `SignInHttpDemo`.

Fixes #897
