### PR TITLE
`simplistic_editor` is failing on beta CI

### DIFF
--- a/tool/flutter_ci_script_beta.sh
+++ b/tool/flutter_ci_script_beta.sh
@@ -41,7 +41,8 @@ declare -ar PROJECT_NAMES=(
     "platform_view_swift"
     "provider_counter"
     "provider_shopper"
-    "simplistic_editor"
+    # TODO(domesticmouse): Re-enable once Dart 2.17 is stable
+    # "simplistic_editor"
     # TODO(domesticmouse): Re-enable once Dart 2.17 is stable
     # "testing_app"
     "veggieseasons"


### PR DESCRIPTION
Hey @Renzo-Olivares, it appears that `simplistic_editor` needs some formatting changes for Flutter beta. I want to drop it from the beta CI to clean up the errors, and then we can follow this PR with a clean up PR for beta changes.

brett

## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md