### PR TITLE
Made elements on component screen stay compact on wider screen

### DIFF
--- a/material_3_demo/lib/component_screen.dart
+++ b/material_3_demo/lib/component_screen.dart
@@ -16,18 +16,20 @@ class ComponentScreen extends StatelessWidget {
           children: [
             _colDivider,
             _colDivider,
-            const Buttons(),
+            const LayoutSetting(child: Buttons()),
             _colDivider,
-            const FloatingActionButtons(),
+            const LayoutSetting(child: FloatingActionButtons()),
             _colDivider,
-            const Cards(),
+            const LayoutSetting(child: Cards()),
             _colDivider,
-            const Dialogs(),
+            const LayoutSetting(child: Dialogs()),
             _colDivider,
             showNavBottomBar
-                ? const NavigationBars(
-                    selectedIndex: 0,
-                    isExampleBar: true,
+                ? const LayoutSetting(
+                    child: NavigationBars(
+                      selectedIndex: 0,
+                      isExampleBar: true,
+                    ),
                   )
                 : Container(),
           ],
@@ -37,9 +39,28 @@ class ComponentScreen extends StatelessWidget {
   }
 }
 
+class LayoutSetting extends StatelessWidget {
+  const LayoutSetting({Key? key, required this.child}) : super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.center,
+      child: SizedBox(
+        width: _maxWidthConstraint,
+        child: child,
+      ),
+    );
+  }
+}
+
+
 const _rowDivider = SizedBox(width: 10);
 const _colDivider = SizedBox(height: 10);
 const double _cardWidth = 115;
+const double _maxWidthConstraint = 400;
 
 void Function()? handlePressed(
     BuildContext context, bool isDisabled, String buttonName) {
@@ -255,8 +276,7 @@ class Cards extends StatelessWidget {
                       alignment: Alignment.topRight,
                       child: Icon(Icons.more_vert),
                     ),
-                    _colDivider,
-                    _colDivider,
+                    SizedBox(height: 35),
                     Align(
                       alignment: Alignment.bottomLeft,
                       child: Text("Elevated"),
@@ -279,8 +299,7 @@ class Cards extends StatelessWidget {
                       alignment: Alignment.topRight,
                       child: Icon(Icons.more_vert),
                     ),
-                    _colDivider,
-                    _colDivider,
+                    SizedBox(height: 35),
                     Align(
                       alignment: Alignment.bottomLeft,
                       child: Text("Filled"),
@@ -308,8 +327,7 @@ class Cards extends StatelessWidget {
                       alignment: Alignment.topRight,
                       child: Icon(Icons.more_vert),
                     ),
-                    _colDivider,
-                    _colDivider,
+                    SizedBox(height: 35),
                     Align(
                       alignment: Alignment.bottomLeft,
                       child: Text("Outlined"),

--- a/material_3_demo/lib/component_screen.dart
+++ b/material_3_demo/lib/component_screen.dart
@@ -11,51 +11,37 @@ class ComponentScreen extends StatelessWidget {
     return Expanded(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10),
-        child: ListView(
-          shrinkWrap: true,
-          children: [
-            _colDivider,
-            _colDivider,
-            const LayoutSetting(child: Buttons()),
-            _colDivider,
-            const LayoutSetting(child: FloatingActionButtons()),
-            _colDivider,
-            const LayoutSetting(child: Cards()),
-            _colDivider,
-            const LayoutSetting(child: Dialogs()),
-            _colDivider,
-            showNavBottomBar
-                ? const LayoutSetting(
-                    child: NavigationBars(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: SizedBox(
+            width: _maxWidthConstraint,
+            child: ListView(
+              shrinkWrap: true,
+              children: [
+                _colDivider,
+                _colDivider,
+                const Buttons(),
+                _colDivider,
+                const FloatingActionButtons(),
+                _colDivider,
+                const Cards(),
+                _colDivider,
+                const Dialogs(),
+                _colDivider,
+                showNavBottomBar
+                    ? const NavigationBars(
                       selectedIndex: 0,
                       isExampleBar: true,
-                    ),
-                  )
-                : Container(),
-          ],
+                    )
+                    : Container(),
+              ],
+            ),
+          ),
         ),
       ),
     );
   }
 }
-
-class LayoutSetting extends StatelessWidget {
-  const LayoutSetting({Key? key, required this.child}) : super(key: key);
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.center,
-      child: SizedBox(
-        width: _maxWidthConstraint,
-        child: child,
-      ),
-    );
-  }
-}
-
 
 const _rowDivider = SizedBox(width: 10);
 const _colDivider = SizedBox(height: 10);

--- a/material_3_demo/lib/main.dart
+++ b/material_3_demo/lib/main.dart
@@ -179,15 +179,17 @@ class _Material3DemoState extends State<Material3Demo> {
             body: SafeArea(
               bottom: false,
               top: false,
-              child: Row(children: <Widget>[
-                Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 5),
-                    child: NavigationRailSection(
-                        onSelectItem: handleScreenChanged,
-                        selectedIndex: screenIndex)),
-                const VerticalDivider(thickness: 1, width: 1),
-                createScreenFor(screenIndex, true),
-              ]),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 5),
+                      child: NavigationRailSection(
+                          onSelectItem: handleScreenChanged,
+                          selectedIndex: screenIndex)),
+                  const VerticalDivider(thickness: 1, width: 1),
+                  createScreenFor(screenIndex, true),
+              ],),
             ),
           );
         }

--- a/material_3_demo/lib/main.dart
+++ b/material_3_demo/lib/main.dart
@@ -179,16 +179,14 @@ class _Material3DemoState extends State<Material3Demo> {
             body: SafeArea(
               bottom: false,
               top: false,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 5),
-                      child: NavigationRailSection(
-                          onSelectItem: handleScreenChanged,
-                          selectedIndex: screenIndex)),
-                  const VerticalDivider(thickness: 1, width: 1),
-                  createScreenFor(screenIndex, true),
+              child: Row(children: <Widget>[
+                Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 5),
+                    child: NavigationRailSection(
+                        onSelectItem: handleScreenChanged,
+                        selectedIndex: screenIndex)),
+                const VerticalDivider(thickness: 1, width: 1),
+                createScreenFor(screenIndex, true),
               ],),
             ),
           );


### PR DESCRIPTION
This PR changed the layout on the first screen so that elements on the screen will compact themselves on a wider screen, such as web version.

Before
<img width="1777" alt="Screen Shot 2022-05-11 at 5 31 50 PM" src="https://user-images.githubusercontent.com/36861262/167968787-845e1ca8-7d56-4df1-91d7-f04a3f41dd06.png">

Now
<img width="1775" alt="Screen Shot 2022-05-11 at 5 33 11 PM" src="https://user-images.githubusercontent.com/36861262/167968919-edfbdd10-b385-41c8-a720-0c8154ab4c4b.png">


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md