### PR TITLE
Drop redundant `ToggleButtonsStateManager` instances

### DIFF
--- a/simplistic_editor/lib/main.dart
+++ b/simplistic_editor/lib/main.dart
@@ -310,58 +310,44 @@ class _MyHomePageState extends State<MyHomePage> {
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      ToggleButtonsStateManager(
-                        isToggleButtonsSelected: _isSelected,
-                        updateToggleButtonsStateOnButtonPressed:
-                            _updateToggleButtonsStateOnButtonPressed,
-                        updateToggleButtonStateOnSelectionChanged:
-                            _updateToggleButtonsStateOnSelectionChanged,
-                        child: Builder(builder: (innerContext) {
-                          final ToggleButtonsStateManager manager =
-                              ToggleButtonsStateManager.of(innerContext);
+                      Builder(builder: (innerContext) {
+                        final ToggleButtonsStateManager manager =
+                            ToggleButtonsStateManager.of(innerContext);
 
-                          return ToggleButtons(
-                            borderRadius:
-                                const BorderRadius.all(Radius.circular(4.0)),
-                            isSelected: [
-                              manager.toggleButtonsState
-                                  .contains(ToggleButtonsState.bold),
-                              manager.toggleButtonsState
-                                  .contains(ToggleButtonsState.italic),
-                              manager.toggleButtonsState
-                                  .contains(ToggleButtonsState.underline),
-                            ],
-                            onPressed: (index) => manager
-                                .updateToggleButtonsOnButtonPressed(index),
-                            children: const [
-                              Icon(Icons.format_bold),
-                              Icon(Icons.format_italic),
-                              Icon(Icons.format_underline),
-                            ],
-                          );
-                        }),
-                      ),
+                        return ToggleButtons(
+                          borderRadius:
+                              const BorderRadius.all(Radius.circular(4.0)),
+                          isSelected: [
+                            manager.toggleButtonsState
+                                .contains(ToggleButtonsState.bold),
+                            manager.toggleButtonsState
+                                .contains(ToggleButtonsState.italic),
+                            manager.toggleButtonsState
+                                .contains(ToggleButtonsState.underline),
+                          ],
+                          onPressed: (index) =>
+                              manager.updateToggleButtonsOnButtonPressed(index),
+                          children: const [
+                            Icon(Icons.format_bold),
+                            Icon(Icons.format_italic),
+                            Icon(Icons.format_underline),
+                          ],
+                        );
+                      }),
                     ],
                   ),
                 ),
                 Expanded(
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 35.0),
-                    child: ToggleButtonsStateManager(
-                      isToggleButtonsSelected: _isSelected,
-                      updateToggleButtonsStateOnButtonPressed:
-                          _updateToggleButtonsStateOnButtonPressed,
-                      updateToggleButtonStateOnSelectionChanged:
-                          _updateToggleButtonsStateOnSelectionChanged,
-                      child: TextEditingDeltaHistoryManager(
-                        history: _textEditingDeltaHistory,
-                        updateHistoryOnInput: _updateTextEditingDeltaHistory,
-                        child: BasicTextField(
-                          controller: _replacementTextEditingController,
-                          style: const TextStyle(
-                              fontSize: 18.0, color: Colors.black),
-                          focusNode: _focusNode,
-                        ),
+                    child: TextEditingDeltaHistoryManager(
+                      history: _textEditingDeltaHistory,
+                      updateHistoryOnInput: _updateTextEditingDeltaHistory,
+                      child: BasicTextField(
+                        controller: _replacementTextEditingController,
+                        style: const TextStyle(
+                            fontSize: 18.0, color: Colors.black),
+                        focusNode: _focusNode,
                       ),
                     ),
                   ),

--- a/simplistic_editor/lib/main.dart
+++ b/simplistic_editor/lib/main.dart
@@ -303,46 +303,46 @@ class _MyHomePageState extends State<MyHomePage> {
                 _updateToggleButtonsStateOnButtonPressed,
             updateToggleButtonStateOnSelectionChanged:
                 _updateToggleButtonsStateOnSelectionChanged,
-            child: Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8.0),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Builder(builder: (innerContext) {
-                        final ToggleButtonsStateManager manager =
-                            ToggleButtonsStateManager.of(innerContext);
+            child: TextEditingDeltaHistoryManager(
+              history: _textEditingDeltaHistory,
+              updateHistoryOnInput: _updateTextEditingDeltaHistory,
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8.0),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Builder(builder: (innerContext) {
+                          final manager =
+                              ToggleButtonsStateManager.of(innerContext);
 
-                        return ToggleButtons(
-                          borderRadius:
-                              const BorderRadius.all(Radius.circular(4.0)),
-                          isSelected: [
-                            manager.toggleButtonsState
-                                .contains(ToggleButtonsState.bold),
-                            manager.toggleButtonsState
-                                .contains(ToggleButtonsState.italic),
-                            manager.toggleButtonsState
-                                .contains(ToggleButtonsState.underline),
-                          ],
-                          onPressed: (index) =>
-                              manager.updateToggleButtonsOnButtonPressed(index),
-                          children: const [
-                            Icon(Icons.format_bold),
-                            Icon(Icons.format_italic),
-                            Icon(Icons.format_underline),
-                          ],
-                        );
-                      }),
-                    ],
+                          return ToggleButtons(
+                            borderRadius:
+                                const BorderRadius.all(Radius.circular(4.0)),
+                            isSelected: [
+                              manager.toggleButtonsState
+                                  .contains(ToggleButtonsState.bold),
+                              manager.toggleButtonsState
+                                  .contains(ToggleButtonsState.italic),
+                              manager.toggleButtonsState
+                                  .contains(ToggleButtonsState.underline),
+                            ],
+                            onPressed: (index) => manager
+                                .updateToggleButtonsOnButtonPressed(index),
+                            children: const [
+                              Icon(Icons.format_bold),
+                              Icon(Icons.format_italic),
+                              Icon(Icons.format_underline),
+                            ],
+                          );
+                        }),
+                      ],
+                    ),
                   ),
