### PR TITLE
Fix typo

### DIFF
--- a/navigation_and_routing/lib/src/routing/route_state.dart
+++ b/navigation_and_routing/lib/src/routing/route_state.dart
@@ -36,7 +36,7 @@ class RouteState extends ChangeNotifier {
   }
 }
 
-/// Provides the current [RouteState] to descendent widgets in the tree.
+/// Provides the current [RouteState] to descendant widgets in the tree.
 class RouteStateScope extends InheritedNotifier<RouteState> {
   const RouteStateScope({
     required RouteState notifier,


### PR DESCRIPTION
`descendant` is more used, and the other one gives a typo in IntelliJ.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. For larger changes, raising an issue first helps
reduce redundant work.*

## Pre-launch Checklist

- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md