### PR TITLE
Force utf8-decoding of Unsplash reponse (#586 & #590)

### DIFF
--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/unsplash.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/unsplash.dart
@@ -73,7 +73,10 @@ class Unsplash {
     }
 
     return SearchPhotosResponse.fromJson(
-      response.body,
+      // Per Response#body, if the Content-Type header is unknown, bodyBytes
+      // is interpreted as latin1. Unsplash returns utf8, but with no encoding
+      // specified in the Content-Type, so we must do it ourselves.
+      utf8.decode(response.bodyBytes),
     );
   }
 

--- a/desktop_photo_search/material/lib/src/unsplash/unsplash.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/unsplash.dart
@@ -73,7 +73,10 @@ class Unsplash {
     }
 
     return SearchPhotosResponse.fromJson(
-      response.body,
+      // Per Response#body, if the Content-Type header is unknown, bodyBytes
+      // is interpreted as latin1. Unsplash returns utf8, but with no encoding
+      // specified in the Content-Type, so we must do it ourselves.
+      utf8.decode(response.bodyBytes),
     );
   }
 


### PR DESCRIPTION
Tested on both Windows and macOS, http package's Response#body is by default interpreted as latin1. Unsplash sends search results as UTF8 but with no content type specified, so we must "manually" decode `bodyBytes`.

Before:
<img width="405" alt="Screen Shot 2022-04-12 at 4 44 21 PM" src="https://user-images.githubusercontent.com/400613/163072085-772f0d1b-d119-4b41-9ac7-af2cfcaa612d.png">

After:
<img width="336" alt="Screen Shot 2022-04-12 at 4 42 59 PM" src="https://user-images.githubusercontent.com/400613/163072004-97f4a693-5d2a-4578-98e5-fefda3cd59e4.png">

