### PR TITLE
Add window setup to provider_counter

### DIFF
--- a/provider_counter/lib/main.dart
+++ b/provider_counter/lib/main.dart
@@ -2,10 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:window_size/window_size.dart';
 
 void main() {
+  setupWindow();
   runApp(
     // Provide the model to all widgets within the app. We're using
     // ChangeNotifierProvider because that's a simple way to rebuild
@@ -21,6 +26,25 @@ void main() {
       child: const MyApp(),
     ),
   );
+}
+
+const double kWindowWidth = 360;
+const double kWindowHeight = 640;
+
+void setupWindow() {
+  if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
+    WidgetsFlutterBinding.ensureInitialized();
+    setWindowTitle('Provider Counter');
+    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMaxSize(const Size(kWindowWidth, kWindowHeight));
+    getCurrentScreen().then((screen) {
+      setWindowFrame(Rect.fromCenter(
+        center: screen!.frame.center,
+        width: kWindowWidth,
+        height: kWindowHeight,
+      ));
+    });
+  }
 }
 
 /// Simplest possible model, with just one field.

--- a/provider_counter/lib/main.dart
+++ b/provider_counter/lib/main.dart
@@ -28,20 +28,20 @@ void main() {
   );
 }
 
-const double kWindowWidth = 360;
-const double kWindowHeight = 640;
+const double windowWidth = 360;
+const double windowHeight = 640;
 
 void setupWindow() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
     setWindowTitle('Provider Counter');
-    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
-    setWindowMaxSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMinSize(const Size(windowWidth, windowHeight));
+    setWindowMaxSize(const Size(windowWidth, windowHeight));
     getCurrentScreen().then((screen) {
       setWindowFrame(Rect.fromCenter(
         center: screen!.frame.center,
-        width: kWindowWidth,
-        height: kWindowHeight,
+        width: windowWidth,
+        height: windowHeight,
       ));
     });
   }

--- a/provider_counter/pubspec.lock
+++ b/provider_counter/pubspec.lock
@@ -88,6 +88,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -162,7 +169,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -177,6 +184,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  window_size:
+    dependency: "direct main"
+    description:
+      path: "plugins/window_size"
+      ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
+      resolved-ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
+      url: "https://github.com/google/flutter-desktop-embedding.git"
+    source: git
+    version: "0.1.0"
 sdks:
   dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.16.0"

--- a/provider_counter/pubspec.yaml
+++ b/provider_counter/pubspec.yaml
@@ -1,6 +1,7 @@
 name: provider_counter
 description: >
   The starter Flutter application, but using Provider to manage state.
+publish_to: none
 
 version: 1.0.0
 
@@ -13,6 +14,11 @@ dependencies:
 
   provider: ^5.0.0
   cupertino_icons: ^1.0.3
+  window_size:
+    git:
+      url: https://github.com/google/flutter-desktop-embedding.git
+      path: plugins/window_size
+      ref: 03d957e8b5c99fc83cd4a781031b154ab3de8753
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Continuing the work in https://github.com/flutter/samples/pull/1028

The app is setup to maintain a mobile-like window size, relatively small since it is just the counter default example. Also adds window title.