### PR TITLE
Rename const - don't use prefixes

### DIFF
--- a/animations/lib/main.dart
+++ b/animations/lib/main.dart
@@ -33,20 +33,20 @@ void main() {
   runApp(const AnimationSamples());
 }
 
-const double kWindowWidth = 480;
-const double kWindowHeight = 854;
+const double windowWidth = 480;
+const double windowHeight = 854;
 
 void setupWindow() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
     setWindowTitle('Animation Samples');
-    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
-    setWindowMaxSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMinSize(const Size(windowWidth, windowHeight));
+    setWindowMaxSize(const Size(windowWidth, windowHeight));
     getCurrentScreen().then((screen) {
       setWindowFrame(Rect.fromCenter(
         center: screen!.frame.center,
-        width: kWindowWidth,
-        height: kWindowHeight,
+        width: windowWidth,
+        height: windowHeight,
       ));
     });
   }

--- a/desktop_photo_search/fluent_ui/lib/main.dart
+++ b/desktop_photo_search/fluent_ui/lib/main.dart
@@ -44,13 +44,13 @@ void main() {
   );
 }
 
-const double kWindowWidth = 1024;
-const double kWindowHeight = 800;
+const double windowWidth = 1024;
+const double windowHeight = 800;
 
 void setupWindow() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
-    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMinSize(const Size(windowWidth, windowHeight));
   }
 }
 

--- a/desktop_photo_search/material/lib/main.dart
+++ b/desktop_photo_search/material/lib/main.dart
@@ -44,13 +44,13 @@ void main() {
   );
 }
 
-const double kWindowWidth = 1024;
-const double kWindowHeight = 800;
+const double windowWidth = 1024;
+const double windowHeight = 800;
 
 void setupWindow() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
-    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMinSize(const Size(windowWidth, windowHeight));
   }
 }
 

--- a/form_app/lib/main.dart
+++ b/form_app/lib/main.dart
@@ -19,20 +19,20 @@ void main() {
   runApp(const FormApp());
 }
 
-const double kWindowWidth = 480;
-const double kWindowHeight = 854;
+const double windowWidth = 480;
+const double windowHeight = 854;
 
 void setupWindow() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
     setWindowTitle('Form Samples');
-    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
-    setWindowMaxSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMinSize(const Size(windowWidth, windowHeight));
+    setWindowMaxSize(const Size(windowWidth, windowHeight));
     getCurrentScreen().then((screen) {
       setWindowFrame(Rect.fromCenter(
         center: screen!.frame.center,
-        width: kWindowWidth,
-        height: kWindowHeight,
+        width: windowWidth,
+        height: windowHeight,
       ));
     });
   }

--- a/infinite_list/lib/main.dart
+++ b/infinite_list/lib/main.dart
@@ -17,20 +17,20 @@ void main() {
   runApp(const MyApp());
 }
 
-const double kWindowWidth = 480;
-const double kWindowHeight = 854;
+const double windowWidth = 480;
+const double windowHeight = 854;
 
 void setupWindow() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
     setWindowTitle('Infinite List');
-    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
-    setWindowMaxSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMinSize(const Size(windowWidth, windowHeight));
+    setWindowMaxSize(const Size(windowWidth, windowHeight));
     getCurrentScreen().then((screen) {
       setWindowFrame(Rect.fromCenter(
         center: screen!.frame.center,
-        width: kWindowWidth,
-        height: kWindowHeight,
+        width: windowWidth,
+        height: windowHeight,
       ));
     });
   }

--- a/isolate_example/lib/main.dart
+++ b/isolate_example/lib/main.dart
@@ -31,14 +31,14 @@ void main() {
   );
 }
 
-const double kWindowWidth = 1024;
-const double kWindowHeight = 800;
+const double windowWidth = 1024;
+const double windowHeight = 800;
 
 void setupWindow() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
     setWindowTitle('Isolate Example');
-    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMinSize(const Size(windowWidth, windowHeight));
   }
 }
 

--- a/jsonexample/lib/main.dart
+++ b/jsonexample/lib/main.dart
@@ -14,14 +14,14 @@ void main() {
   runApp(const MyApp());
 }
 
-const double kWindowWidth = 1200;
-const double kWindowHeight = 800;
+const double windowWidth = 1200;
+const double windowHeight = 800;
 
 void setupWindow() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
     setWindowTitle('JSON Sample');
-    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMinSize(const Size(windowWidth, windowHeight));
   }
 }
 

--- a/null_safety/null_safe_app/lib/main.dart
+++ b/null_safety/null_safe_app/lib/main.dart
@@ -15,13 +15,13 @@ void main() {
   runApp(const GoodMyApp());
 }
 
-const double kWindowWidth = 400;
-const double kWindowHeight = 400;
+const double windowWidth = 400;
+const double windowHeight = 400;
 
 void setupWindow() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
     setWindowTitle('Weather');
-    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMinSize(const Size(windowWidth, windowHeight));
   }
 }

--- a/provider_shopper/lib/main.dart
+++ b/provider_shopper/lib/main.dart
@@ -20,20 +20,20 @@ void main() {
   runApp(const MyApp());
 }
 
-const double kWindowWidth = 400;
-const double kWindowHeight = 800;
+const double windowWidth = 400;
+const double windowHeight = 800;
 
 void setupWindow() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
     setWindowTitle('Provider Demo');
-    setWindowMinSize(const Size(kWindowWidth, kWindowHeight));
-    setWindowMaxSize(const Size(kWindowWidth, kWindowHeight));
+    setWindowMinSize(const Size(windowWidth, windowHeight));
+    setWindowMaxSize(const Size(windowWidth, windowHeight));
     getCurrentScreen().then((screen) {
       setWindowFrame(Rect.fromCenter(
         center: screen!.frame.center,
-        width: kWindowWidth,
-        height: kWindowHeight,
+        width: windowWidth,
+        height: windowHeight,
       ));
     });
   }


### PR DESCRIPTION
Following the styleguide: https://dart.dev/guides/language/effective-dart/style#dont-use-prefix-letters

This PR renames all the `kWindowWidth` and `kWindowHeight` const to `windowWidth` and `windowHeight`