### PR TITLE
Update filled button and filled tonal button

### DIFF
--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -118,21 +118,12 @@ class ButtonsWithoutIcon extends StatelessWidget {
             child: const Text('Elevated'),
           ),
           colDivider,
-          ElevatedButton(
-            style: ElevatedButton.styleFrom(
-              foregroundColor: Theme.of(context).colorScheme.onPrimary,
-              backgroundColor: Theme.of(context).colorScheme.primary,
-            ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+          FilledButton(
             onPressed: handlePressed(context, isDisabled, 'FilledButton'),
             child: const Text('Filled'),
           ),
           colDivider,
-          ElevatedButton(
-            style: ElevatedButton.styleFrom(
-              foregroundColor:
-                  Theme.of(context).colorScheme.onSecondaryContainer,
-              backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
-            ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+          FilledButton.tonal(
             onPressed: handlePressed(context, isDisabled, 'FilledTonalButton'),
             child: const Text('Filled Tonal'),
           ),
@@ -167,22 +158,13 @@ class ButtonsWithIcon extends StatelessWidget {
             label: const Text('Icon'),
           ),
           colDivider,
-          ElevatedButton.icon(
-            style: ElevatedButton.styleFrom(
-              foregroundColor: Theme.of(context).colorScheme.onPrimary,
-              backgroundColor: Theme.of(context).colorScheme.primary,
-            ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+          FilledButton.icon(
             onPressed: handlePressed(context, false, 'FilledButton with Icon'),
             label: const Text('Icon'),
             icon: const Icon(Icons.add),
           ),
           colDivider,
-          ElevatedButton.icon(
-            style: ElevatedButton.styleFrom(
-              foregroundColor:
-                  Theme.of(context).colorScheme.onSecondaryContainer,
-              backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
-            ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+          FilledButton.tonalIcon(
             onPressed:
                 handlePressed(context, false, 'FilledTonalButton with Icon'),
             label: const Text('Icon'),

--- a/experimental/material_3_demo/test/component_screen_test.dart
+++ b/experimental/material_3_demo/test/component_screen_test.dart
@@ -24,8 +24,7 @@ void main() {
     // Buttons
     expect(find.widgetWithText(ElevatedButton, 'Elevated'), findsNWidgets(2));
     expect(find.widgetWithText(FilledButton, 'Filled'), findsNWidgets(2));
-    expect(
-        find.widgetWithText(FilledButton, 'Filled Tonal'), findsNWidgets(2));
+    expect(find.widgetWithText(FilledButton, 'Filled Tonal'), findsNWidgets(2));
     expect(find.widgetWithText(OutlinedButton, 'Outlined'), findsNWidgets(2));
     expect(find.widgetWithText(TextButton, 'Text'), findsNWidgets(2));
     expect(find.text('Icon'), findsNWidgets(5));

--- a/experimental/material_3_demo/test/component_screen_test.dart
+++ b/experimental/material_3_demo/test/component_screen_test.dart
@@ -23,9 +23,9 @@ void main() {
     // Elements on the component screen
     // Buttons
     expect(find.widgetWithText(ElevatedButton, 'Elevated'), findsNWidgets(2));
-    expect(find.widgetWithText(ElevatedButton, 'Filled'), findsNWidgets(2));
+    expect(find.widgetWithText(FilledButton, 'Filled'), findsNWidgets(2));
     expect(
-        find.widgetWithText(ElevatedButton, 'Filled Tonal'), findsNWidgets(2));
+        find.widgetWithText(FilledButton, 'Filled Tonal'), findsNWidgets(2));
     expect(find.widgetWithText(OutlinedButton, 'Outlined'), findsNWidgets(2));
     expect(find.widgetWithText(TextButton, 'Text'), findsNWidgets(2));
     expect(find.text('Icon'), findsNWidgets(5));


### PR DESCRIPTION
Instead of using ElevatedButton with filled, filled tonal style, this pr shows FilledButton and FilledButton.tonal without extra style configuration.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.