### PR TITLE
Photo search: Set window title on Windows

### DIFF
--- a/experimental/desktop_photo_search/windows/runner/main.cpp
+++ b/experimental/desktop_photo_search/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.CreateAndShow(L"desktop_photo_search", origin, size)) {
+  if (!window.CreateAndShow(L"Desktop Photo Search", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
Updates the window title to "Desktop Photo Search" in the Windows
build of desktop_photo_search.

## Pre-launch Checklist

- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I read the [Contributors Guide].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md