### PR TITLE
Photo search: Wrap tree node in Semantics widget

### DIFF
--- a/experimental/desktop_photo_search/lib/main.dart
+++ b/experimental/desktop_photo_search/lib/main.dart
@@ -151,6 +151,9 @@ class UnsplashHomePage extends StatelessWidget {
   }
 
   TreeNode _buildSearchEntry(SearchEntry searchEntry) {
+    void selectPhoto(photo) { searchEntry.model.selectedPhoto = photo; }
+    String labelForPhoto(photo) => 'Photo by ${photo.user!.name}';
+
     return TreeNode(
       content: Expanded(
         child: Text(searchEntry.query),
@@ -159,14 +162,16 @@ class UnsplashHomePage extends StatelessWidget {
           .map<TreeNode>(
             (photo) => TreeNode(
               content: Expanded(
-                child: InkWell(
-                  onTap: () {
-                    searchEntry.model.selectedPhoto = photo;
-                  },
-                  child: Padding(
-                    padding: const EdgeInsets.all(12.0),
-                    child: Text(
-                      'Photo by ${photo.user!.name}',
+                child: Semantics(
+                  button: true,
+                  onTap: () => selectPhoto(photo),
+                  label: labelForPhoto(photo),
+                  excludeSemantics: true,
+                  child: InkWell(
+                    onTap: () => selectPhoto(photo),
+                    child: Padding(
+                      padding: const EdgeInsets.all(12.0),
+                      child: Text(labelForPhoto(photo)),
                     ),
                   ),
                 ),


### PR DESCRIPTION
The results tree view nodes are each a Row widget containing an
IconButton (which in this case is blank) and an InkWell. In order to
expose this as a tappable widget in screen readers, we wrap the tree
nodes in a Semantics widget that performs the same function as the
InkWell would when tapped.

## Pre-launch Checklist

- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I read the [Contributors Guide].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md