### PR TITLE
Photo search: minor menu item text cleanup

### DIFF
--- a/desktop_photo_search/fluent_ui/lib/main.dart
+++ b/desktop_photo_search/fluent_ui/lib/main.dart
@@ -62,7 +62,7 @@ class UnsplashHomePage extends StatelessWidget {
     menubar.setApplicationMenu([
       menubar.Submenu(label: 'Search', children: [
         menubar.MenuItem(
-          label: 'Search...',
+          label: 'Search…',
           onClicked: () {
             showDialog<void>(
               context: context,
@@ -74,7 +74,7 @@ class UnsplashHomePage extends StatelessWidget {
       ]),
       menubar.Submenu(label: 'About', children: [
         menubar.MenuItem(
-          label: 'About...',
+          label: 'About',
           onClicked: () {
             showDialog<void>(
               context: context,

--- a/desktop_photo_search/material/lib/main.dart
+++ b/desktop_photo_search/material/lib/main.dart
@@ -65,7 +65,7 @@ class UnsplashHomePage extends StatelessWidget {
     menubar.setApplicationMenu([
       menubar.Submenu(label: 'Search', children: [
         menubar.MenuItem(
-          label: 'Search...',
+          label: 'Search…',
           onClicked: () {
             showDialog<void>(
               context: context,
@@ -77,7 +77,7 @@ class UnsplashHomePage extends StatelessWidget {
       ]),
       menubar.Submenu(label: 'About', children: [
         menubar.MenuItem(
-          label: 'About...',
+          label: 'About',
           onClicked: () {
             showDialog<void>(
               context: context,


### PR DESCRIPTION
Switches to using an elipsis character instead of three periods.

Eliminates the elipsis after 'About'. This appears to be consistent
across operating systems:

From Apple's Human Interface guidelines:
Use an ellipsis whenever choosing a menu item requires additional input
from the user. The ellipsis character (…) means a dialog or separate
window will open and prompt the user for additional information or to
make a choice.

From Microsoft's UI guidelines:
An ellipsis should be used "only when additional information is required
to perform the action. For example, the commands About, Advanced, Help,
Options, Properties, and Settings must display another window when
clicked, but don't require additional information from the user.
Therefore they don't need ellipses."

Ref: https://developer.apple.com/design/human-interface-guidelines/macos/menus/menu-anatomy/
Ref: https://docs.microsoft.com/en-us/windows/win32/uxguide/cmd-menus#using-ellipses

## Pre-launch Checklist

- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I read the [Contributors Guide].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md