### PR TITLE
updatedCrashlytics link in main.dart

### DIFF
--- a/game_template/lib/main.dart
+++ b/game_template/lib/main.dart
@@ -35,7 +35,7 @@ import 'src/win_game/win_game_screen.dart';
 
 Future<void> main() async {
   // Uncomment the following lines to enable Firebase Crashlytics.
-  // See lib/src/crashlytics/README.md for details.
+  // See the 'Crashlytics' section of the main README.md file for details.
 
   FirebaseCrashlytics? crashlytics;
   // if (!kIsWeb && (Platform.isIOS || Platform.isAndroid)) {


### PR DESCRIPTION
Link in comments section of [main.dart](https://github.com/flutter/samples/blob/main/game_template/lib/main.dart) doesn't exist. Updated it to direct users to the Crashlytics section of the main [README.md](https://github.com/flutter/samples/blob/main/game_template/README.md) file instead. 

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md