### PR TITLE
migrate provider_shopper to go_router

### DIFF
--- a/provider_shopper/lib/main.dart
+++ b/provider_shopper/lib/main.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:provider_shopper/common/theme.dart';
 import 'package:provider_shopper/models/cart.dart';
@@ -39,6 +40,28 @@ void setupWindow() {
   }
 }
 
+GoRouter router() {
+  return GoRouter(
+    initialLocation: '/login',
+    routes: [
+      GoRoute(
+        path: '/login',
+        builder: (context, state) => const MyLogin(),
+      ),
+      GoRoute(
+        path: '/catalog',
+        builder: (context, state) => const MyCatalog(),
+        routes: [
+          GoRoute(
+            path: 'cart',
+            builder: (context, state) => const MyCart(),
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
@@ -62,15 +85,10 @@ class MyApp extends StatelessWidget {
           },
         ),
       ],
-      child: MaterialApp(
+      child: MaterialApp.router(
         title: 'Provider Demo',
         theme: appTheme,
-        initialRoute: '/',
-        routes: {
-          '/': (context) => const MyLogin(),
-          '/catalog': (context) => const MyCatalog(),
-          '/cart': (context) => const MyCart(),
-        },
+        routerConfig: router(),
       ),
     );
   }

--- a/provider_shopper/lib/screens/catalog.dart
+++ b/provider_shopper/lib/screens/catalog.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:provider_shopper/models/cart.dart';
 import 'package:provider_shopper/models/catalog.dart';
@@ -80,7 +81,7 @@ class _MyAppBar extends StatelessWidget {
       actions: [
         IconButton(
           icon: const Icon(Icons.shopping_cart),
-          onPressed: () => Navigator.pushNamed(context, '/cart'),
+          onPressed: () => context.go('/catalog/cart'),
         ),
       ],
     );

--- a/provider_shopper/lib/screens/login.dart
+++ b/provider_shopper/lib/screens/login.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class MyLogin extends StatelessWidget {
   const MyLogin({super.key});
@@ -36,7 +37,7 @@ class MyLogin extends StatelessWidget {
               ),
               ElevatedButton(
                 onPressed: () {
-                  Navigator.pushReplacementNamed(context, '/catalog');
+                  context.pushReplacement('/catalog');
                 },
                 style: ElevatedButton.styleFrom(
                   foregroundColor: Colors.yellow,

--- a/provider_shopper/pubspec.yaml
+++ b/provider_shopper/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  go_router: ^6.0.0
   provider: ^6.0.2
   window_size:
     git:

--- a/provider_shopper/test/login_widget_test.dart
+++ b/provider_shopper/test/login_widget_test.dart
@@ -5,10 +5,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
+import 'package:provider_shopper/main.dart';
 import 'package:provider_shopper/models/cart.dart';
 import 'package:provider_shopper/models/catalog.dart';
-import 'package:provider_shopper/screens/catalog.dart';
-import 'package:provider_shopper/screens/login.dart';
 
 void main() {
   testWidgets('Login page Widget test', (tester) async {
@@ -23,13 +22,7 @@ void main() {
           },
         ),
       ],
-      child: MaterialApp(
-        initialRoute: '/',
-        routes: {
-          '/': (context) => const MyLogin(),
-          '/catalog': (context) => const MyCatalog(),
-        },
-      ),
+      child: MaterialApp.router(routerConfig: router()),
     ));
 
     // Verifying the behaviour of ENTER button.


### PR DESCRIPTION
Migrated provider_shopper to go_router.

The routes have been rearranged this way:

- `/` has been moved to `/login`. Also, `/login` is the initial route.
- `/cart` has been moved to `/catalog/cart`, so it follows the route path logic.

cc. @domesticmouse 

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md