### PR TITLE
game_template dependencies

### DIFF
--- a/game_template/pubspec.yaml
+++ b/game_template/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   # delete the relevant line below, and get rid of any Dart code
   # that references the dependency.
   firebase_core: ^1.15.0  # Needed for Crashlytics below
-  firebase_crashlytics: ^2.6.3  # Error reporting
+  firebase_crashlytics: ^2.8.1  # Error reporting
   games_services: ^2.0.7  # Achievements and leaderboards
   google_mobile_ads: ^1.1.0  # Ads
   in_app_purchase: ^3.0.1  # In-app purchases


### PR DESCRIPTION
Bumps `firebase_crashlytics` to `2.8.1`, as the old version wasn't building on macOS.

Fixes #1287