### PR TITLE
Download the Gradle wrapper in CI checks

### DIFF
--- a/tool/android_ci_script.sh
+++ b/tool/android_ci_script.sh
@@ -37,6 +37,7 @@ do
     echo "== Testing '${PROJECT_NAME}' on Flutter's stable channel =="
     pushd "${PROJECT_NAME}"
 
+    gradle wrapper
     ./gradlew --stacktrace assembleDebug
     ./gradlew --stacktrace assembleRelease
 


### PR DESCRIPTION
This is required because gradle-wrapper.jar isn't checked in.

For more: https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:adding_wrapper
