### PR TITLE
Add Radios, CircularProgressIndicator and LinearProgressIndicator to the demo app

### DIFF
--- a/experimental/material_3_demo/README.md
+++ b/experimental/material_3_demo/README.md
@@ -2,7 +2,7 @@
 
 This sample Flutter app showcases Material 3 features in the Flutter Material library. These features include updated components, typography, color system and elevation support. The app supports light and dark themes, different color palettes, as well as the ability to switch between Material 2 and Material 3. For more information about Material 3, the guidance is now live at https://m3.material.io/.
 
-This app also includes new M3 components that haven't landed in the Flutter stable channel, such as IconButtons, Chips, TextFields, Switches, Checkboxes, Radios and ProgressIndicators. The app will be migrated to the non-experimental directory in the samples repo once all the components land in the stable branch. For more information about the components in the stable channel, please check the "material_3_demo" in the non-experimental directory.
+This app also includes new M3 components that haven't landed in the Flutter stable channel, such as IconButtons, Chips, TextFields, Switches, Checkboxes, Radio buttons and ProgressIndicators. The app will be migrated to the non-experimental directory in the samples repo once all the components land in the stable branch. For more information about the components in the stable channel, please check the "material_3_demo" in the non-experimental directory.
 
 # Preview
 
@@ -18,7 +18,7 @@ This app also includes new M3 components that haven't landed in the Flutter stab
 <img src="https://user-images.githubusercontent.com/36861262/166511137-85dea8df-0017-4649-b913-14d4b7a17c2f.png" width="25" /> This button will bring up a pop-up menu that allows the user to change the base color used for the light and dark themes. This uses a new color seed feature to generate entire color schemes from a single color.
 
 ## Component Screen
-The default screen displays all the updated components in Material 3: AppBar, common Buttons, Floating Action Button(FAB), Chips, Card, Checkbox, Dialog, NavigationBar, NavigationRail, ProgressIndicators, Radios, TextFields and Switch.
+The default screen displays all the updated components in Material 3: AppBar, common Buttons, Floating Action Button(FAB), Chips, Card, Checkbox, Dialog, NavigationBar, NavigationRail, ProgressIndicators, Radio buttons, TextFields and Switch.
 
 ### Adaptive Layout
 Based on the fact that NavigationRail is not recommended on a small screen, the app changes its layout based on the screen width. If it's played on iOS or Android devices which have a narrow screen, a Navigation Bar will show at the bottom and will be used to navigate. But if it's played as a desktop or a web app, a Navigation Rail will show on the left side and at the same time, a Navigation Bar will show as an example but will not have any functionality.

--- a/experimental/material_3_demo/README.md
+++ b/experimental/material_3_demo/README.md
@@ -2,7 +2,7 @@
 
 This sample Flutter app showcases Material 3 features in the Flutter Material library. These features include updated components, typography, color system and elevation support. The app supports light and dark themes, different color palettes, as well as the ability to switch between Material 2 and Material 3. For more information about Material 3, the guidance is now live at https://m3.material.io/.
 
-This app also includes new M3 components that haven't landed in the Flutter stable channel, such as IconButtons, Chips, TextFields, Switches and Checkboxes. The app will be migrated to the non-experimental directory in the samples repo once all the components land in the stable branch. For more information about the components in the stable channel, please check the "material_3_demo" in the non-experimental directory.
+This app also includes new M3 components that haven't landed in the Flutter stable channel, such as IconButtons, Chips, TextFields, Switches, Checkboxes, Radios and ProgressIndicators. The app will be migrated to the non-experimental directory in the samples repo once all the components land in the stable branch. For more information about the components in the stable channel, please check the "material_3_demo" in the non-experimental directory.
 
 # Preview
 
@@ -18,7 +18,7 @@ This app also includes new M3 components that haven't landed in the Flutter stab
 <img src="https://user-images.githubusercontent.com/36861262/166511137-85dea8df-0017-4649-b913-14d4b7a17c2f.png" width="25" /> This button will bring up a pop-up menu that allows the user to change the base color used for the light and dark themes. This uses a new color seed feature to generate entire color schemes from a single color.
 
 ## Component Screen
