### PR TITLE
Specify workflow permissions for build-and-deploy action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,8 +5,9 @@ on:
       - master
 jobs:
   build-and-deploy:
+    permissions:
+     contents: write
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,7 @@ jobs:
     permissions:
      contents: write
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Write permissions are needed so that [actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) can commit to the gh-pages branch.

To verify, I restricted the permissions, and loosened them in the YAML to simulate the configuration flutter/samples uses:

<img width="754" alt="Screen Shot 2021-11-01 at 4 08 27 PM" src="https://user-images.githubusercontent.com/1145719/139753914-2d934095-c399-4bcd-b5e3-3234eb25e7a2.png">

Example run from my fork of this repo: https://github.com/johnpryan/flutter_samples/runs/4073943383

Resolves #914 
