### PR TITLE
Fix some web tool pub issues

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,7 +6,7 @@ permissions: read-all
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   build-and-deploy:
     permissions:

--- a/web/_tool/build_ci.dart
+++ b/web/_tool/build_ci.dart
@@ -17,8 +17,8 @@ main() async {
   ];
 
   print('Building the sample index...');
-  await _run('samples_index', 'pub', ['get']);
-  await _run('samples_index', 'pub', ['run', 'grinder', 'deploy']);
+  await _run('samples_index', 'flutter', ['pub', 'get']);
+  await _run('samples_index', 'flutter', ['pub', 'run', 'grinder', 'deploy']);
 
   // Create the directory each Flutter Web sample lives in
   Directory(p.join(Directory.current.path, 'samples_index', 'public', 'web'))

--- a/web/_tool/peanut_post_build.dart
+++ b/web/_tool/peanut_post_build.dart
@@ -42,8 +42,8 @@ main(List<String> args) async {
 
   // Build the sample index and copy the files into this directory
   print('building the sample index...');
-  await run('samples_index', 'pub', ['get']);
-  await run('samples_index', 'pub', ['run', 'grinder', 'deploy']);
+  await run('samples_index', 'flutter', ['pub', 'get']);
+  await run('samples_index', 'flutter', ['pub', 'run', 'grinder', 'deploy']);
 
   // Copy the contents of the samples_index/public directory to the build
   // directory


### PR DESCRIPTION
The standalone pub tool has been replaced with subcommands under the `flutter` or `dart` executables.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/master/CONTRIBUTING.md