### PR TITLE
Fix go_router navigation

### DIFF
--- a/game_template/lib/src/level_selection/level_selection_screen.dart
+++ b/game_template/lib/src/level_selection/level_selection_screen.dart
@@ -61,7 +61,7 @@ class LevelSelectionScreen extends StatelessWidget {
         ),
         rectangularMenuArea: ElevatedButton(
           onPressed: () {
-            GoRouter.of(context).pop();
+            GoRouter.of(context).go('/');
           },
           child: const Text('Back'),
         ),

--- a/game_template/lib/src/main_menu/main_menu_screen.dart
+++ b/game_template/lib/src/main_menu/main_menu_screen.dart
@@ -71,7 +71,7 @@ class MainMenuScreen extends StatelessWidget {
               _gap,
             ],
             ElevatedButton(
-              onPressed: () => GoRouter.of(context).go('/settings'),
+              onPressed: () => GoRouter.of(context).push('/settings'),
               child: const Text('Settings'),
             ),
             _gap,

--- a/game_template/lib/src/play_session/play_session_screen.dart
+++ b/game_template/lib/src/play_session/play_session_screen.dart
@@ -94,7 +94,7 @@ class _PlaySessionScreenState extends State<PlaySessionScreen> {
                       child: SizedBox(
                         width: double.infinity,
                         child: ElevatedButton(
-                          onPressed: () => GoRouter.of(context).pop(),
+                          onPressed: () => GoRouter.of(context).go('/play'),
                           child: const Text('Back'),
                         ),
                       ),

--- a/game_template/lib/src/win_game/win_game_screen.dart
+++ b/game_template/lib/src/win_game/win_game_screen.dart
@@ -63,7 +63,7 @@ class WinGameScreen extends StatelessWidget {
         ),
         rectangularMenuArea: ElevatedButton(
           onPressed: () {
-            GoRouter.of(context).pop();
+            GoRouter.of(context).go('/play');
           },
           child: const Text('Continue'),
         ),

--- a/game_template/pubspec.yaml
+++ b/game_template/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 
   audioplayers: ^1.1.0
   cupertino_icons: ^1.0.2
-  go_router: ^5.0.5
+  go_router: ^5.2.1
   logging: ^1.1.0
   provider: ^6.0.2
   shared_preferences: ^2.0.13


### PR DESCRIPTION
Mixing declarative (`.go()`) and imperative (`.pop()`) navigation no longer works.

This CL changes all navigation to the declarative `go()` wherever possible. The only imperative navigation still standing is the `/settings` route, which needs to be accessed (pushed) from both the main screen and the play session screen, and therefore there is no single URL to go back to. So we’re keeping `push()` / `pop()` there.

I’m sure it’s possible to implement even the `/settings` route with declarative navigation, but it seems way beyond the scope of this sample.

Fixes #1514.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md