### PR TITLE
Migrate animations to go_router

### DIFF
--- a/animations/lib/main.dart
+++ b/animations/lib/main.dart
@@ -165,7 +165,7 @@ final router = GoRouter(
             path: demo.route.substring(1),
             builder: (context, state) => demo.builder(context),
           ),
-      ]
+      ],
     ),
   ],
 );

--- a/animations/lib/main.dart
+++ b/animations/lib/main.dart
@@ -157,12 +157,12 @@ final router = GoRouter(
       routes: [
         for (final demo in basicDemos)
           GoRoute(
-            path: demo.route.substring(1),
+            path: demo.route,
             builder: (context, state) => demo.builder(context),
           ),
         for (final demo in miscDemos)
           GoRoute(
-            path: demo.route.substring(1),
+            path: demo.route,
             builder: (context, state) => demo.builder(context),
           ),
       ],
@@ -217,7 +217,7 @@ class DemoTile extends StatelessWidget {
     return ListTile(
       title: Text(demo.name),
       onTap: () {
-        context.go(demo.route);
+        context.go('/${demo.route}');
       },
     );
   }

--- a/animations/lib/main.dart
+++ b/animations/lib/main.dart
@@ -6,6 +6,8 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
 // ignore: depend_on_referenced_packages
 import 'package:window_size/window_size.dart';
 
@@ -147,29 +149,38 @@ final miscDemos = [
       builder: (context) => const CurvedAnimationDemo()),
 ];
 
-final basicDemoRoutes =
-    Map.fromEntries(basicDemos.map((d) => MapEntry(d.route, d.builder)));
-
-final miscDemoRoutes =
-    Map.fromEntries(miscDemos.map((d) => MapEntry(d.route, d.builder)));
-
-final allRoutes = <String, WidgetBuilder>{
-  ...basicDemoRoutes,
-  ...miscDemoRoutes,
-};
+final router = GoRouter(
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const HomePage(),
+      routes: [
+        for (final demo in basicDemos)
+          GoRoute(
+            path: demo.route.substring(1),
+            builder: (context, state) => demo.builder(context),
+          ),
+        for (final demo in miscDemos)
+          GoRoute(
+            path: demo.route.substring(1),
+            builder: (context, state) => demo.builder(context),
+          ),
+      ]
+    ),
+  ],
+);
 
 class AnimationSamples extends StatelessWidget {
   const AnimationSamples({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'Animation Samples',
       theme: ThemeData(
         primarySwatch: Colors.deepPurple,
       ),
-      routes: allRoutes,
-      home: const HomePage(),
+      routerConfig: router,
     );
   }
 }
@@ -206,7 +217,7 @@ class DemoTile extends StatelessWidget {
     return ListTile(
       title: Text(demo.name),
       onTap: () {
-        Navigator.pushNamed(context, demo.route);
+        context.go(demo.route);
       },
     );
   }

