### PR TITLE
Add window desktop setup to navigation_and_routing

### DIFF
--- a/navigation_and_routing/lib/main.dart
+++ b/navigation_and_routing/lib/main.dart
@@ -2,8 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:url_strategy/url_strategy.dart';
+import 'package:window_size/window_size.dart';
 
 import 'src/app.dart';
 
@@ -19,5 +23,25 @@ void main() {
   setHashUrlStrategy();
   // setPathUrlStrategy();
 
+  setupWindow();
   runApp(const Bookstore());
+}
+
+const double kWindowWidth = 480;
+const double kWindowHeight = 854;
+
+void setupWindow() {
+  if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
+    WidgetsFlutterBinding.ensureInitialized();
+    setWindowTitle('Navigation and routing');
+    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMaxSize(const Size(kWindowWidth, kWindowHeight));
+    getCurrentScreen().then((screen) {
+      setWindowFrame(Rect.fromCenter(
+        center: screen!.frame.center,
+        width: kWindowWidth,
+        height: kWindowHeight,
+      ));
+    });
+  }
 }

--- a/navigation_and_routing/lib/main.dart
+++ b/navigation_and_routing/lib/main.dart
@@ -27,20 +27,20 @@ void main() {
   runApp(const Bookstore());
 }
 
-const double kWindowWidth = 480;
-const double kWindowHeight = 854;
+const double windowWidth = 480;
+const double windowHeight = 854;
 
 void setupWindow() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
     setWindowTitle('Navigation and routing');
-    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
-    setWindowMaxSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMinSize(const Size(windowWidth, windowHeight));
+    setWindowMaxSize(const Size(windowWidth, windowHeight));
     getCurrentScreen().then((screen) {
       setWindowFrame(Rect.fromCenter(
         center: screen!.frame.center,
-        width: kWindowWidth,
-        height: kWindowHeight,
+        width: windowWidth,
+        height: windowHeight,
       ));
     });
   }

--- a/navigation_and_routing/pubspec.lock
+++ b/navigation_and_routing/pubspec.lock
@@ -212,6 +212,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -254,13 +261,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -377,21 +377,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.12"
+    version: "1.19.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -497,6 +497,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  window_size:
+    dependency: "direct main"
+    description:
+      path: "plugins/window_size"
+      ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
+      resolved-ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
+      url: "https://github.com/google/flutter-desktop-embedding.git"
+    source: git
+    version: "0.1.0"
   yaml:
     dependency: transitive
     description:

--- a/navigation_and_routing/pubspec.yaml
+++ b/navigation_and_routing/pubspec.yaml
@@ -14,6 +14,11 @@ dependencies:
   quiver: ^3.0.0
   url_launcher: ^6.0.0
   url_strategy: ^0.2.0
+  window_size:
+    git:
+      url: https://github.com/google/flutter-desktop-embedding.git
+      path: plugins/window_size
+      ref: 03d957e8b5c99fc83cd4a781031b154ab3de8753
 dev_dependencies:
   flutter_lints: ^1.0.0
   flutter_test:


### PR DESCRIPTION
Continuing the work in https://github.com/flutter/samples/pull/1028

In this case the app is setup to maintain a mobile-like window size.