### PR TITLE
Try fixing setup-java flake

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -29,8 +29,8 @@ jobs:
       - uses: actions/checkout@f25a3a9f25bd5f4c5d77189cab02ff357b5aedeb
       - uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142
         with:
-          distribution: 'zulu'
-          java-version: '12.x'
+          distribution: 'temurin'
+          java-version: '17.x'
       - uses: subosito/flutter-action@d8687e6979e8ef66d2b2970e2c92c1d8e801d7bf
         with:
           channel: beta
@@ -44,8 +44,8 @@ jobs:
       - uses: actions/checkout@d171c3b028d844f2bf14e9fdec0c58114451e4bf
       - uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142
         with:
-          distribution: 'zulu'
-          java-version: '12.x'
+          distribution: 'temurin'
+          java-version: '17.x'
       - uses: subosito/flutter-action@d8687e6979e8ef66d2b2970e2c92c1d8e801d7bf
         with:
           channel: beta
@@ -59,8 +59,8 @@ jobs:
       - uses: actions/checkout@d171c3b028d844f2bf14e9fdec0c58114451e4bf
       - uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142
         with:
-          distribution: 'zulu'
-          java-version: '12.x'
+          distribution: 'temurin'
+          java-version: '17.x'
       - uses: subosito/flutter-action@d8687e6979e8ef66d2b2970e2c92c1d8e801d7bf
         with:
           channel: beta

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,8 @@ jobs:
       - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
       - uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142
         with:
-          distribution: 'zulu'
-          java-version: '12.x'
+          distribution: 'temurin'
+          java-version: '17.x'
       - uses: subosito/flutter-action@d8687e6979e8ef66d2b2970e2c92c1d8e801d7bf
         with:
           channel: ${{ matrix.flutter_version }}
@@ -43,8 +43,8 @@ jobs:
       - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
       - uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142
         with:
-          distribution: 'zulu'
-          java-version: '12.x'
+          distribution: 'temurin'
+          java-version: '17.x'
       - uses: subosito/flutter-action@d8687e6979e8ef66d2b2970e2c92c1d8e801d7bf
         with:
           channel: stable
@@ -56,8 +56,8 @@ jobs:
       - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
       - uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142
         with:
-          distribution: 'zulu'
-          java-version: '12.x'
+          distribution: 'temurin'
+          java-version: '17.x'
       - uses: subosito/flutter-action@d8687e6979e8ef66d2b2970e2c92c1d8e801d7bf
         with:
           channel: stable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/cache@14c4fd4871149762bbba2312aaf4b031861333d5
         with:
           path: |
+            ~/.gradle
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle/wrapper/gradle-wrapper.properties') }}
@@ -51,6 +52,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17.x'
+          cache: 'gradle'
       - uses: subosito/flutter-action@d8687e6979e8ef66d2b2970e2c92c1d8e801d7bf
         with:
           channel: stable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,13 +41,9 @@ jobs:
     if: github.repository == 'flutter/samples'
     steps:
       - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
-      - uses: actions/cache@14c4fd4871149762bbba2312aaf4b031861333d5
+      - uses: gradle/gradle-build-action@v2
         with:
-          path: |
-            ~/.gradle
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle/wrapper/gradle-wrapper.properties') }}
+          gradle-version: 7.4
       - uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142
         with:
           distribution: 'temurin'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,12 @@ jobs:
     if: github.repository == 'flutter/samples'
     steps:
       - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
+      - uses: actions/cache@14c4fd4871149762bbba2312aaf4b031861333d5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle/wrapper/gradle-wrapper.properties') }}
       - uses: actions/setup-java@860f60056505705214d223b91ed7a30f173f6142
         with:
           distribution: 'temurin'

