### PR TITLE
Fix issue where intervals where merged when they did not overlap due to a typo

### DIFF
--- a/simplistic_editor/lib/replacements.dart
+++ b/simplistic_editor/lib/replacements.dart
@@ -603,12 +603,13 @@ class ReplacementTextEditingController extends TextEditingController {
       final List<dynamic> toRemoveRangesThatHaveBeenMerged = <dynamic>[];
       final List<dynamic> toAddRangesThatHaveBeenMerged = <dynamic>[];
       for (int i = 0; i < overlappingTriples.length; i++) {
+        bool didOverlap = false;
         List<dynamic> tripleA = overlappingTriples[i];
         if (toRemoveRangesThatHaveBeenMerged.contains(tripleA)) continue;
         for (int j = i + 1; j < overlappingTriples.length; j++) {
           final List<dynamic> tripleB = overlappingTriples[j];
           if (math.max(tripleA[0] as int, tripleB[0] as int)
-              <= math.min(tripleB[1] as int, tripleB[1] as int)
+              <= math.min(tripleA[1] as int, tripleB[1] as int)
               && tripleA[2] == tripleB[2]) {
             toRemoveRangesThatHaveBeenMerged.addAll(<dynamic>[tripleA, tripleB]);
             tripleA = <dynamic>[
@@ -616,10 +617,11 @@ class ReplacementTextEditingController extends TextEditingController {
               math.max(tripleA[1] as int, tripleB[1] as int),
               tripleA[2],
             ];
+            didOverlap = true;
           }
         }
 
-        if (i != overlappingTriples.length - 1
+        if (didOverlap
             && !toAddRangesThatHaveBeenMerged.contains(tripleA)
             && !toRemoveRangesThatHaveBeenMerged.contains(tripleA)) {
           toAddRangesThatHaveBeenMerged.add(tripleA);


### PR DESCRIPTION
This PR fixes an issue where styled intervals of the same attribute would merge even if they did not overlap. This issue was due to a typo. 

Before|After
---|---
https://user-images.githubusercontent.com/948037/167379131-6ff4d1e2-b36a-4dc1-a249-3b141015d2fc.mov|




Also fixes an issue where a duplicate interval may be added to the interval list during overlapping interval merging by adding a bool check to make sure that an overlap had occurred. 



## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.