### PR TITLE
[simplistic_editor] - Fix delete key on desktop and backspace key on Web

### DIFF
--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -330,6 +330,7 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
 
     if (_selection.isCollapsed) {
       if (forward) {
+        if (_selection.baseOffset == _value.text.length) return;
         deletedText = _value.text.substring(offset).characters.first;
         deletedRange = TextRange(
           start: offset,

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -315,6 +315,9 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
     PasteTextIntent: CallbackAction<PasteTextIntent>(
       onInvoke: (intent) => pasteText(intent.cause),
     ),
+    DoNothingAndStopPropagationTextIntent: DoNothingAction(
+      consumesKey: false,
+    ),
   };
 
   void _delete() {

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -299,7 +299,7 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
   TextSelection get _selection => _value.selection;
   late final Map<Type, Action<Intent>> _actions = <Type, Action<Intent>>{
     DeleteCharacterIntent: CallbackAction<DeleteCharacterIntent>(
-      onInvoke: (intent) => _delete(),
+      onInvoke: (intent) => _delete(intent.forward),
     ),
     ExtendSelectionByCharacterIntent:
         CallbackAction<ExtendSelectionByCharacterIntent>(
@@ -320,20 +320,28 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
     ),
   };
 
-  void _delete() {
+  void _delete(bool forward) {
     if (_value.text.isEmpty) return;
 
     late final TextRange deletedRange;
     late final TextRange newComposing;
-    final int deletedLength =
-        _value.text.substring(0, _selection.baseOffset).characters.last.length;
+    late final int deletedLength;
 
     if (_selection.isCollapsed) {
-      if (_selection.baseOffset == 0) return;
-      deletedRange = TextRange(
-        start: _selection.baseOffset - deletedLength,
-        end: _selection.baseOffset,
-      );
+      if (forward) {
+        deletedLength = _value.text.substring(_selection.baseOffset).characters.first.length;
+        deletedRange = TextRange(
+          start: _selection.baseOffset,
+          end: _selection.baseOffset + deletedLength,
+        );
+      } else {
+        if (_selection.baseOffset == 0) return;
+        deletedLength = _value.text.substring(0, _selection.baseOffset).characters.last.length;
+        deletedRange = TextRange(
+          start: _selection.baseOffset - deletedLength,
+          end: _selection.baseOffset,
+        );
+      }
     } else {
       deletedRange = _selection;
     }

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -325,21 +325,22 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
 
     late final TextRange deletedRange;
     late final TextRange newComposing;
-    late final int deletedLength;
+    late final String deletedText;
+    final int offset = _selection.baseOffset;
 
     if (_selection.isCollapsed) {
       if (forward) {
-        deletedLength = _value.text.substring(_selection.baseOffset).characters.first.length;
+        deletedText = _value.text.substring(offset).characters.first;
         deletedRange = TextRange(
-          start: _selection.baseOffset,
-          end: _selection.baseOffset + deletedLength,
+          start: offset,
+          end: offset + deletedText.length,
         );
       } else {
         if (_selection.baseOffset == 0) return;
-        deletedLength = _value.text.substring(0, _selection.baseOffset).characters.last.length;
+        deletedText = _value.text.substring(0, offset).characters.last;
         deletedRange = TextRange(
-          start: _selection.baseOffset - deletedLength,
-          end: _selection.baseOffset,
+          start: offset - deletedText.length,
+          end: offset,
         );
       }
     } else {


### PR DESCRIPTION
## Description

This PR updates the `simplistic_editor` sample to fix some issues related to `delete` and `backspace` keys.
- On web: before this PR, the `backspace` keys was handled by both the web browser and the framework which leads to a selection state entanglement. (see https://github.com/flutter/samples/issues/1413 and https://github.com/flutter/samples/issues/1450)
- On Desktop: before this PR, the `delete` and `backspace` were not differentiated.

For full context, see https://github.com/flutter/samples/issues/1424#issuecomment-1262738099


# Related issues

Fixes https://github.com/flutter/samples/issues/1450
Fixes https://github.com/flutter/samples/issues/1413
