### PR TITLE
Removed FormDatePicker type param.

### DIFF
--- a/form_app/ios/Flutter/AppFrameworkInfo.plist
+++ b/form_app/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/form_app/lib/src/form_widgets.dart
+++ b/form_app/lib/src/form_widgets.dart
@@ -66,8 +66,8 @@ class _FormWidgetsDemoState extends State<FormWidgetsDemo> {
                           },
                           maxLines: 5,
                         ),
-                        _FormDatePicker<DateTime>(
-                          date: date,
+                        _FormDatePicker(
+                          initialDate: date,
                           onChanged: (value) {
                             setState(() {
                               date = value;
@@ -158,13 +158,13 @@ class _FormWidgetsDemoState extends State<FormWidgetsDemo> {
   }
 }
 
-class _FormDatePicker<T> extends StatefulWidget {
-  final DateTime? date;
-  final ValueChanged<T>? onChanged;
+class _FormDatePicker extends StatefulWidget {
+  final DateTime initialDate;
+  final ValueChanged<DateTime> onChanged;
 
   const _FormDatePicker({
-    this.date,
-    this.onChanged,
+    required this.initialDate,
+    required this.onChanged,
   });
 
   @override
@@ -187,7 +187,7 @@ class _FormDatePickerState extends State<_FormDatePicker> {
               style: Theme.of(context).textTheme.bodyText1,
             ),
             Text(
-              intl.DateFormat.yMd().format(widget.date!),
+              intl.DateFormat.yMd().format(widget.initialDate),
               style: Theme.of(context).textTheme.subtitle1,
             ),
           ],
@@ -197,7 +197,7 @@ class _FormDatePickerState extends State<_FormDatePicker> {
           onPressed: () async {
             var newDate = await showDatePicker(
               context: context,
-              initialDate: widget.date!,
+              initialDate: widget.initialDate,
               firstDate: DateTime(1900),
               lastDate: DateTime(2100),
             );
@@ -207,7 +207,7 @@ class _FormDatePickerState extends State<_FormDatePicker> {
               return;
             }
 
-            widget.onChanged!(newDate);
+            widget.onChanged(newDate);
           },
         )
       ],

--- a/form_app/lib/src/form_widgets.dart
+++ b/form_app/lib/src/form_widgets.dart
@@ -67,7 +67,7 @@ class _FormWidgetsDemoState extends State<FormWidgetsDemo> {
                           maxLines: 5,
                         ),
                         _FormDatePicker(
-                          initialDate: date,
+                          date: date,
                           onChanged: (value) {
                             setState(() {
                               date = value;
@@ -159,11 +159,11 @@ class _FormWidgetsDemoState extends State<FormWidgetsDemo> {
 }
 
 class _FormDatePicker extends StatefulWidget {
-  final DateTime initialDate;
+  final DateTime date;
   final ValueChanged<DateTime> onChanged;
 
   const _FormDatePicker({
-    required this.initialDate,
+    required this.date,
     required this.onChanged,
   });
 
@@ -187,7 +187,7 @@ class _FormDatePickerState extends State<_FormDatePicker> {
               style: Theme.of(context).textTheme.bodyText1,
             ),
             Text(
-              intl.DateFormat.yMd().format(widget.initialDate),
+              intl.DateFormat.yMd().format(widget.date),
               style: Theme.of(context).textTheme.subtitle1,
             ),
           ],
@@ -197,7 +197,7 @@ class _FormDatePickerState extends State<_FormDatePicker> {
           onPressed: () async {
             var newDate = await showDatePicker(
               context: context,
-              initialDate: widget.initialDate,
+              initialDate: widget.date,
               firstDate: DateTime(1900),
               lastDate: DateTime(2100),
             );


### PR DESCRIPTION
@johnpryan, this was a small issue that came in recently, so I just hopped on it. It looks like an unused type parameter on one of the widget classes was weirding up a callback's inferred type, making it dynamic and producing a console warning.

* Removes the type param from the `_FormDatePicker` class.
* Changes the nullability of the fields in that class to make them non-nullable.
* Updates minimum iOS version, which is an artifact of building with Flutter 2.5.

Fixes #932. 