### PR TITLE
Migrate testing_app to go_router

### DIFF
--- a/testing_app/lib/main.dart
+++ b/testing_app/lib/main.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:testing_app/models/favorites.dart';
 import 'package:testing_app/screens/favorites.dart';
@@ -12,6 +13,23 @@ void main() {
   runApp(const TestingApp());
 }
 
+GoRouter router() {
+  return GoRouter(
+    routes: [
+      GoRoute(
+        path: HomePage.routeName,
+        builder: (context, state) => const HomePage(),
+        routes: [
+          GoRoute(
+            path: FavoritesPage.routeName,
+            builder: (context, state) => const FavoritesPage(),
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
 class TestingApp extends StatelessWidget {
   const TestingApp({super.key});
 
@@ -19,17 +37,13 @@ class TestingApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<Favorites>(
       create: (context) => Favorites(),
-      child: MaterialApp(
+      child: MaterialApp.router(
         title: 'Testing Sample',
         theme: ThemeData(
           primarySwatch: Colors.blue,
           visualDensity: VisualDensity.adaptivePlatformDensity,
         ),
-        routes: {
-          HomePage.routeName: (context) => const HomePage(),
-          FavoritesPage.routeName: (context) => const FavoritesPage(),
-        },
-        initialRoute: HomePage.routeName,
+        routerConfig: router(),
       ),
     );
   }

--- a/testing_app/lib/screens/favorites.dart
+++ b/testing_app/lib/screens/favorites.dart
@@ -7,7 +7,8 @@ import 'package:provider/provider.dart';
 import 'package:testing_app/models/favorites.dart';
 
 class FavoritesPage extends StatelessWidget {
-  static const routeName = '/favorites_page';
+  static const routeName = 'favorites_page';
+  static const fullPath = '/$routeName';
 
   const FavoritesPage({super.key});
 

--- a/testing_app/lib/screens/home.dart
+++ b/testing_app/lib/screens/home.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:testing_app/models/favorites.dart';
 import 'package:testing_app/screens/favorites.dart';
@@ -21,7 +22,7 @@ class HomePage extends StatelessWidget {
           TextButton.icon(
             style: TextButton.styleFrom(foregroundColor: Colors.white),
             onPressed: () {
-              Navigator.pushNamed(context, FavoritesPage.routeName);
+              context.go(FavoritesPage.fullPath);
             },
             icon: const Icon(Icons.favorite_border),
             label: const Text('Favorites'),

--- a/testing_app/pubspec.yaml
+++ b/testing_app/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
 
   cupertino_icons: ^1.0.3
   provider: ^6.0.2
+  go_router: ^0.0.1
 
 dev_dependencies:
   integration_test:

--- a/testing_app/pubspec.yaml
+++ b/testing_app/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   cupertino_icons: ^1.0.3
   provider: ^6.0.2
-  go_router: ^0.0.1
+  go_router: ^6.0.0
 
 dev_dependencies:
   integration_test:

--- a/testing_app/test/home_test.dart
+++ b/testing_app/test/home_test.dart
@@ -5,13 +5,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
+import 'package:testing_app/main.dart';
 import 'package:testing_app/models/favorites.dart';
-import 'package:testing_app/screens/home.dart';
 
 Widget createHomeScreen() => ChangeNotifierProvider<Favorites>(
       create: (context) => Favorites(),
-      child: const MaterialApp(
-        home: HomePage(),
+      child: MaterialApp.router(
+        routerConfig: router(),
       ),
     );
 
@@ -64,6 +64,17 @@ void main() {
 
       // Check if the filled icon changes back to bordered icon.
       expect(find.byIcon(Icons.favorite), findsNothing);
+    });
+
+    testWidgets('Testing Navigation', (tester) async {
+      await tester.pumpWidget(createHomeScreen());
+
+      // Tap the Favorites button in the app bar
+      await tester.tap(find.text('Favorites'));
+      await tester.pumpAndSettle();
+
+      // Verify if the empty favorites screen is shown.
+      expect(find.text('No favorites added.'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Migrated the testing_app sample to go_router.

Added a navigation unit test as well.

cc. @domesticmouse 

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md