### PR TITLE
Changes to package import statements to prevent errors when using FirebaseCrashlytics code

### DIFF
--- a/game_template/lib/main.dart
+++ b/game_template/lib/main.dart
@@ -2,8 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_crashlytics/firebase_crashlytics.dart';
-import 'package:flutter/foundation.dart';
+import 'dart:io' show Platform;
+
+import 'package:firebase_core/firebase_core.dart' show Firebase, FirebaseOptions;
+import 'package:firebase_crashlytics/firebase_crashlytics.dart' show FirebaseCrashlytics;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb, TargetPlatform, kReleaseMode;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';

--- a/game_template/lib/main.dart
+++ b/game_template/lib/main.dart
@@ -2,12 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io' show Platform;
+// Uncomment the following lines when enabling Firebase Crashlytics
+// import 'dart:io';
+// import 'package:firebase_core/firebase_core.dart';
+// import 'firebase_options.dart';
 
-import 'package:firebase_core/firebase_core.dart' show Firebase, FirebaseOptions;
-import 'package:firebase_crashlytics/firebase_crashlytics.dart' show FirebaseCrashlytics;
-import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb, TargetPlatform, kReleaseMode;
-
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
@@ -38,7 +39,8 @@ import 'src/style/snack_bar.dart';
 import 'src/win_game/win_game_screen.dart';
 
 Future<void> main() async {
-  // Uncomment the following lines to enable Firebase Crashlytics.
+  // To enable Firebase Crashlytics, uncomment the following lines and
+  // the import statements at the top of this file.
   // See the 'Crashlytics' section of the main README.md file for details.
 
   FirebaseCrashlytics? crashlytics;


### PR DESCRIPTION
Without these changes to the package import statements, a user who enables the FirebaseCrashlytics code in main.dart of game_template, they will see a list of errors.

![Screen Shot 2022-06-16 at 11 49 46 pm](https://user-images.githubusercontent.com/183972/174085049-5151d985-9a92-4baf-b609-ba813a5811da.png)

These are the changes I had to make to get rid of the errors. 
@domesticmouse @johnpryan - please advise if this causes any problems or if there is a better way to do this.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md