### PR TITLE
Enable mouse scrolling on Carousel sample

### DIFF
--- a/animations/lib/src/misc/carousel.dart
+++ b/animations/lib/src/misc/carousel.dart
@@ -1,7 +1,7 @@
 // Copyright 2019 The Flutter team. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
+import 'dart:ui';
 import 'package:flutter/material.dart';
 
 class CarouselDemo extends StatelessWidget {
@@ -77,6 +77,12 @@ class _CarouselState extends State<Carousel> {
         });
       },
       controller: _controller,
+      scrollBehavior: ScrollConfiguration.of(context).copyWith(
+        dragDevices: {
+          PointerDeviceKind.touch,
+          PointerDeviceKind.mouse,
+        },
+      ),
       itemBuilder: (context, index) => AnimatedBuilder(
         animation: _controller,
         builder: (context, child) {

--- a/animations/lib/src/misc/carousel.dart
+++ b/animations/lib/src/misc/carousel.dart
@@ -1,6 +1,7 @@
 // Copyright 2019 The Flutter team. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 import 'dart:ui';
 import 'package:flutter/material.dart';
 


### PR DESCRIPTION
**Description**
Overriding `scrollBehavior` on `PageView` so it will work on Flutter web, importing `import 'dart:ui';` for adding `PointerDeviceKind.mouse,` as dragDevice.

**Issues**
#964 

**Tests**
![image](https://user-images.githubusercontent.com/12734070/146657780-15150ee5-4bca-4f36-8038-b2bdd4e68bde.png)


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md