### PR TITLE
Add window desktop setup to jsonexample

### DIFF
--- a/jsonexample/lib/main.dart
+++ b/jsonexample/lib/main.dart
@@ -2,10 +2,28 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:jsonexample/tab_pages.dart';
+import 'package:window_size/window_size.dart';
 
-void main() => runApp(const MyApp());
+void main() {
+  setupWindow();
+  runApp(const MyApp());
+}
+
+const double kWindowWidth = 1200;
+const double kWindowHeight = 800;
+
+void setupWindow() {
+  if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
+    WidgetsFlutterBinding.ensureInitialized();
+    setWindowTitle('JSON Sample');
+    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
+  }
+}
 
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);

--- a/jsonexample/pubspec.lock
+++ b/jsonexample/pubspec.lock
@@ -291,6 +291,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -428,7 +435,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   timing:
     dependency: transitive
     description:
@@ -464,6 +471,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  window_size:
+    dependency: "direct main"
+    description:
+      path: "plugins/window_size"
+      ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
+      resolved-ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
+      url: "https://github.com/google/flutter-desktop-embedding.git"
+    source: git
+    version: "0.1.0"
   yaml:
     dependency: transitive
     description:

--- a/jsonexample/pubspec.yaml
+++ b/jsonexample/pubspec.yaml
@@ -1,5 +1,6 @@
 name: jsonexample
 description: A demonstration of JSON parsing
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -11,6 +12,12 @@ dependencies:
 
   flutter:
     sdk: flutter
+
+  window_size:
+    git:
+      url: https://github.com/google/flutter-desktop-embedding.git
+      path: plugins/window_size
+      ref: 03d957e8b5c99fc83cd4a781031b154ab3de8753
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Continuing the work in https://github.com/flutter/samples/pull/1028

The min window size is set to 1200 x 800, because the tabs at the top needed as much space to be visible.