### PR TITLE
Add min window size to simplistic_calculator

### DIFF
--- a/simplistic_calculator/lib/main.dart
+++ b/simplistic_calculator/lib/main.dart
@@ -16,6 +16,7 @@ void main() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
     setWindowTitle('Simplistic Calculator');
+    setWindowMinSize(const Size(600, 500));
   }
 
   runApp(


### PR DESCRIPTION
The project already had the window_size plugin in it, so adding the window min size was just a matter of finding trial and error.

The UI scales, but some buttons will be too small under 600x500.

Example at 600x500.

![image](https://user-images.githubusercontent.com/2494376/157050394-5b659721-25fb-4a61-b906-610e0f0da27e.png)
