### PR TITLE
fix the issue of generating more than [catalogLength] items when [cat…

### DIFF
--- a/infinite_list/lib/src/api/fetch.dart
+++ b/infinite_list/lib/src/api/fetch.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
 import 'package:flutter/material.dart';
 
 import 'item.dart';
@@ -30,7 +31,7 @@ Future<ItemPage> fetchPage(int startingIndex) async {
   // The page of items is generated here.
   return ItemPage(
     items: List.generate(
-        itemsPerPage,
+        min(itemsPerPage, catalogLength - startingIndex),
         (index) => Item(
               color: Colors.primaries[index % Colors.primaries.length],
               name: 'Color #${startingIndex + index}',


### PR DESCRIPTION
…alogLength] is not divisible by [itemsPerPage]

It only checks if [startingIndex] is greater than [catalogLength] in the existing implementation. It doesn't check the index of an item in a page. So it may generate more items than the number specified by [catalogLength]. i.e if [catalogLength] is 113, the existing implementation will still generate 120 items. This PR solves the issue by adding the check for the indices of items in a page.