### PR TITLE
Pull up `TextEditingDeltaHistoryManager` to drop redundancy

### DIFF
--- a/simplistic_editor/lib/main.dart
+++ b/simplistic_editor/lib/main.dart
@@ -303,59 +303,59 @@ class _MyHomePageState extends State<MyHomePage> {
                 _updateToggleButtonsStateOnButtonPressed,
             updateToggleButtonStateOnSelectionChanged:
                 _updateToggleButtonsStateOnSelectionChanged,
-            child: Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8.0),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      ToggleButtonsStateManager(
+            child: TextEditingDeltaHistoryManager(
+              history: _textEditingDeltaHistory,
+              updateHistoryOnInput: _updateTextEditingDeltaHistory,
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8.0),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        ToggleButtonsStateManager(
+                          isToggleButtonsSelected: _isSelected,
+                          updateToggleButtonsStateOnButtonPressed:
+                              _updateToggleButtonsStateOnButtonPressed,
+                          updateToggleButtonStateOnSelectionChanged:
+                              _updateToggleButtonsStateOnSelectionChanged,
+                          child: Builder(builder: (innerContext) {
+                            final ToggleButtonsStateManager manager =
+                                ToggleButtonsStateManager.of(innerContext);
+
+                            return ToggleButtons(
+                              borderRadius:
+                                  const BorderRadius.all(Radius.circular(4.0)),
+                              isSelected: [
+                                manager.toggleButtonsState
+                                    .contains(ToggleButtonsState.bold),
+                                manager.toggleButtonsState
+                                    .contains(ToggleButtonsState.italic),
+                                manager.toggleButtonsState
+                                    .contains(ToggleButtonsState.underline),
+                              ],
+                              onPressed: (index) => manager
+                                  .updateToggleButtonsOnButtonPressed(index),
+                              children: const [
+                                Icon(Icons.format_bold),
+                                Icon(Icons.format_italic),
+                                Icon(Icons.format_underline),
+                              ],
+                            );
+                          }),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 35.0),
+                      child: ToggleButtonsStateManager(
                         isToggleButtonsSelected: _isSelected,
                         updateToggleButtonsStateOnButtonPressed:
                             _updateToggleButtonsStateOnButtonPressed,
                         updateToggleButtonStateOnSelectionChanged:
                             _updateToggleButtonsStateOnSelectionChanged,
-                        child: Builder(builder: (innerContext) {
-                          final ToggleButtonsStateManager manager =
-                              ToggleButtonsStateManager.of(innerContext);
-
-                          return ToggleButtons(
-                            borderRadius:
-                                const BorderRadius.all(Radius.circular(4.0)),
-                            isSelected: [
-                              manager.toggleButtonsState
-                                  .contains(ToggleButtonsState.bold),
-                              manager.toggleButtonsState
-                                  .contains(ToggleButtonsState.italic),
-                              manager.toggleButtonsState
-                                  .contains(ToggleButtonsState.underline),
-                            ],
-                            onPressed: (index) => manager
-                                .updateToggleButtonsOnButtonPressed(index),
-                            children: const [
-                              Icon(Icons.format_bold),
-                              Icon(Icons.format_italic),
-                              Icon(Icons.format_underline),
-                            ],
-                          );
-                        }),
-                      ),
-                    ],
-                  ),
-                ),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 35.0),
-                    child: ToggleButtonsStateManager(
-                      isToggleButtonsSelected: _isSelected,
-                      updateToggleButtonsStateOnButtonPressed:
-                          _updateToggleButtonsStateOnButtonPressed,
-                      updateToggleButtonStateOnSelectionChanged:
-                          _updateToggleButtonsStateOnSelectionChanged,
-                      child: TextEditingDeltaHistoryManager(
-                        history: _textEditingDeltaHistory,
-                        updateHistoryOnInput: _updateTextEditingDeltaHistory,
                         child: BasicTextField(
                           controller: _replacementTextEditingController,
                           style: const TextStyle(
@@ -365,15 +365,11 @@ class _MyHomePageState extends State<MyHomePage> {
                       ),
                     ),
                   ),
-                ),
-                Expanded(
-                  child: Column(
-                    children: [
-                      _buildTextEditingDeltaViewHeader(),
-                      Expanded(
-                        child: TextEditingDeltaHistoryManager(
-                          history: _textEditingDeltaHistory,
-                          updateHistoryOnInput: _updateTextEditingDeltaHistory,
+                  Expanded(
+                    child: Column(
+                      children: [
+                        _buildTextEditingDeltaViewHeader(),
+                        Expanded(
                           child: Builder(
                             builder: (innerContext) {
                               final TextEditingDeltaHistoryManager manager =
@@ -395,12 +391,12 @@ class _MyHomePageState extends State<MyHomePage> {
                             },
                           ),
                         ),
-                      ),
-                      const SizedBox(height: 10),
-                    ],
+                        const SizedBox(height: 10),
+                      ],
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/simplistic_editor/lib/text_editing_delta_history_manager.dart
+++ b/simplistic_editor/lib/text_editing_delta_history_manager.dart
@@ -18,7 +18,8 @@ class TextEditingDeltaHistoryManager extends InheritedWidget {
   static TextEditingDeltaHistoryManager of(BuildContext context) {
     final TextEditingDeltaHistoryManager? result = context
         .dependOnInheritedWidgetOfExactType<TextEditingDeltaHistoryManager>();
-    assert(result != null, 'No ToggleButtonsStateManager found in context');
+    assert(
+        result != null, 'No TextEditingDeltaHistoryManager found in context');
     return result!;
   }
 


### PR DESCRIPTION
Similar to https://github.com/flutter/samples/pull/1305

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md