### PR TITLE
Add min window size to fluent_ui desktop app

### DIFF
--- a/desktop_photo_search/fluent_ui/lib/main.dart
+++ b/desktop_photo_search/fluent_ui/lib/main.dart
@@ -5,9 +5,11 @@
 import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:menubar/menubar.dart' as menubar;
 import 'package:provider/provider.dart';
+import 'package:window_size/window_size.dart';
 
 import 'src/model/photo_search_model.dart';
 import 'src/unsplash/unsplash.dart';
@@ -30,6 +32,8 @@ void main() {
     exit(1);
   }
 
+  setupWindow();
+
   runApp(
     ChangeNotifierProvider<PhotoSearchModel>(
       create: (context) => PhotoSearchModel(
@@ -38,6 +42,16 @@ void main() {
       child: const UnsplashSearchApp(),
     ),
   );
+}
+
+const double kWindowWidth = 1024;
+const double kWindowHeight = 800;
+
+void setupWindow() {
+  if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
+    WidgetsFlutterBinding.ensureInitialized();
+    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
+  }
 }
 
 class UnsplashSearchApp extends StatelessWidget {

--- a/desktop_photo_search/fluent_ui/pubspec.lock
+++ b/desktop_photo_search/fluent_ui/pubspec.lock
@@ -702,6 +702,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  window_size:
+    dependency: "direct main"
+    description:
+      path: "plugins/window_size"
+      ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
+      resolved-ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
+      url: "https://github.com/google/flutter-desktop-embedding.git"
+    source: git
+    version: "0.1.0"
   xml:
     dependency: transitive
     description:

--- a/desktop_photo_search/fluent_ui/pubspec.yaml
+++ b/desktop_photo_search/fluent_ui/pubspec.yaml
@@ -24,6 +24,11 @@ dependencies:
     git:
       url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/menubar
+  window_size:
+    git:
+      url: https://github.com/google/flutter-desktop-embedding.git
+      path: plugins/window_size
+      ref: 03d957e8b5c99fc83cd4a781031b154ab3de8753
   provider: ^6.0.2
   transparent_image: ^2.0.0
   url_launcher: ^6.0.18


### PR DESCRIPTION
Continuing the work in https://github.com/flutter/samples/pull/1028

Here, I have only added the min window size. The window title seems to be from the native code, and since this is a desktop app, the window size is not limited by a maximum size.

From my tests, a minimum 1024 x 800 is necessary, so the UI is not cut off.

Interestingly, this project also contained another desktop only plugin as git reference (the menubar)