### PR TITLE
Photo search: update Linux window title

### DIFF
--- a/experimental/desktop_photo_search/linux/my_application.cc
+++ b/experimental/desktop_photo_search/linux/my_application.cc
@@ -40,11 +40,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "desktop_photo_search");
+    gtk_header_bar_set_title(header_bar, "Desktop Photo Search");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "desktop_photo_search");
+    gtk_window_set_title(window, "Desktop Photo Search");
   }
 
   gtk_window_set_default_size(window, 1280, 720);


### PR DESCRIPTION
Sets the window title on Linux to "Desktop Photo Search".


## Pre-launch Checklist

- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I read the [Contributors Guide].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md