### PR TITLE
Fixup `varfont_shader_puzzle`

### DIFF
--- a/experimental/varfont_shader_puzzle/analysis_options.yaml
+++ b/experimental/varfont_shader_puzzle/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:flutter_lints/flutter.yaml
+include: ../../analysis_options.yaml

--- a/experimental/varfont_shader_puzzle/lib/components/components.dart
+++ b/experimental/varfont_shader_puzzle/lib/components/components.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'wonky_char.dart';
-export 'wonky_anim_palette.dart';
-export 'rotator_puzzle.dart';
-export 'lightboxed_panel.dart';
 export 'fragment_shaded.dart';
+export 'lightboxed_panel.dart';
+export 'rotator_puzzle.dart';
+export 'wonky_anim_palette.dart';
+export 'wonky_char.dart';

--- a/experimental/varfont_shader_puzzle/lib/components/fragment_shaded.dart
+++ b/experimental/varfont_shader_puzzle/lib/components/fragment_shaded.dart
@@ -62,7 +62,7 @@ class FragmentShadedState extends State<FragmentShaded>
     initializeFragmentProgramsAndBuilder();
   }
 
-  void initializeFragmentProgramsAndBuilder() async {
+  Future<void> initializeFragmentProgramsAndBuilder() async {
     if (FragmentShaded.fragmentPrograms.isEmpty) {
       for (String s in FragmentShaded.fragmentProgramNames) {
         FragmentShaded.fragmentPrograms[s] =

--- a/experimental/varfont_shader_puzzle/lib/components/lightboxed_panel.dart
+++ b/experimental/varfont_shader_puzzle/lib/components/lightboxed_panel.dart
@@ -18,7 +18,7 @@ class LightboxedPanel extends StatefulWidget {
   final Color cardBgColor;
 
   const LightboxedPanel({
-    Key? key,
+    super.key,
     required this.pageConfig,
     required this.content,
     this.onDismiss,
@@ -27,7 +27,7 @@ class LightboxedPanel extends StatefulWidget {
     this.buildButton = true,
     this.lightBoxBgColor = const Color.fromARGB(200, 255, 255, 255),
     this.cardBgColor = Colors.white,
-  }) : super(key: key);
+  });
 
   @override
   State<LightboxedPanel> createState() => _LightboxedPanelState();

--- a/experimental/varfont_shader_puzzle/lib/components/rotator_puzzle.dart
+++ b/experimental/varfont_shader_puzzle/lib/components/rotator_puzzle.dart
@@ -3,12 +3,14 @@
 // found in the LICENSE file.
 
 import 'dart:math';
-import 'package:flutter/rendering.dart';
-import 'components.dart';
-import 'package:flutter/material.dart';
 import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
 import '../model/puzzle_model.dart';
 import '../page_content/pages_flow.dart';
+import 'components.dart';
 
 class RotatorPuzzle extends StatefulWidget {
   final PageConfig pageConfig;
@@ -25,7 +27,7 @@ class RotatorPuzzle extends StatefulWidget {
   final double tileScaleModifier;
 
   const RotatorPuzzle({
-    Key? key,
+    super.key,
     required this.pageConfig,
     required this.numTiles,
     required this.puzzleNum,
@@ -37,7 +39,7 @@ class RotatorPuzzle extends StatefulWidget {
     required this.tileShadedStringAnimDuration,
     this.tileShadedStringAnimSettings = const [],
     this.tileScaleModifier = 1.0,
-  }) : super(key: key);
+  });
 
   @override
   State<RotatorPuzzle> createState() => RotatorPuzzleState();
@@ -258,7 +260,7 @@ class RotatorPuzzleTile extends StatefulWidget {
   final int col;
 
   RotatorPuzzleTile({
-    Key? key,
+    super.key,
     required this.tileID,
     required this.row,
     required this.col,
@@ -271,7 +273,7 @@ class RotatorPuzzleTile extends StatefulWidget {
     required this.animationSettings,
     required this.tileShadedStringAnimDuration,
     required this.tileScaleModifier,
-  }) : super(key: key);
+  });
 
   final State<RotatorPuzzleTile> tileState = RotatorPuzzleTileState();
 

--- a/experimental/varfont_shader_puzzle/lib/components/wonky_char.dart
+++ b/experimental/varfont_shader_puzzle/lib/components/wonky_char.dart
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'dart:ui';
+
 import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter/material.dart';
 
 class WonkyChar extends StatefulWidget {
   final String text;
@@ -13,13 +14,13 @@ class WonkyChar extends StatefulWidget {
   final int animDurationMillis;
   final List<WonkyAnimSetting> animationSettings;
   const WonkyChar({
-    Key? key,
+    super.key,
     required this.text,
     required this.size,
     this.baseRotation = 0,
     this.animDurationMillis = 1000,
     this.animationSettings = const <WonkyAnimSetting>[],
-  }) : super(key: key);
+  });
 
   @override
   State<WonkyChar> createState() => WonkyCharState();
@@ -79,20 +80,21 @@ class WonkyCharState extends State<WonkyChar>
   Widget build(BuildContext context) {
     List<FontVariation> fontVariations = [];
     for (int i = 0; i < _fvAxes.length; i++) {
-      fontVariations.add(FontVariation(_fvAxes[i], _fvAnimations[i].value));
+      fontVariations
+          .add(FontVariation(_fvAxes[i], _fvAnimations[i].value as double));
     }
     return Transform(
       alignment: Alignment.center,
-      transform: Matrix4.translationValues(
-          _offsetXAnimation.value, _offsetYAnimation.value, 0)
+      transform: Matrix4.translationValues(_offsetXAnimation.value as double,
+          _offsetYAnimation.value as double, 0)
         ..scale(_scaleAnimation.value)
-        ..rotateZ(widget.baseRotation + _rotationAnimation.value),
+        ..rotateZ(widget.baseRotation + (_rotationAnimation.value as double)),
       child: IgnorePointer(
         child: Text(
           widget.text,
           textAlign: TextAlign.center,
           style: TextStyle(
-            color: _colorAnimation.value,
+            color: _colorAnimation.value as Color?,
             fontFamily: 'Amstelvar',
             fontSize: widget.size,
             fontVariations: fontVariations,
@@ -114,13 +116,15 @@ class WonkyCharState extends State<WonkyChar>
       );
       late Animation animation;
       if (s.property == 'color') {
-        animation =
-            ColorTween(begin: s.fromTo.fromValue(), end: s.fromTo.toValue())
-                .animate(curve);
+        animation = ColorTween(
+                begin: s.fromTo.fromValue() as Color?,
+                end: s.fromTo.toValue() as Color?)
+            .animate(curve);
       } else {
-        animation =
-            Tween<double>(begin: s.fromTo.fromValue(), end: s.fromTo.toValue())
-                .animate(curve);
+        animation = Tween<double>(
+                begin: s.fromTo.fromValue() as double,
+                end: s.fromTo.toValue() as double)
+            .animate(curve);
       }
       if (s.type == 'fv') {
         _fvAxes.add(s.property);
@@ -168,13 +172,13 @@ class WonkyCharState extends State<WonkyChar>
   }
 }
 
-abstract class WCRange {
+abstract class WCRange<T> {
   WCRange();
-  fromValue() {}
-  toValue() {}
+  T fromValue();
+  T toValue();
 }
 
-class RangeColor implements WCRange {
+class RangeColor implements WCRange<Color> {
   Color from;
   Color to;
   RangeColor({required this.from, required this.to});
@@ -189,7 +193,7 @@ class RangeColor implements WCRange {
   }
 }
 
-class RangeDbl implements WCRange {
+class RangeDbl implements WCRange<double> {
   double from;
   double to;
 

--- a/experimental/varfont_shader_puzzle/lib/page_content/page_ascender_descender.dart
+++ b/experimental/varfont_shader_puzzle/lib/page_content/page_ascender_descender.dart
@@ -2,19 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
 import '../components/components.dart';
 import '../page_content/pages_flow.dart';
-import 'package:flutter/material.dart';
-import 'dart:math';
 import '../styles.dart';
 
 class PageAscenderDescender extends SinglePage {
   const PageAscenderDescender({
-    Key? key,
+    super.key,
     required super.pageConfig,
-  }) : super(
-          key: key,
-        );
+  });
   @override
   State<SinglePage> createState() => _PageAscenderDescenderState();
 }

--- a/experimental/varfont_shader_puzzle/lib/page_content/page_narrative_post.dart
+++ b/experimental/varfont_shader_puzzle/lib/page_content/page_narrative_post.dart
@@ -8,9 +8,9 @@ import '../styles.dart';
 
 class PageNarrativePost extends NarrativePage {
   const PageNarrativePost({
-    Key? key,
+    super.key,
     required super.pageConfig,
-  }) : super(key: key);
+  });
 
   @override
   State<NarrativePage> createState() => _PageNarrativePostState();

--- a/experimental/varfont_shader_puzzle/lib/page_content/page_narrative_pre.dart
+++ b/experimental/varfont_shader_puzzle/lib/page_content/page_narrative_pre.dart
@@ -8,9 +8,9 @@ import '../styles.dart';
 
 class PageNarrativePre extends NarrativePage {
   const PageNarrativePre({
-    Key? key,
+    super.key,
     required super.pageConfig,
-  }) : super(key: key);
+  });
 
   @override
   State<NarrativePage> createState() => _PageNarrativePreState();

--- a/experimental/varfont_shader_puzzle/lib/page_content/page_optical_size.dart
+++ b/experimental/varfont_shader_puzzle/lib/page_content/page_optical_size.dart
@@ -1,17 +1,19 @@
 // Copyright 2023 The Flutter team. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import '../components/components.dart';
-import 'package:flutter/material.dart';
-import '../page_content/pages_flow.dart';
 import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../components/components.dart';
+import '../page_content/pages_flow.dart';
 import '../styles.dart';
 
 class PageOpticalSize extends SinglePage {
   const PageOpticalSize({
-    Key? key,
+    super.key,
     required super.pageConfig,
-  }) : super(key: key);
+  });
 
   @override
   State<SinglePage> createState() => _PageOpticalSizeState();

--- a/experimental/varfont_shader_puzzle/lib/page_content/page_weight.dart
+++ b/experimental/varfont_shader_puzzle/lib/page_content/page_weight.dart
@@ -1,17 +1,19 @@
 // Copyright 2023 The Flutter team. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import '../components/components.dart';
-import 'package:flutter/material.dart';
 import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../components/components.dart';
 import '../page_content/pages_flow.dart';
 import '../styles.dart';
 
 class PageWeight extends SinglePage {
   const PageWeight({
-    Key? key,
+    super.key,
     required super.pageConfig,
-  }) : super(key: key);
+  });
 
   @override
   State<SinglePage> createState() => _PageWeightState();

--- a/experimental/varfont_shader_puzzle/lib/page_content/page_width.dart
+++ b/experimental/varfont_shader_puzzle/lib/page_content/page_width.dart
@@ -1,19 +1,19 @@
 // Copyright 2023 The Flutter team. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import '../components/components.dart';
-import 'package:flutter/material.dart';
 import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../components/components.dart';
 import '../page_content/pages_flow.dart';
 import '../styles.dart';
 
 class PageWidth extends SinglePage {
   const PageWidth({
-    Key? key,
+    super.key,
     required super.pageConfig,
-  }) : super(
-          key: key,
-        );
+  });
   @override
   State<SinglePage> createState() => _PageWidthState();
 }

--- a/experimental/varfont_shader_puzzle/lib/page_content/pages.dart
+++ b/experimental/varfont_shader_puzzle/lib/page_content/pages.dart
@@ -1,9 +1,9 @@
 // Copyright 2023 The Flutter team. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+export 'page_ascender_descender.dart';
+export 'page_narrative_post.dart';
+export 'page_narrative_pre.dart';
+export 'page_optical_size.dart';
 export 'page_weight.dart';
 export 'page_width.dart';
-export 'page_ascender_descender.dart';
-export 'page_optical_size.dart';
-export 'page_narrative_pre.dart';
-export 'page_narrative_post.dart';

--- a/experimental/varfont_shader_puzzle/lib/page_content/pages_flow.dart
+++ b/experimental/varfont_shader_puzzle/lib/page_content/pages_flow.dart
@@ -2,13 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 import 'dart:math';
+
 import 'package:flutter/material.dart';
-import '../page_content/wallpapers_flow.dart';
+
 import '../components/components.dart';
+import '../page_content/wallpapers_flow.dart';
 import 'pages.dart';
 
 class PagesFlow extends StatefulWidget {
-  const PagesFlow({Key? key}) : super(key: key);
+  const PagesFlow({super.key});
 
   static const pageScrollDuration = 400;
 
@@ -92,9 +94,9 @@ class PageConfig {
 class SinglePage extends StatefulWidget {
   final PageConfig pageConfig;
   const SinglePage({
-    Key? key,
+    super.key,
     required this.pageConfig,
-  }) : super(key: key);
+  });
 
   @override
   State<SinglePage> createState() => SinglePageState();
@@ -133,9 +135,9 @@ class SinglePageState extends State<SinglePage> with TickerProviderStateMixin {
 class NarrativePage extends StatefulWidget {
   final PageConfig pageConfig;
   const NarrativePage({
-    Key? key,
+    super.key,
     required this.pageConfig,
-  }) : super(key: key);
+  });
 
   @override
   State<NarrativePage> createState() => NarrativePageState();

--- a/experimental/varfont_shader_puzzle/lib/styles.dart
+++ b/experimental/varfont_shader_puzzle/lib/styles.dart
@@ -31,17 +31,17 @@ class ButtonStyles {
   static ButtonStyle style() {
     return ButtonStyle(
       fixedSize:
-          MaterialStateProperty.resolveWith<Size>((Set<MaterialState> states) {
+          MaterialStateProperty.resolveWith<Size>((states) {
         return const Size(100, 36);
       }),
       shape: MaterialStateProperty.resolveWith<OutlinedBorder>(
-          (Set<MaterialState> states) {
+          (states) {
         return const RoundedRectangleBorder(
             borderRadius: BorderRadius.all(Radius.circular(18)));
       }),
       overlayColor: null,
       backgroundColor: MaterialStateProperty.resolveWith<Color?>(
-          (Set<MaterialState> states) {
+          (states) {
         if (states.contains(MaterialState.hovered)) {
           return Colors.black; // Hovered bg (for desktop with mouse)
         }


### PR DESCRIPTION
Tidying up `varfont_shader_puzzle` to comply with the stricter lint rule set that the samples repo enforces.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md