### PR TITLE
Revert "Bump ossf/scorecard-action from 1.1.2 to 2.0.0"

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@68bf5b3327e4fd443d2add8ab122280547b4a16d
+        uses: ossf/scorecard-action@ce330fde6b1a5c9c75b417e7efc510b822a35564
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Bug: https://github.com/ossf/scorecard-action/issues/900

This is causing the `main` build to fail.