### PR TITLE
Add the leak_vm meta-data in add-to-app sample

### DIFF
--- a/add_to_app/multiple_flutters/multiple_flutters_android/app/src/main/AndroidManifest.xml
+++ b/add_to_app/multiple_flutters/multiple_flutters_android/app/src/main/AndroidManifest.xml
@@ -37,6 +37,15 @@
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize"
             />
+        <!-- Whether leave or clean up the VM after the last shell shuts down. If your want to let
+             your app destroy the last shell and re-create shells more quickly, set it to true,
+             otherwise if you want to clean up the memory of the leak VM, set it to false.
+             (This setting works after the Flutter 2.10 stable version.)
+             View https://github.com/flutter/flutter/issues/95903 for more detail. -->
+        <meta-data
+            android:name="io.flutter.embedding.android.LeakVM"
+            android:value="false"
+            />
     </application>
 
 </manifest>


### PR DESCRIPTION
Add an example code for custom switch leak VM settings, issue link:
* https://github.com/flutter/flutter/issues/95903

Related PR:
* https://github.com/flutter/engine/pull/30541

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