-The default screen displays all the updated components in Material 3: AppBar, common Buttons, Floating Action Button(FAB), Chips, Card, Checkbox, Dialog, NavigationBar, NavigationRail, TextFields and Switch.
+The default screen displays all the updated components in Material 3: AppBar, common Buttons, Floating Action Button(FAB), Chips, Card, Checkbox, Dialog, NavigationBar, NavigationRail, ProgressIndicators, Radios, TextFields and Switch.
 
 ### Adaptive Layout
 Based on the fact that NavigationRail is not recommended on a small screen, the app changes its layout based on the screen width. If it's played on iOS or Android devices which have a narrow screen, a Navigation Bar will show at the bottom and will be used to navigate. But if it's played as a desktop or a web app, a Navigation Rail will show on the left side and at the same time, a Navigation Bar will show as an example but will not have any functionality.

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -696,7 +696,8 @@ class _ProgressIndicatorsState extends State<ProgressIndicators> {
               icon: const Icon(Icons.play_arrow),
               onPressed: () {
                 setState(() {
-                  playCircularProgressIndicator = !playCircularProgressIndicator;
+                  playCircularProgressIndicator =
+                      !playCircularProgressIndicator;
                 });
               },
             ),
@@ -704,9 +705,13 @@ class _ProgressIndicatorsState extends State<ProgressIndicators> {
               flex: 10,
               child: Center(
                 child: playCircularProgressIndicator
-                    ? const CircularProgressIndicator(value: null,)
-                    : const CircularProgressIndicator(value: 0.7,),
-              )
+                    ? const CircularProgressIndicator(
+                        value: null,
+                      )
+                    : const CircularProgressIndicator(
+                        value: 0.7,
+                      ),
+              ),
             ),
             const Spacer(),
           ],
@@ -725,11 +730,15 @@ class _ProgressIndicatorsState extends State<ProgressIndicators> {
             ),
             Expanded(
               child: playLinearProgressIndicator
-                  ? const LinearProgressIndicator(value: null,)
-                  : const LinearProgressIndicator(value: 0.7,),
-            )
+                  ? const LinearProgressIndicator(
+                      value: null,
+                    )
+                  : const LinearProgressIndicator(
+                      value: 0.7,
+                    ),
+            ),
           ],
