### PR TITLE
Replace tuneup in samples_index

### DIFF
--- a/web/samples_index/pubspec.yaml
+++ b/web/samples_index/pubspec.yaml
@@ -23,7 +23,6 @@ dev_dependencies:
   build: ^2.0.3
   build_runner: ^2.0.6
   build_web_compilers: ^3.0.0
-  tuneup: ^0.3.8
   image: ^3.0.2
 # waiting for the next material-components-web release.
 # Once released, it will need to be rolled into package:mdc_web.

--- a/web/samples_index/tool/grind.dart
+++ b/web/samples_index/tool/grind.dart
@@ -20,7 +20,7 @@ Future<void> testCli() async =>
 
 @Task()
 void analyze() {
-  PubApp.local('tuneup').run(['check']);
+  run('dart', arguments: const ['analyze', '--fatal-infos', '.']);
 }
 
 @Task('deploy')


### PR DESCRIPTION
tuneup has been discontinued as much of the functionality can be handled by built-in `dart` tools. For `check` we can just replace with direct usage of the analyzer.

Supersedes https://github.com/flutter/samples/pull/1496

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.