--- a/animations/lib/src/basics/01_animated_container.dart
+++ b/animations/lib/src/basics/01_animated_container.dart
@@ -12,7 +12,7 @@ Color generateColor() => Color(0xFFFFFFFF & Random().nextInt(0xFFFFFFFF));
 
 class AnimatedContainerDemo extends StatefulWidget {
   const AnimatedContainerDemo({super.key});
-  static String routeName = '/basics/01_animated_container';
+  static String routeName = 'basics/01_animated_container';
 
   @override
   State<AnimatedContainerDemo> createState() => _AnimatedContainerDemoState();

--- a/animations/lib/src/basics/02_page_route_builder.dart
+++ b/animations/lib/src/basics/02_page_route_builder.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 class PageRouteBuilderDemo extends StatelessWidget {
   const PageRouteBuilderDemo({super.key});
-  static const String routeName = '/basics/page_route_builder';
+  static const String routeName = 'basics/page_route_builder';
 
   @override
   Widget build(BuildContext context) {

--- a/animations/lib/src/basics/03_animation_controller.dart
+++ b/animations/lib/src/basics/03_animation_controller.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 class AnimationControllerDemo extends StatefulWidget {
   const AnimationControllerDemo({super.key});
-  static const String routeName = '/basics/animation_controller';
+  static const String routeName = 'basics/animation_controller';
 
   @override
   State<AnimationControllerDemo> createState() =>

--- a/animations/lib/src/basics/04_tweens.dart
+++ b/animations/lib/src/basics/04_tweens.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 class TweenDemo extends StatefulWidget {
   const TweenDemo({super.key});
-  static const String routeName = '/basics/tweens';
+  static const String routeName = 'basics/tweens';
 
   @override
   State<TweenDemo> createState() => _TweenDemoState();

--- a/animations/lib/src/basics/05_animated_builder.dart
+++ b/animations/lib/src/basics/05_animated_builder.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 class AnimatedBuilderDemo extends StatefulWidget {
   const AnimatedBuilderDemo({super.key});
-  static const String routeName = '/basics/animated_builder';
+  static const String routeName = 'basics/animated_builder';
 
   @override
   State<AnimatedBuilderDemo> createState() => _AnimatedBuilderDemoState();

--- a/animations/lib/src/basics/06_custom_tween.dart
+++ b/animations/lib/src/basics/06_custom_tween.dart
@@ -17,7 +17,7 @@ class TypewriterTween extends Tween<String> {
 
 class CustomTweenDemo extends StatefulWidget {
   const CustomTweenDemo({super.key});
-  static const String routeName = '/basics/custom_tweens';
+  static const String routeName = 'basics/custom_tweens';
 
   @override
   State<CustomTweenDemo> createState() => _CustomTweenDemoState();

--- a/animations/lib/src/basics/07_tween_sequence.dart
+++ b/animations/lib/src/basics/07_tween_sequence.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 class TweenSequenceDemo extends StatefulWidget {
   const TweenSequenceDemo({super.key});
-  static const String routeName = '/basics/chaining_tweens';
+  static const String routeName = 'basics/chaining_tweens';
 
   @override
   State<TweenSequenceDemo> createState() => _TweenSequenceDemoState();

--- a/animations/lib/src/basics/08_fade_transition.dart
+++ b/animations/lib/src/basics/08_fade_transition.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 // for examples of other common animated widgets.
 class FadeTransitionDemo extends StatefulWidget {
   const FadeTransitionDemo({super.key});
-  static const String routeName = '/basics/fade_transition';
+  static const String routeName = 'basics/fade_transition';
 
   @override
   State<FadeTransitionDemo> createState() => _FadeTransitionDemoState();

--- a/animations/lib/src/misc/animated_list.dart
+++ b/animations/lib/src/misc/animated_list.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 class AnimatedListDemo extends StatefulWidget {
   const AnimatedListDemo({super.key});
-  static String routeName = '/misc/animated_list';
+  static String routeName = 'misc/animated_list';
 
   @override
   State<AnimatedListDemo> createState() => _AnimatedListDemoState();

--- a/animations/lib/src/misc/animated_positioned.dart
+++ b/animations/lib/src/misc/animated_positioned.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 
 class AnimatedPositionedDemo extends StatefulWidget {
   const AnimatedPositionedDemo({super.key});
-  static String routeName = '/basics/09_animated_positioned';
+  static String routeName = 'misc/animated_positioned';
 
   @override
   State<AnimatedPositionedDemo> createState() => _AnimatedPositionedDemoState();

--- a/animations/lib/src/misc/animated_switcher.dart
+++ b/animations/lib/src/misc/animated_switcher.dart
@@ -24,7 +24,7 @@ Widget generateContainer(int keyCount) => Container(
 
 class AnimatedSwitcherDemo extends StatefulWidget {
   const AnimatedSwitcherDemo({super.key});
-  static String routeName = '/basics/10_animated_switcher';
+  static String routeName = 'misc/animated_switcher';
 
   @override
   State<AnimatedSwitcherDemo> createState() => _AnimatedSwitcherDemoState();

--- a/animations/lib/src/misc/card_swipe.dart
+++ b/animations/lib/src/misc/card_swipe.dart
@@ -7,7 +7,7 @@ import 'package:flutter/physics.dart';
 
 class CardSwipeDemo extends StatefulWidget {
   const CardSwipeDemo({super.key});
-  static String routeName = '/misc/card_swipe';
+  static String routeName = 'misc/card_swipe';
 
   @override
   State<CardSwipeDemo> createState() => _CardSwipeDemoState();

--- a/animations/lib/src/misc/carousel.dart
+++ b/animations/lib/src/misc/carousel.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 
 class CarouselDemo extends StatelessWidget {
   CarouselDemo({super.key});
-  static String routeName = '/misc/carousel';
+  static String routeName = 'misc/carousel';
 
   static const List<String> fileNames = [
     'assets/eat_cape_town_sm.jpg',

--- a/animations/lib/src/misc/curved_animation.dart
+++ b/animations/lib/src/misc/curved_animation.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 
 class CurvedAnimationDemo extends StatefulWidget {
   const CurvedAnimationDemo({super.key});
-  static const String routeName = '/misc/curved_animation';
+  static const String routeName = 'misc/curved_animation';
 
   @override
   State<CurvedAnimationDemo> createState() => _CurvedAnimationDemoState();

--- a/animations/lib/src/misc/expand_card.dart
+++ b/animations/lib/src/misc/expand_card.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 class ExpandCardDemo extends StatelessWidget {
   const ExpandCardDemo({super.key});
-  static const String routeName = '/misc/expand_card';
+  static const String routeName = 'misc/expand_card';
 
   @override
   Widget build(BuildContext context) {

--- a/animations/lib/src/misc/focus_image.dart
+++ b/animations/lib/src/misc/focus_image.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 class FocusImageDemo extends StatelessWidget {
   const FocusImageDemo({super.key});
-  static String routeName = '/misc/focus_image';
+  static String routeName = 'misc/focus_image';
 
   @override
   Widget build(BuildContext context) {

--- a/animations/lib/src/misc/hero_animation.dart
+++ b/animations/lib/src/misc/hero_animation.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 class HeroAnimationDemo extends StatelessWidget {
   const HeroAnimationDemo({super.key});
-  static const String routeName = '/misc/hero_animation';
+  static const String routeName = 'misc/hero_animation';
 
   @override
   Widget build(BuildContext context) {

--- a/animations/lib/src/misc/physics_card_drag.dart
+++ b/animations/lib/src/misc/physics_card_drag.dart
@@ -7,7 +7,7 @@ import 'package:flutter/physics.dart';
 
 class PhysicsCardDragDemo extends StatelessWidget {
   const PhysicsCardDragDemo({super.key});
-  static const String routeName = '/misc/physics_card';
+  static const String routeName = 'misc/physics_card';
 
   @override
   Widget build(BuildContext context) {

--- a/animations/lib/src/misc/repeating_animation.dart
+++ b/animations/lib/src/misc/repeating_animation.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 class RepeatingAnimationDemo extends StatefulWidget {
   const RepeatingAnimationDemo({super.key});
-  static String routeName = '/misc/repeating_animation';
+  static String routeName = 'misc/repeating_animation';
 
   @override
   State<RepeatingAnimationDemo> createState() => _RepeatingAnimationDemoState();

--- a/animations/pubspec.yaml
+++ b/animations/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
+  go_router: ^5.2.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
In this PR, I am replacing the named routes implementation in the `animations` sample for one using `go_router`.

The codelab_rebuild.yaml would need to be updated to add the go_router installation step.

cc. @domesticmouse @RedBrogdon 

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md