### PR TITLE
Remove `file_selector_*` from pubspecs.

### DIFF
--- a/desktop_photo_search/fluent_ui/pubspec.yaml
+++ b/desktop_photo_search/fluent_ui/pubspec.yaml
@@ -10,10 +10,7 @@ dependencies:
   built_collection: ^5.1.1
   built_value: ^8.3.0
   cupertino_icons: ^1.0.2
-  file_selector: ^0.9.0
-  file_selector_linux: ^0.9.0
-  file_selector_macos: ^0.9.0
-  file_selector_windows: ^0.9.0
+  file_selector: ^0.9.1
   fluent_ui: ^3.11.1
   fluentui_system_icons: ^1.1.168
   flutter:

--- a/desktop_photo_search/material/pubspec.yaml
+++ b/desktop_photo_search/material/pubspec.yaml
@@ -10,10 +10,7 @@ dependencies:
   built_collection: ^5.1.1
   built_value: ^8.3.0
   cupertino_icons: ^1.0.2
-  file_selector: ^0.9.0
-  file_selector_linux: ^0.9.0
-  file_selector_macos: ^0.9.0
-  file_selector_windows: ^0.9.0
+  file_selector: ^0.9.1
   flutter:
     sdk: flutter
   flutter_simple_treeview: ^3.0.0-nullsafety.1

--- a/experimental/linting_tool/pubspec.yaml
+++ b/experimental/linting_tool/pubspec.yaml
@@ -14,11 +14,7 @@ dependencies:
   adaptive_breakpoints: ^0.1.1
   cupertino_icons: ^1.0.2
   equatable: ^2.0.3
-  file_selector: ^0.9.0
-  file_selector_linux: ^0.9.0
-  file_selector_macos: ^0.9.0
-  file_selector_web: ^0.9.0
-  file_selector_windows: ^0.9.0
+  file_selector: ^0.9.1
   flutter_markdown: ^0.6.2
   google_fonts: ^3.0.0
   hive: ^2.0.4


### PR DESCRIPTION
As of 0.9.1, all of the 1P implementations of `file_selector` are
endorsed, so there's no need to directly include the sub-packages.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md