### PR TITLE
Add setupWindow with min size to Material desktop photo search

### DIFF
--- a/desktop_photo_search/material/lib/main.dart
+++ b/desktop_photo_search/material/lib/main.dart
@@ -54,7 +54,6 @@ void setupWindow() {
   }
 }
 
-
 class UnsplashSearchApp extends StatelessWidget {
   const UnsplashSearchApp({Key? key}) : super(key: key);
 

--- a/desktop_photo_search/material/lib/main.dart
+++ b/desktop_photo_search/material/lib/main.dart
@@ -4,10 +4,12 @@
 
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:menubar/menubar.dart' as menubar;
 import 'package:provider/provider.dart';
+import 'package:window_size/window_size.dart';
 
 import 'src/model/photo_search_model.dart';
 import 'src/unsplash/unsplash.dart';
@@ -30,6 +32,8 @@ void main() {
     exit(1);
   }
 
+  setupWindow();
+
   runApp(
     ChangeNotifierProvider<PhotoSearchModel>(
       create: (context) => PhotoSearchModel(
@@ -39,6 +43,17 @@ void main() {
     ),
   );
 }
+
+const double kWindowWidth = 1024;
+const double kWindowHeight = 800;
+
+void setupWindow() {
+  if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
+    WidgetsFlutterBinding.ensureInitialized();
+    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
+  }
+}
+
 
 class UnsplashSearchApp extends StatelessWidget {
   const UnsplashSearchApp({Key? key}) : super(key: key);

--- a/desktop_photo_search/material/pubspec.lock
+++ b/desktop_photo_search/material/pubspec.lock
@@ -674,6 +674,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  window_size:
+    dependency: "direct main"
+    description:
+      path: "plugins/window_size"
+      ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
+      resolved-ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
+      url: "https://github.com/google/flutter-desktop-embedding.git"
+    source: git
+    version: "0.1.0"
   xml:
     dependency: transitive
     description:

--- a/desktop_photo_search/material/pubspec.yaml
+++ b/desktop_photo_search/material/pubspec.yaml
@@ -27,6 +27,11 @@ dependencies:
   transparent_image: ^2.0.0
   url_launcher: ^6.0.18
   uuid: ^3.0.5
+  window_size:
+    git:
+      url: https://github.com/google/flutter-desktop-embedding.git
+      path: plugins/window_size
+      ref: 03d957e8b5c99fc83cd4a781031b154ab3de8753
 
 dev_dependencies:
   build: ^2.2.1


### PR DESCRIPTION
Same as https://github.com/flutter/samples/pull/1036 but for the Material project sample