### PR TITLE
Add-to-app iOS flutter_post_install post_install hook

### DIFF
--- a/add_to_app/books/ios_books/Podfile
+++ b/add_to_app/books/ios_books/Podfile
@@ -10,3 +10,7 @@ target 'IosBooks' do
   # Pods for IosBooks
   install_all_flutter_pods(flutter_application_path)
 end
+
+post_install do |installer|
+  flutter_post_install(installer) if defined?(flutter_post_install)
+end

--- a/add_to_app/fullscreen/ios_fullscreen/Podfile
+++ b/add_to_app/fullscreen/ios_fullscreen/Podfile
@@ -22,3 +22,7 @@ target 'IOSFullScreen' do
   end
 
 end
+
+post_install do |installer|
+  flutter_post_install(installer) if defined?(flutter_post_install)
+end

--- a/add_to_app/multiple_flutters/multiple_flutters_ios/Podfile
+++ b/add_to_app/multiple_flutters/multiple_flutters_ios/Podfile
@@ -9,3 +9,7 @@ target 'MultipleFluttersIos' do
   use_frameworks!
   install_all_flutter_pods(flutter_application_path)
 end
+
+post_install do |installer|
+  flutter_post_install(installer) if defined?(flutter_post_install)
+end

--- a/add_to_app/plugin/ios_using_plugin/Podfile
+++ b/add_to_app/plugin/ios_using_plugin/Podfile
@@ -20,5 +20,8 @@ target 'IOSUsingPlugin' do
     inherit! :search_paths
     # Pods for testing
   end
+end
 
+post_install do |installer|
+  flutter_post_install(installer) if defined?(flutter_post_install)
 end


### PR DESCRIPTION
Add-to-app host `Podfile`s will be required to call `flutter_post_install(installer)` when https://github.com/flutter/flutter/pull/101943 merges.  The addition of `defined?(flutter_post_install)` will allow `pod install` to succeed on versions of Flutter that do not yet have `flutter_post_install` available.

Hold until https://github.com/flutter/flutter/pull/101943 merges.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md