-                ),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 35.0),
-                    child: TextEditingDeltaHistoryManager(
-                      history: _textEditingDeltaHistory,
-                      updateHistoryOnInput: _updateTextEditingDeltaHistory,
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 35.0),
                       child: BasicTextField(
                         controller: _replacementTextEditingController,
                         style: const TextStyle(
@@ -351,20 +351,15 @@ class _MyHomePageState extends State<MyHomePage> {
                       ),
                     ),
                   ),
-                ),
-                Expanded(
-                  child: Column(
-                    children: [
-                      _buildTextEditingDeltaViewHeader(),
-                      Expanded(
-                        child: TextEditingDeltaHistoryManager(
-                          history: _textEditingDeltaHistory,
-                          updateHistoryOnInput: _updateTextEditingDeltaHistory,
+                  Expanded(
+                    child: Column(
+                      children: [
+                        _buildTextEditingDeltaViewHeader(),
+                        Expanded(
                           child: Builder(
                             builder: (innerContext) {
-                              final TextEditingDeltaHistoryManager manager =
-                                  TextEditingDeltaHistoryManager.of(
-                                      innerContext);
+                              final manager = TextEditingDeltaHistoryManager.of(
+                                  innerContext);
                               return ListView.separated(
                                 padding: const EdgeInsets.symmetric(
                                     horizontal: 35.0),
@@ -381,12 +376,12 @@ class _MyHomePageState extends State<MyHomePage> {
                             },
                           ),
                         ),
-                      ),
-                      const SizedBox(height: 10),
-                    ],
+                        const SizedBox(height: 10),
+                      ],
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/simplistic_editor/lib/main.dart
+++ b/simplistic_editor/lib/main.dart
@@ -303,46 +303,46 @@ class _MyHomePageState extends State<MyHomePage> {
                 _updateToggleButtonsStateOnButtonPressed,
             updateToggleButtonStateOnSelectionChanged:
                 _updateToggleButtonsStateOnSelectionChanged,
-            child: TextEditingDeltaHistoryManager(
-              history: _textEditingDeltaHistory,
-              updateHistoryOnInput: _updateTextEditingDeltaHistory,
-              child: Column(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 8.0),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Builder(builder: (innerContext) {
-                          final manager =
-                              ToggleButtonsStateManager.of(innerContext);
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8.0),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Builder(builder: (innerContext) {
+                        final ToggleButtonsStateManager manager =
+                            ToggleButtonsStateManager.of(innerContext);
 
-                          return ToggleButtons(
-                            borderRadius:
-                                const BorderRadius.all(Radius.circular(4.0)),
-                            isSelected: [
-                              manager.toggleButtonsState
-                                  .contains(ToggleButtonsState.bold),
-                              manager.toggleButtonsState
-                                  .contains(ToggleButtonsState.italic),
-                              manager.toggleButtonsState
-                                  .contains(ToggleButtonsState.underline),
-                            ],
-                            onPressed: (index) => manager
-                                .updateToggleButtonsOnButtonPressed(index),
-                            children: const [
-                              Icon(Icons.format_bold),
-                              Icon(Icons.format_italic),
-                              Icon(Icons.format_underline),
-                            ],
-                          );
-                        }),
-                      ],
-                    ),
+                        return ToggleButtons(
+                          borderRadius:
+                              const BorderRadius.all(Radius.circular(4.0)),
+                          isSelected: [
+                            manager.toggleButtonsState
+                                .contains(ToggleButtonsState.bold),
+                            manager.toggleButtonsState
+                                .contains(ToggleButtonsState.italic),
+                            manager.toggleButtonsState
+                                .contains(ToggleButtonsState.underline),
+                          ],
+                          onPressed: (index) =>
+                              manager.updateToggleButtonsOnButtonPressed(index),
+                          children: const [
+                            Icon(Icons.format_bold),
+                            Icon(Icons.format_italic),
+                            Icon(Icons.format_underline),
+                          ],
+                        );
+                      }),
+                    ],
                   ),
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 35.0),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 35.0),
+                    child: TextEditingDeltaHistoryManager(
+                      history: _textEditingDeltaHistory,
+                      updateHistoryOnInput: _updateTextEditingDeltaHistory,
                       child: BasicTextField(
                         controller: _replacementTextEditingController,
                         style: const TextStyle(
@@ -351,15 +351,20 @@ class _MyHomePageState extends State<MyHomePage> {
                       ),
                     ),
                   ),
-                  Expanded(
-                    child: Column(
-                      children: [
-                        _buildTextEditingDeltaViewHeader(),
-                        Expanded(
+                ),
+                Expanded(
+                  child: Column(
+                    children: [
+                      _buildTextEditingDeltaViewHeader(),
+                      Expanded(
+                        child: TextEditingDeltaHistoryManager(
+                          history: _textEditingDeltaHistory,
+                          updateHistoryOnInput: _updateTextEditingDeltaHistory,
                           child: Builder(
                             builder: (innerContext) {
-                              final manager = TextEditingDeltaHistoryManager.of(
-                                  innerContext);
+                              final TextEditingDeltaHistoryManager manager =
+                                  TextEditingDeltaHistoryManager.of(
+                                      innerContext);
                               return ListView.separated(
                                 padding: const EdgeInsets.symmetric(
                                     horizontal: 35.0),
@@ -376,12 +381,12 @@ class _MyHomePageState extends State<MyHomePage> {
                             },
                           ),
                         ),
-                        const SizedBox(height: 10),
-                      ],
-                    ),
+                      ),
+                      const SizedBox(height: 10),
+                    ],
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ),


### PR DESCRIPTION
If I understand the code correctly, there appears to be redundant `ToggleButtonsStateManager` instances in the tree. There are three instances, all with the same configuration, with two instances underneath a single higher instance. I'm guessing all three wind up with identical state. I hope.

Or am I misunderstanding the intent of the structure?

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md