### PR TITLE
Updated the dart english_words package to 4.0.0

### DIFF
--- a/form_app/pubspec.yaml
+++ b/form_app/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   http: ^0.12.0
   mockito: ^5.0.0
   json_annotation: any
-  english_words: ^3.1.0
+  english_words: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Required changed for the form_app to build and launch on the iPhone 12 Pro Max - IOS 14.5 simulator. I didn't test it elsewhere.