### PR TITLE
Photo search: Add image, download button semantics

### DIFF
--- a/experimental/desktop_photo_search/lib/src/widgets/photo_details.dart
+++ b/experimental/desktop_photo_search/lib/src/widgets/photo_details.dart
@@ -78,6 +78,7 @@ class _PhotoDetailsState extends State<PhotoDetails> {
                       ),
                       child: FadeInImage.memoryNetwork(
                         placeholder: kTransparentImage,
+                        imageSemanticLabel: widget.photo.description,
                         image: widget.photo.urls!.small!,
                       ),
                     ),
@@ -94,6 +95,7 @@ class _PhotoDetailsState extends State<PhotoDetails> {
                     _buildPhotoAttribution(context),
                     const SizedBox(width: 8),
                     IconButton(
+                      tooltip: 'Download',
                       visualDensity: VisualDensity.compact,
                       icon: const Icon(Icons.cloud_download),
                       onPressed: () => widget.onPhotoSave(widget.photo),


### PR DESCRIPTION
Adds the Unsplash photo description, if available, as the image
semantics label in the photo detail view.

Adds a 'download' tooltip to the download IconButton, which also sets
the semantics label for screen readers.


## Pre-launch Checklist

- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I read the [Contributors Guide].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md