### PR TITLE
Avoid allocation of large canvases on the web

### DIFF
--- a/experimental/material_3_demo/lib/color_palettes_screen.dart
+++ b/experimental/material_3_demo/lib/color_palettes_screen.dart
@@ -252,10 +252,12 @@ class ColorGroup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      clipBehavior: Clip.antiAlias,
-      child: Column(
-        children: children,
+    return RepaintBoundary(
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        child: Column(
+          children: children,
+        ),
       ),
     );
   }

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -1928,7 +1928,8 @@ class ComponentDecoration extends StatelessWidget {
               ],
             ),
             ConstrainedBox(
-              constraints: const BoxConstraints.tightFor(width: widthConstraint),
+              constraints:
+                  const BoxConstraints.tightFor(width: widthConstraint),
               child: Card(
                 elevation: 0,
                 shape: RoundedRectangleBorder(

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -1910,39 +1910,41 @@ class ComponentDecoration extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 10.0),
-      child: Column(
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(label, style: Theme.of(context).textTheme.titleSmall),
-              Tooltip(
-                message: tooltipMessage,
-                child: const Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 5.0),
-                    child: Icon(Icons.info_outline, size: 16)),
-              ),
-            ],
-          ),
-          ConstrainedBox(
-            constraints: const BoxConstraints.tightFor(width: widthConstraint),
-            child: Card(
-              elevation: 0,
-              shape: RoundedRectangleBorder(
-                side: BorderSide(
-                  color: Theme.of(context).colorScheme.outline,
+    return RepaintBoundary(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 10.0),
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(label, style: Theme.of(context).textTheme.titleSmall),
+                Tooltip(
+                  message: tooltipMessage,
+                  child: const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 5.0),
+                      child: Icon(Icons.info_outline, size: 16)),
                 ),
-                borderRadius: const BorderRadius.all(Radius.circular(12)),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(20.0),
-                child: child,
+              ],
+            ),
+            ConstrainedBox(
+              constraints: const BoxConstraints.tightFor(width: widthConstraint),
+              child: Card(
+                elevation: 0,
+                shape: RoundedRectangleBorder(
+                  side: BorderSide(
+                    color: Theme.of(context).colorScheme.outline,
+                  ),
+                  borderRadius: const BorderRadius.all(Radius.circular(12)),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: child,
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Introduce a few `RepaintBoundary`s in strategic locations to minimize the size of canvases allocated by Flutter Web.

This PR is an attempt to help with this: https://github.com/flutter/flutter/issues/117164