### PR TITLE
Manually update scorecard action to v2.0.3

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -18,6 +18,7 @@ jobs:
       security-events: write
       actions: read
       contents: read
+      id-token: write
 
     steps:
       - name: "Checkout code"
@@ -26,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@ce330fde6b1a5c9c75b417e7efc510b822a35564
+        uses: ossf/scorecard-action@865b4092859256271290c77adbd10a43f4779972
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Adds the `id-token: write` permission as required by v2.