### PR TITLE
Working slide_puzzle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "web/slide_puzzle"]
 	path = web/slide_puzzle
 	url = https://github.com/VGVentures/slide_puzzle.git
+	branch = release


### PR DESCRIPTION
This bumps the transitive dependency on `platform` to the latest version, which works against the current stable version of Flutter, and should unblock the deploy CI job.