### PR TITLE
Restrict sass_builder to v2.1.4 to fix build

### DIFF
--- a/web/samples_index/pubspec.yaml
+++ b/web/samples_index/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   yaml: ^3.0.0
   mdc_web: ^0.6.0
   # ^2.1.5 is no longer compatible with our overridden sass version
+  # https://github.com/flutter/samples/issues/1472
   sass_builder: 2.1.4
   checked_yaml: ^2.0.1
   webdriver: ^3.0.0
@@ -28,5 +29,6 @@ dev_dependencies:
 # Once released, it will need to be rolled into package:mdc_web.
 #
 # https://github.com/material-components/material-components-web/pull/7158
+# https://github.com/flutter/samples/issues/1472
 dependency_overrides:
   sass: 1.32.10

--- a/web/samples_index/pubspec.yaml
+++ b/web/samples_index/pubspec.yaml
@@ -9,7 +9,8 @@ dependencies:
   path: ^1.6.0
   yaml: ^3.0.0
   mdc_web: ^0.6.0
-  sass_builder: ^2.1.0
+  # ^2.1.5 is no longer compatible with our overridden sass version
+  sass_builder: 2.1.4
   checked_yaml: ^2.0.1
   webdriver: ^3.0.0
   html: ^0.15.0


### PR DESCRIPTION
The [2.1.5](https://pub.dev/packages/sass_builder/changelog#215) release has a change that was required by newer versions of the sass package. 

Since we still override the sass version due to mdc_web needing to be updated, our version of sass is no longer compatible with new versions of sass_builder, resulting in errors if we upgrade. This PR solves this for now, by limiting sass_builder to v2.1.4. In the long run, we should investigate getting mdc_web updated so we can upgrade sass as well.