### PR TITLE
Update M3 demo app layout on small screen

### DIFF
--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -281,32 +281,61 @@ class FloatingActionButtons extends StatelessWidget {
       label: 'Floating action buttons',
       tooltipMessage:
           'Floating action buttons include: \nFloatingActionButton.small, FloatingActionButton, FloatingActionButton.extended, and FloatingActionButton.large',
-      child: Wrap(
-        alignment: WrapAlignment.spaceEvenly,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          FloatingActionButton.small(
-            onPressed: () {},
-            child: const Icon(Icons.add),
-          ),
-          rowDivider,
-          FloatingActionButton(
-            onPressed: () {},
-            child: const Icon(Icons.add),
-          ),
-          rowDivider,
-          FloatingActionButton.extended(
-            onPressed: () {},
-            icon: const Icon(Icons.add),
-            label: const Text('Create'),
-          ),
-          rowDivider,
-          FloatingActionButton.large(
-            onPressed: () {},
-            child: const Icon(Icons.add),
-          ),
-        ],
-      ),
+      child: LayoutBuilder(builder: (context, constraints) {
+        double screenWidth = MediaQuery.of(context).size.width;
+        if (screenWidth < 375.0) {
+          return Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  FloatingActionButton.small(
+                    onPressed: () {},
+                    child: const Icon(Icons.add),
+                  ),
+                  FloatingActionButton(
+                    onPressed: () {},
+                    child: const Icon(Icons.add),
+                  ),
+                  FloatingActionButton.large(
+                    onPressed: () {},
+                    child: const Icon(Icons.add),
+                  ),
+                ],
+              ),
+              colDivider,
+              FloatingActionButton.extended(
+                onPressed: () {},
+                icon: const Icon(Icons.add),
+                label: const Text('Create'),
+              ),
+            ],
+          );
+        } else {
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              FloatingActionButton.small(
+                onPressed: () {},
+                child: const Icon(Icons.add),
+              ),
+              FloatingActionButton(
+                onPressed: () {},
+                child: const Icon(Icons.add),
+              ),
+              FloatingActionButton.extended(
+                onPressed: () {},
+                icon: const Icon(Icons.add),
+                label: const Text('Create'),
+              ),
+              FloatingActionButton.large(
+                onPressed: () {},
+                child: const Icon(Icons.add),
+              ),
+            ],
+          );
+        }
+      }),
     );
   }
 }
@@ -455,6 +484,9 @@ class TextFields extends StatelessWidget {
                     ),
                   ),
                 ),
+                SizedBox(
+                  width: 10,
+                ),
                 Flexible(
                   child: SizedBox(
                     width: 180,
@@ -509,6 +541,7 @@ class TextFields extends StatelessWidget {
                         ),
                       ),
                     ),