--- a/add_to_app/android_view/android_view/gradle/wrapper/gradle-wrapper.properties
+++ b/add_to_app/android_view/android_view/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Mar 10 09:46:16 PST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/add_to_app/books/android_books/gradle/wrapper/gradle-wrapper.properties
+++ b/add_to_app/books/android_books/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Mar 10 09:43:03 PST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/add_to_app/fullscreen/android_fullscreen/gradle/wrapper/gradle-wrapper.properties
+++ b/add_to_app/fullscreen/android_fullscreen/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon May 17 23:38:12 PDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/add_to_app/multiple_flutters/multiple_flutters_android/gradle/wrapper/gradle-wrapper.properties
+++ b/add_to_app/multiple_flutters/multiple_flutters_android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/add_to_app/plugin/android_using_plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/add_to_app/plugin/android_using_plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sun Oct 13 15:03:51 PDT 2019
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/add_to_app/prebuilt_module/android_using_prebuilt_module/gradle/wrapper/gradle-wrapper.properties
+++ b/add_to_app/prebuilt_module/android_using_prebuilt_module/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Oct 23 10:17:48 PDT 2019
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/android_splash_screen/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android_splash_screen/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/animations/android/gradle/wrapper/gradle-wrapper.properties
+++ b/animations/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/experimental/federated_plugin/federated_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/experimental/federated_plugin/federated_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/form_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/form_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/game_template/android/gradle/wrapper/gradle-wrapper.properties
+++ b/game_template/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/infinite_list/android/gradle/wrapper/gradle-wrapper.properties
+++ b/infinite_list/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/isolate_example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/isolate_example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/jsonexample/android/gradle/wrapper/gradle-wrapper.properties
+++ b/jsonexample/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/material_3_demo/android/gradle/wrapper/gradle-wrapper.properties
+++ b/material_3_demo/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/navigation_and_routing/android/gradle/wrapper/gradle-wrapper.properties
+++ b/navigation_and_routing/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/null_safety/null_safe_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/null_safety/null_safe_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/null_safety/null_unsafe_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/null_safety/null_unsafe_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/place_tracker/android/gradle/wrapper/gradle-wrapper.properties
+++ b/place_tracker/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/platform_channels/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform_channels/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/platform_design/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform_design/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/provider_counter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/provider_counter/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/provider_shopper/android/gradle/wrapper/gradle-wrapper.properties
+++ b/provider_shopper/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/simplistic_calculator/android/gradle/wrapper/gradle-wrapper.properties
+++ b/simplistic_calculator/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/testing_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/testing_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/tool/android_ci_script.sh
+++ b/tool/android_ci_script.sh
@@ -6,8 +6,10 @@ gradle -v
 flutter doctor -v
 
 echo "Fetching dependencies and building 'prebuilt_module/flutter_module/'."
-pushd add_to_app/prebuilt_module/flutter_module/
+pushd add_to_app/prebuilt_module/android_using_prebuilt_module/
 gradle wrapper --gradle-version=7.4 --distribution-type=all
+popd
+pushd add_to_app/prebuilt_module/flutter_module/
 flutter packages get
 flutter build aar
 popd

--- a/tool/android_ci_script.sh
+++ b/tool/android_ci_script.sh
@@ -37,7 +37,7 @@ do
     echo "== Testing '${PROJECT_NAME}' on Flutter's stable channel =="
     pushd "${PROJECT_NAME}"
 
-    gradle wrapper
+    gradle wrapper --gradle-version=7.4 --distribution-type=all
     ./gradlew --stacktrace assembleDebug
     ./gradlew --stacktrace assembleRelease
 

--- a/tool/android_ci_script.sh
+++ b/tool/android_ci_script.sh
@@ -2,10 +2,12 @@
 
 set -e
 
+gradle -v
 flutter doctor -v
 
 echo "Fetching dependencies and building 'prebuilt_module/flutter_module/'."
 pushd add_to_app/prebuilt_module/flutter_module/
+gradle wrapper --gradle-version=7.4 --distribution-type=all
 flutter packages get
 flutter build aar
 popd


### PR DESCRIPTION
Trying to see if this fixes the setup-java flakes on macOS since the Zulu builds have been reported as flaking recently. temurin builds are also open but unfortunately don't have a JDK 12 build. We should update from JDK 12 anyway as it was not a LTS release and reached end of life 2+ years ago. We'll see if it updating works with this PR. 

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [] All existing and new tests are passing.