### PR TITLE
Move to using analyzer strict modes instead of deprecated strong mode

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,9 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    strict-casts: true
+    strict-inference: true
 
 linter:
   rules:

--- a/web/samples_index/analysis_options.yaml
+++ b/web/samples_index/analysis_options.yaml
@@ -3,9 +3,9 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - lib/src/data.g.dart
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    strict-casts: true
+    strict-inference: true
 
 linter:
   rules:


### PR DESCRIPTION
The strong mode options were already deprecated and are [being removed](https://github.com/dart-lang/sdk/commit/ea120b5d441edd0803e8313b2a1f706db793c855) in Dart 3.