+                    SizedBox(width: 10),
                     Flexible(
                       child: SizedBox(
                         width: 180,
@@ -1188,11 +1221,9 @@ class Chips extends StatelessWidget {
       tooltipMessage:
           'Use ActionChip, FilterChip, and InputChip to show chips. \nActionChip can also be used for suggestion chip',
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          Wrap(
-            alignment: WrapAlignment.spaceBetween,
-            runSpacing: 5,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
             children: <Widget>[
               ActionChip(
                   label: const Text('Assist'),
@@ -1209,34 +1240,27 @@ class Chips extends StatelessWidget {
             ],
           ),
           colDivider,
-          Wrap(
-            alignment: WrapAlignment.spaceBetween,
-            runSpacing: 5,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
             children: <Widget>[
               FilterChip(
                 label: const Text('Filter'),
                 onSelected: (isSelected) {},
               ),
               FilterChip(
-                label: const Text('OK'),
+                label: const Text('Selected'),
                 selected: true,
                 onSelected: (isSelected) {},
               ),
               const FilterChip(
                 label: Text('Disabled'),
-                selected: true,
                 onSelected: null,
               ),
-              const FilterChip(
-                label: Text('Disabled'),
-                onSelected: null,
-              )
             ],
           ),
           colDivider,
-          Wrap(
-            alignment: WrapAlignment.spaceBetween,
-            runSpacing: 5,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
             children: <Widget>[
               InputChip(
                 label: const Text('Input'),
@@ -1259,9 +1283,8 @@ class Chips extends StatelessWidget {
             ],
           ),
           colDivider,
-          Wrap(
-            alignment: WrapAlignment.spaceBetween,
-            runSpacing: 5,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
             children: <Widget>[
               ActionChip(
                 label: const Text('Suggestion'),
@@ -1880,6 +1903,7 @@ class _SlidersState extends State<Sliders> {
                 });
               },
             ),
+            const SizedBox(height: 20),
             Slider(
               max: 100,
               divisions: 5,
@@ -1939,7 +1963,7 @@ class ComponentDecoration extends StatelessWidget {
                   borderRadius: const BorderRadius.all(Radius.circular(12)),
                 ),
                 child: Padding(
-                  padding: const EdgeInsets.all(20.0),
+                  padding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 20.0),
                   child: child,
                 ),
               ),
@@ -1965,7 +1989,7 @@ class ComponentGroupDecoration extends StatelessWidget {
       elevation: 0,
       color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.3),
       child: Padding(
-        padding: const EdgeInsets.all(20.0),
+        padding: const EdgeInsets.symmetric(vertical: 20.0),
         child: Center(
           child: Column(
             children: [

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -470,7 +470,7 @@ class TextFields extends StatelessWidget {
               children: const [
                 Flexible(
                   child: SizedBox(
-                    width: 180,
+                    width: 200,
                     child: TextField(
                       decoration: InputDecoration(
                         prefixIcon: Icon(Icons.search),
@@ -489,7 +489,7 @@ class TextFields extends StatelessWidget {
                 ),
                 Flexible(
                   child: SizedBox(
-                    width: 180,
+                    width: 200,
                     child: TextField(
                       enabled: false,
                       decoration: InputDecoration(
@@ -526,7 +526,7 @@ class TextFields extends StatelessWidget {
                   children: const [
                     Flexible(
                       child: SizedBox(
-                        width: 180,
+                        width: 200,
                         child: TextField(
                           decoration: InputDecoration(
                             prefixIcon: Icon(Icons.search),
@@ -544,7 +544,7 @@ class TextFields extends StatelessWidget {
                     SizedBox(width: 10),
                     Flexible(
                       child: SizedBox(
-                        width: 180,
+                        width: 200,
                         child: TextField(
                           enabled: false,
                           decoration: InputDecoration(

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -1221,9 +1221,10 @@ class Chips extends StatelessWidget {
       tooltipMessage:
           'Use ActionChip, FilterChip, and InputChip to show chips. \nActionChip can also be used for suggestion chip',
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
+          Wrap(
+            alignment: WrapAlignment.spaceAround,
             children: <Widget>[
               ActionChip(
                   label: const Text('Assist'),
@@ -1240,8 +1241,8 @@ class Chips extends StatelessWidget {
             ],
           ),
           colDivider,
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
+          Wrap(
+            alignment: WrapAlignment.spaceAround,
             children: <Widget>[
               FilterChip(
                 label: const Text('Filter'),
@@ -1259,8 +1260,8 @@ class Chips extends StatelessWidget {
             ],
           ),
           colDivider,
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
+          Wrap(
+            alignment: WrapAlignment.spaceAround,
             children: <Widget>[
               InputChip(
                 label: const Text('Input'),
@@ -1283,8 +1284,8 @@ class Chips extends StatelessWidget {
             ],
           ),
           colDivider,
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
+          Wrap(
+            alignment: WrapAlignment.spaceAround,
             children: <Widget>[
               ActionChip(
                 label: const Text('Suggestion'),

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -289,26 +289,47 @@ class FloatingActionButtons extends StatelessWidget {
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: [
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.add),
+                  Expanded(
+                    child: Center(
+                      child: FloatingActionButton.small(
+                        onPressed: () {},
+                        child: const Icon(Icons.add),
+                      ),
+                    ),
                   ),
-                  FloatingActionButton(
-                    onPressed: () {},
-                    child: const Icon(Icons.add),
-                  ),
-                  FloatingActionButton.large(
-                    onPressed: () {},
-                    child: const Icon(Icons.add),
+                  Expanded(
+                    child: Center(
+                      child: FloatingActionButton.extended(
+                        onPressed: () {},
+                        icon: const Icon(Icons.add),
+                        label: const Text('Create'),
+                      ),
+                    ),
                   ),
                 ],
               ),
               colDivider,
-              FloatingActionButton.extended(
-                onPressed: () {},
-                icon: const Icon(Icons.add),
-                label: const Text('Create'),
-              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  Expanded(
+                    child: Center(
+                      child: FloatingActionButton(
+                        onPressed: () {},
+                        child: const Icon(Icons.add),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Center(
+                      child: FloatingActionButton.large(
+                        onPressed: () {},
+                        child: const Icon(Icons.add),
+                      ),
+                    ),
+                  ),
+                ],
+              )
             ],
           );
         } else {
@@ -484,9 +505,7 @@ class TextFields extends StatelessWidget {
                     ),
                   ),
                 ),
-                SizedBox(
-                  width: 10,
-                ),
+                SizedBox(width: 10),
                 Flexible(
                   child: SizedBox(
                     width: 200,
@@ -1964,7 +1983,8 @@ class ComponentDecoration extends StatelessWidget {
                   borderRadius: const BorderRadius.all(Radius.circular(12)),
                 ),
                 child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 20.0),
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 5.0, vertical: 20.0),
                   child: child,
                 ),
               ),

--- a/experimental/material_3_demo/test/component_screen_test.dart
+++ b/experimental/material_3_demo/test/component_screen_test.dart
@@ -40,7 +40,7 @@ void main() {
     // Chips
     expect(find.byType(ActionChip),
         findsNWidgets(7)); // includes Assist and Suggestion chip.
-    expect(find.byType(FilterChip), findsNWidgets(4));
+    expect(find.byType(FilterChip), findsNWidgets(3));
     expect(find.byType(InputChip), findsNWidgets(4));
 
     // Cards


### PR DESCRIPTION
This PR is to update the layout of the M3 demo app when it is running on a narrow screen (phone devices).

On iPhone 8 (screen width: 375):

https://user-images.githubusercontent.com/36861262/211948833-3dbed76e-9e8d-4a45-9ae1-e42c97137782.mov


On a 16-inch laptop:

<img width="1312" alt="Screenshot 2023-01-11 at 4 47 40 PM" src="https://user-images.githubusercontent.com/36861262/211949370-e894b5e6-3031-4bf2-9f77-6540a5eba576.png">

On a 32-inch monitor (future improvement: create a 3-column grid view so that more components can show up and the list can scroll together. And welcome for any other suggestions:) )

<img width="2560" alt="Screenshot 2023-01-11 at 4 49 22 PM" src="https://user-images.githubusercontent.com/36861262/211949549-233955b2-3d86-4ae0-b414-b610a85ceb7c.png">


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
