### PR TITLE
Ensure that the engine is destroyed when 'EngineBindings.detach' in the multiple_flutters example on Android

### DIFF
--- a/add_to_app/multiple_flutters/multiple_flutters_android/app/src/main/java/dev/flutter/multipleflutters/EngineBindings.kt
+++ b/add_to_app/multiple_flutters/multiple_flutters_android/app/src/main/java/dev/flutter/multipleflutters/EngineBindings.kt
@@ -74,8 +74,7 @@ class EngineBindings(activity: Activity, delegate: EngineBindingsDelegate, entry
      * This tears down the messaging connections on the platform channel and the DataModel.
      */
     fun detach() {
-        // TODO: Uncomment after https://github.com/flutter/engine/pull/24644 is on stable.
-        // engine.destroy();
+        engine.destroy();
         DataModel.instance.removeObserver(this)
         channel.setMethodCallHandler(null)
     }


### PR DESCRIPTION
Since https://github.com/flutter/engine/pull/24644 is on stable, we can uncomment it now.

## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.