-        )
+        ),
       ],
     );
   }

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -681,52 +681,55 @@ class ProgressIndicators extends StatefulWidget {
 }
 
 class _ProgressIndicatorsState extends State<ProgressIndicators> {
-  bool showCircularProgressIndicator = false;
-  bool showLinearProgressIndicator = false;
-
-  Text buttonText(String text) {
-    return Text(
-      text,
-      style: const TextStyle(fontWeight: FontWeight.bold),
-    );
-  }
+  bool playCircularProgressIndicator = false;
+  bool playLinearProgressIndicator = false;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: <Widget>[
-        TextButton(
-          onPressed: () {
-            setState(() {
-              showCircularProgressIndicator = !showCircularProgressIndicator;
-            });
-          },
-          child: showCircularProgressIndicator
-              ? buttonText('Hide circular progress indicator')
-              : buttonText('Show circular progress indicator'),
-        ),
-        showCircularProgressIndicator
-            ? const CircularProgressIndicator(
-                value: null,
+        Row(
+          children: [
+            IconButton(
+              isSelected: playCircularProgressIndicator,
+              selectedIcon: const Icon(Icons.pause),
+              icon: const Icon(Icons.play_arrow),
+              onPressed: () {
+                setState(() {
+                  playCircularProgressIndicator = !playCircularProgressIndicator;
+                });
+              },
+            ),
+            Expanded(
+              flex: 10,
+              child: Center(
+                child: playCircularProgressIndicator
+                    ? const CircularProgressIndicator(value: null,)
+                    : const CircularProgressIndicator(value: 0.7,),
               )
-            : Container(),
-        colDivider,
-        TextButton(
-          onPressed: () {
-            setState(() {
-              showLinearProgressIndicator = !showLinearProgressIndicator;
-            });
-          },
-          child: showLinearProgressIndicator
-              ? buttonText('Hide linear progress indicator')
-              : buttonText('Show linear progress indicator'),
+            ),
+            const Spacer(),
+          ],
         ),
-        colDivider,
-        showLinearProgressIndicator
-            ? const LinearProgressIndicator(
-                value: null,
-              )
-            : Container(),
+        Row(
+          children: [
+            IconButton(
+              isSelected: playLinearProgressIndicator,
+              selectedIcon: const Icon(Icons.pause),
+              icon: const Icon(Icons.play_arrow),
+              onPressed: () {
+                setState(() {
+                  playLinearProgressIndicator = !playLinearProgressIndicator;
+                });
+              },
+            ),
+            Expanded(
+              child: playLinearProgressIndicator
+                  ? const LinearProgressIndicator(value: null,)
+                  : const LinearProgressIndicator(value: 0.7,),
+            )
+          ],
+        )
       ],
     );
   }

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -685,6 +685,8 @@ class _ProgressIndicatorsState extends State<ProgressIndicators> {
 
   @override
   Widget build(BuildContext context) {
+    final double? progressValue = playProgressIndicator ? null : 0.7;
+
     return Column(
       children: <Widget>[
         Row(
@@ -699,40 +701,21 @@ class _ProgressIndicatorsState extends State<ProgressIndicators> {
                 });
               },
             ),
-            playProgressIndicator
-                ? Expanded(
-                    child: Row(
-                      children: const <Widget>[
-                        CircularProgressIndicator(
-                          value: null,
-                        ),
-                        SizedBox(
-                          width: 10,
-                        ),
-                        Expanded(
-                          child: LinearProgressIndicator(
-                            value: null,
-                          ),
-                        )
-                      ],
+            Expanded(
+              child: Row(
+                children: <Widget>[
+                  CircularProgressIndicator(
+                    value: progressValue,
+                  ),
+                  const SizedBox(width: 10,),
+                  Expanded(
+                    child: LinearProgressIndicator(
+                      value: progressValue,
                     ),
                   )
-                : Expanded(
-                    child: Row(
-                      children: const <Widget>[
-                        CircularProgressIndicator(
-                          value: 0.7,
-                        ),
-                        SizedBox(
-                          width: 10,
-                        ),
-                        Expanded(
-                            child: LinearProgressIndicator(
-                          value: 0.7,
-                        ))
-                      ],
-                    ),
-                  ),
+                ],
+              ),
+            ),
           ],
         ),
       ],

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -42,6 +42,10 @@ class ComponentScreen extends StatelessWidget {
                 colDivider,
                 const Checkboxes(),
                 colDivider,
+                const Radios(),
+                colDivider,
+                const ProgressIndicators(),
+                colDivider,
                 showNavBottomBar
                     ? const NavigationBars(
                         selectedIndex: 0,
@@ -624,6 +628,105 @@ class _CheckboxRowState extends State<CheckboxRow> {
           value: true,
           onChanged: null,
         ),
+      ],
+    );
+  }
+}
+
+enum Value { first, second }
+
+class Radios extends StatefulWidget {
+  const Radios({super.key});
+
+  @override
+  State<Radios> createState() => _RadiosState();
+}
+
+class _RadiosState extends State<Radios> {
+  Value? _value = Value.first;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: <Widget>[
+        Radio<Value>(
+          value: Value.first,
+          groupValue: _value,
+          onChanged: (value) {
+            setState(() {
+              _value = value;
+            });
+          },
+        ),
+        Radio<Value>(
+          value: Value.second,
+          groupValue: _value,
+          onChanged: (value) {
+            setState(() {
+              _value = value;
+            });
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class ProgressIndicators extends StatefulWidget {
+  const ProgressIndicators({super.key});
+
+  @override
+  State<ProgressIndicators> createState() => _ProgressIndicatorsState();
+}
+
+class _ProgressIndicatorsState extends State<ProgressIndicators> {
+  bool showCircularProgressIndicator = false;
+  bool showLinearProgressIndicator = false;
+
+  Text buttonText(String text) {
+    return Text(
+      text,
+      style: const TextStyle(fontWeight: FontWeight.bold),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        TextButton(
+          onPressed: () {
+            setState(() {
+              showCircularProgressIndicator = !showCircularProgressIndicator;
+            });
+          },
+          child: showCircularProgressIndicator
+              ? buttonText('Hide circular progress indicator')
+              : buttonText('Show circular progress indicator'),
+        ),
+        showCircularProgressIndicator
+            ? const CircularProgressIndicator(
+                value: null,
+              )
+            : Container(),
+        colDivider,
+        TextButton(
+          onPressed: () {
+            setState(() {
+              showLinearProgressIndicator = !showLinearProgressIndicator;
+            });
+          },
+          child: showLinearProgressIndicator
+              ? buttonText('Hide linear progress indicator')
+              : buttonText('Show linear progress indicator'),
+        ),
+        colDivider,
+        showLinearProgressIndicator
+            ? const LinearProgressIndicator(
+                value: null,
+              )
+            : Container(),
       ],
     );
   }

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -681,8 +681,7 @@ class ProgressIndicators extends StatefulWidget {
 }
 
 class _ProgressIndicatorsState extends State<ProgressIndicators> {
-  bool playCircularProgressIndicator = false;
-  bool playLinearProgressIndicator = false;
+  bool playProgressIndicator = false;
 
   @override
   Widget build(BuildContext context) {
@@ -691,52 +690,49 @@ class _ProgressIndicatorsState extends State<ProgressIndicators> {
         Row(
           children: [
             IconButton(
-              isSelected: playCircularProgressIndicator,
+              isSelected: playProgressIndicator,
               selectedIcon: const Icon(Icons.pause),
               icon: const Icon(Icons.play_arrow),
               onPressed: () {
                 setState(() {
-                  playCircularProgressIndicator =
-                      !playCircularProgressIndicator;
+                  playProgressIndicator = !playProgressIndicator;
                 });
               },
             ),
-            Expanded(
-              flex: 10,
-              child: Center(
-                child: playCircularProgressIndicator
-                    ? const CircularProgressIndicator(
-                        value: null,
-                      )
-                    : const CircularProgressIndicator(
-                        value: 0.7,
-                      ),
-              ),
-            ),
-            const Spacer(),
-          ],
-        ),
-        Row(
-          children: [
-            IconButton(
-              isSelected: playLinearProgressIndicator,
-              selectedIcon: const Icon(Icons.pause),
-              icon: const Icon(Icons.play_arrow),
-              onPressed: () {
-                setState(() {
-                  playLinearProgressIndicator = !playLinearProgressIndicator;
-                });
-              },
-            ),
-            Expanded(
-              child: playLinearProgressIndicator
-                  ? const LinearProgressIndicator(
-                      value: null,
-                    )
-                  : const LinearProgressIndicator(
-                      value: 0.7,
+            playProgressIndicator
+                ? Expanded(
+                    child: Row(
+                      children: const <Widget>[
+                        CircularProgressIndicator(
+                          value: null,
+                        ),
+                        SizedBox(
+                          width: 10,
+                        ),
+                        Expanded(
+                          child: LinearProgressIndicator(
+                            value: null,
+                          ),
+                        )
+                      ],
                     ),
-            ),
+                  )
+                : Expanded(
+                    child: Row(
+                      children: const <Widget>[
+                        CircularProgressIndicator(
+                          value: 0.7,
+                        ),
+                        SizedBox(
+                          width: 10,
+                        ),
+                        Expanded(
+                            child: LinearProgressIndicator(
+                          value: 0.7,
+                        ))
+                      ],
+                    ),
+                  ),
           ],
         ),
       ],

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -707,7 +707,9 @@ class _ProgressIndicatorsState extends State<ProgressIndicators> {
                   CircularProgressIndicator(
                     value: progressValue,
                   ),
-                  const SizedBox(width: 10,),
+                  const SizedBox(
+                    width: 10,
+                  ),
                   Expanded(
                     child: LinearProgressIndicator(
                       value: progressValue,

--- a/experimental/material_3_demo/test/component_screen_test.dart
+++ b/experimental/material_3_demo/test/component_screen_test.dart
@@ -63,6 +63,23 @@ void main() {
     // Checkboxes
     Finder checkboxExample = find.byType(Checkbox);
     expect(checkboxExample, findsNWidgets(8));
+
+    // Radios
+    Finder radioExample = find.byType(Radio<Value>);
+    expect(radioExample, findsNWidgets(2));
+
+    // ProgressIndicator
+    Finder progressIndicator1 = find.text('Show circular progress indicator');
+    await tester.tap(progressIndicator1);
+    await tester.pump();
+    Finder circularProgressIndicator = find.byType(CircularProgressIndicator);
+    expect(circularProgressIndicator, findsOneWidget);
+
+    Finder progressIndicator2 = find.text('Show linear progress indicator');
+    await tester.tap(progressIndicator2);
+    await tester.pump();
+    Finder linearProgressIndicator = find.byType(LinearProgressIndicator);
+    expect(linearProgressIndicator, findsOneWidget);
   });
 
   testWidgets(

--- a/experimental/material_3_demo/test/component_screen_test.dart
+++ b/experimental/material_3_demo/test/component_screen_test.dart
@@ -69,15 +69,8 @@ void main() {
     expect(radioExample, findsNWidgets(2));
 
     // ProgressIndicator
-    Finder progressIndicator1 = find.text('Show circular progress indicator');
-    await tester.tap(progressIndicator1);
-    await tester.pump();
     Finder circularProgressIndicator = find.byType(CircularProgressIndicator);
     expect(circularProgressIndicator, findsOneWidget);
-
-    Finder progressIndicator2 = find.text('Show linear progress indicator');
-    await tester.tap(progressIndicator2);
-    await tester.pump();
     Finder linearProgressIndicator = find.byType(LinearProgressIndicator);
     expect(linearProgressIndicator, findsOneWidget);
   });


### PR DESCRIPTION
Added `Radio` and `ProgressIndicator` to the demo app.

<img width="760" alt="Screen Shot 2022-09-26 at 10 19 33 PM" src="https://user-images.githubusercontent.com/36861262/192438543-0f834fc4-f887-4b83-b6fe-2e790b6f4ef0.png">

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.