### PR TITLE
Add read-all default permission to remaining github workflows templates

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,5 +1,8 @@
 name: Beta Branch CI
 
+# Declare default permissions as read only.
+permissions: read-all
+
 on:
   push:
     branches: [beta]

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,8 @@
 name: Deploy to GitHub Pages
+
+# Declare default permissions as read only.
+permissions: read-all
+
 on:
   push:
     branches:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Master Branch CI
 
+# Declare default permissions as read only.
+permissions: read-all
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/verify-web-demos.yml
+++ b/.github/workflows/verify-web-demos.yml
@@ -1,4 +1,8 @@
 name: Verify web demos
+
+# Declare default permissions as read only.
+permissions: read-all
+
 on: [push, pull_request]
 jobs:
   verify-web-demos:


### PR DESCRIPTION
This PR adds read-all default permissions to github workflow templates that don't already have a default set.

This fixes a handful of security issues:
* https://github.com/flutter/samples/security/code-scanning/27
* https://github.com/flutter/samples/security/code-scanning/26
* https://github.com/flutter/samples/security/code-scanning/25
* https://github.com/flutter/samples/security/code-scanning/24
* https://github.com/flutter/samples/security/code-scanning/23

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md