### PR TITLE
`simplistic_editor` Making `ToggleButtonState` more obvious

### DIFF
--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -7,7 +7,7 @@ import 'package:flutter/services.dart';
 
 import 'replacements.dart';
 import 'text_editing_delta_history_manager.dart';
-import 'toggle_button_state_manager.dart';
+import 'toggle_buttons_state_manager.dart';
 
 /// Signature for the callback that reports when the user changes the selection
 /// (including the cursor location).

--- a/simplistic_editor/lib/toggle_buttons_state_manager.dart
+++ b/simplistic_editor/lib/toggle_buttons_state_manager.dart
@@ -10,11 +10,18 @@ typedef UpdateToggleButtonsStateOnSelectionChangedCallback = void Function(
 typedef UpdateToggleButtonsStateOnButtonPressedCallback = void Function(
     int index);
 
+/// The toggle buttons that can be selected.
+enum ToggleButtonsState {
+  bold,
+  italic,
+  underline,
+}
+
 class ToggleButtonsStateManager extends InheritedWidget {
   const ToggleButtonsStateManager({
     super.key,
     required super.child,
-    required List<bool> isToggleButtonsSelected,
+    required Set<ToggleButtonsState> isToggleButtonsSelected,
     required UpdateToggleButtonsStateOnButtonPressedCallback
         updateToggleButtonsStateOnButtonPressed,
     required UpdateToggleButtonsStateOnSelectionChangedCallback
@@ -32,13 +39,13 @@ class ToggleButtonsStateManager extends InheritedWidget {
     return result!;
   }
 
-  final List<bool> _isToggleButtonsSelected;
+  final Set<ToggleButtonsState> _isToggleButtonsSelected;
   final UpdateToggleButtonsStateOnButtonPressedCallback
       _updateToggleButtonsStateOnButtonPressed;
   final UpdateToggleButtonsStateOnSelectionChangedCallback
       _updateToggleButtonStateOnSelectionChanged;
 
-  List<bool> get toggleButtonsState => _isToggleButtonsSelected;
+  Set<ToggleButtonsState> get toggleButtonsState => _isToggleButtonsSelected;
   UpdateToggleButtonsStateOnButtonPressedCallback
       get updateToggleButtonsOnButtonPressed =>
           _updateToggleButtonsStateOnButtonPressed;


### PR DESCRIPTION
Encoding the bold, italic, underline state as a List<bool> is performant but opaque. I'm attempting to introduce an informative abstraction that makes the code a bit more understandable.

I don't think I've broken the API, it appears to work when I test the app. I'd like to get confirmation that this change is both sane and correct.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md