### PR TITLE
fix: provider_shopper login button invisible text

### DIFF
--- a/provider_shopper/lib/screens/login.dart
+++ b/provider_shopper/lib/screens/login.dart
@@ -40,7 +40,7 @@ class MyLogin extends StatelessWidget {
                   context.pushReplacement('/catalog');
                 },
                 style: ElevatedButton.styleFrom(
-                  foregroundColor: Colors.yellow,
+                  backgroundColor: Colors.yellow,
                 ),
                 child: const Text('ENTER'),
               )


### PR DESCRIPTION
Fixed text on provider_shopper login button being invisible.
Previous version had yellow text on a yellow button due to use of foregroundColor instead of backgroundColor.

fixed issue: #1559 