### PR TITLE
Fix multiple_flutters_android

### DIFF
--- a/add_to_app/multiple_flutters/multiple_flutters_android/app/build.gradle
+++ b/add_to_app/multiple_flutters/multiple_flutters_android/app/build.gradle
@@ -8,7 +8,7 @@ android {
         self {
         }
     }
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "dev.flutter.multipleflutters"

--- a/add_to_app/multiple_flutters/multiple_flutters_android/build.gradle
+++ b/add_to_app/multiple_flutters/multiple_flutters_android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.3.72"
+    ext.kotlin_version = "1.6.0"
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
I was trying to run the `multiple_flutters_android` sample (https://github.com/flutter/samples/tree/master/add_to_app/multiple_flutters/multiple_flutters_android) on my Android device with Android Studio following the instructions in the readme and I ran into two problems:

## First Problem

```
Execution failed for task ':app:checkDebugAarMetadata'.
> Multiple task action failures occurred:
   > A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
      > The minCompileSdk (31) specified in a
        dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
        is greater than this module's compileSdkVersion (android-30).
        Dependency: androidx.window:window-java:1.0.0-beta04.
        AAR metadata file: /Users/goderbauer/.gradle/caches/transforms-2/files-2.1/2a762a5a9b692fea4fef5c909f3caf07/jetified-window-java-1.0.0-beta04/META-INF/com/android/build/gradle/aar-metadata.properties.
   > A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
      > The minCompileSdk (31) specified in a
        dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
        is greater than this module's compileSdkVersion (android-30).
        Dependency: androidx.window:window:1.0.0-beta04.
        AAR metadata file: /Users/goderbauer/.gradle/caches/transforms-2/files-2.1/fd64c40cdf7b498dad8b6c684c28aba0/jetified-window-1.0.0-beta04/META-INF/com/android/build/gradle/aar-metadata.properties.
```

I fixed that by bumping the compileSdkVersion to 31 here.

## Second Problem

(There are multiple errors that all have the same style, though):
```
/Users/goderbauer/.gradle/caches/transforms-2/files-2.1/06b412bb3e997acc7532c38fe1e7552d/jetified-kotlin-stdlib-jdk7-1.5.30.jar!/META-INF/kotlin-stdlib-jdk7.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.5.1, expected version is 1.1.16.
```

I fixed that by bumping ext.kotlin_version to 1.6.0.

With these two fixes applied, the sample would build and run again.