### PR TITLE
Add a menu example to show menu system

### DIFF
--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -184,8 +184,8 @@ class _ButtonsState extends State<Buttons> {
           ButtonsWithIcon(),
           ButtonsWithoutIcon(isDisabled: true),
         ],
-        ),
-      );
+      ),
+    );
   }
 }
 

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -1516,10 +1516,7 @@ class BottomAppBars extends StatelessWidget {
               bottomNavigationBar: BottomAppBar(
                 child: Row(
                   children: <Widget>[
-                    IconButton(
-                      icon: const Icon(Icons.more_vert),
-                      onPressed: () {},
-                    ),
+                    const MenuExample(),
                     IconButton(
                       tooltip: 'Search',
                       icon: const Icon(Icons.search),
@@ -1537,6 +1534,60 @@ class BottomAppBars extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class MenuExample extends StatefulWidget {
+  const MenuExample({super.key});
+
+  @override
+  State<MenuExample> createState() => _MenuExampleState();
+}
+
+class _MenuExampleState extends State<MenuExample> {
+  @override
+  Widget build(BuildContext context) {
+    return MenuAnchor(
+      builder: (context, controller, child) {
+        return IconButton(
+          onPressed: () {
+            if (controller.isOpen) {
+              controller.close();
+            } else {
+              controller.open();
+            }
+          },
+          icon: const Icon(Icons.more_vert),
+        );
+      },
+      menuChildren: [
+        MenuItemButton(
+          child: const Text('Menu 1'),
+          onPressed: () {},
+        ),
+        MenuItemButton(
+          child: const Text('Menu 2'),
+          onPressed: () {},
+        ),
+        SubmenuButton(
+          menuChildren: <Widget>[
+            MenuItemButton(
+              onPressed: () {},
+              child: const Text('Menu 3.1'),
+            ),
+            MenuItemButton(
+              onPressed: () {},
+              child: const Text('Menu 3.2'),
+            ),
+            MenuItemButton(
+              onPressed: () {},
+              child: const Text('Menu 3.3'),
+            ),
+          ],
+          child: const Text('Menu 3'),
+        ),
+      ],
     );
   }
 }

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -177,13 +177,16 @@ class _ButtonsState extends State<Buttons> {
       label: 'Common buttons',
       tooltipMessage:
           'Use ElevatedButton, FilledButton, FilledButton.tonal, OutlinedButton, or TextButton',
-      child: Wrap(
-        alignment: WrapAlignment.spaceAround,
-        children: const <Widget>[
-          ButtonsWithoutIcon(isDisabled: false),
-          ButtonsWithIcon(),
-          ButtonsWithoutIcon(isDisabled: true),
-        ],
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: const <Widget>[
+            ButtonsWithoutIcon(isDisabled: false),
+            ButtonsWithIcon(),
+            ButtonsWithoutIcon(isDisabled: true),
+          ],
+        ),
       ),
     );
   }

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -177,21 +177,15 @@ class _ButtonsState extends State<Buttons> {
       label: 'Common buttons',
       tooltipMessage:
           'Use ElevatedButton, FilledButton, FilledButton.tonal, OutlinedButton, or TextButton',
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: tinySpacing),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: const <Widget>[
-            ButtonsWithoutIcon(isDisabled: false),
-            colDivider,
-            ButtonsWithIcon(),
-            colDivider,
-            ButtonsWithoutIcon(isDisabled: true),
-          ],
+      child: Wrap(
+        alignment: WrapAlignment.spaceAround,
+        children: const <Widget>[
+          ButtonsWithoutIcon(isDisabled: false),
+          ButtonsWithIcon(),
+          ButtonsWithoutIcon(isDisabled: true),
+        ],
         ),
-      ),
-    );
+      );
   }
 }
 
@@ -202,33 +196,39 @@ class ButtonsWithoutIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: <Widget>[
-        ElevatedButton(
-          onPressed: isDisabled ? null : () {},
-          child: const Text('Elevated'),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 5.0),
+      child: IntrinsicWidth(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            ElevatedButton(
+              onPressed: isDisabled ? null : () {},
+              child: const Text('Elevated'),
+            ),
+            colDivider,
+            FilledButton(
+              onPressed: isDisabled ? null : () {},
+              child: const Text('Filled'),
+            ),
+            colDivider,
+            FilledButton.tonal(
+              onPressed: isDisabled ? null : () {},
+              child: const Text('Filled tonal'),
+            ),
+            colDivider,
+            OutlinedButton(
+              onPressed: isDisabled ? null : () {},
+              child: const Text('Outlined'),
+            ),
+            colDivider,
+            TextButton(
+              onPressed: isDisabled ? null : () {},
+              child: const Text('Text'),
+            ),
+          ],
         ),
-        const SizedBox(width: tinySpacing),
-        FilledButton(
-          onPressed: isDisabled ? null : () {},
-          child: const Text('Filled'),
-        ),
-        const SizedBox(width: tinySpacing),
-        FilledButton.tonal(
-          onPressed: isDisabled ? null : () {},
-          child: const Text('Filled tonal'),
-        ),
-        const SizedBox(width: tinySpacing),
-        OutlinedButton(
-          onPressed: isDisabled ? null : () {},
-          child: const Text('Outlined'),
-        ),
-        const SizedBox(width: tinySpacing),
-        TextButton(
-          onPressed: isDisabled ? null : () {},
-          child: const Text('Text'),
-        ),
-      ],
+      ),
     );
   }
 }
@@ -238,38 +238,44 @@ class ButtonsWithIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: <Widget>[
-        ElevatedButton.icon(
-          onPressed: () {},
-          icon: const Icon(Icons.add),
-          label: const Text('Icon'),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10.0),
+      child: IntrinsicWidth(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            ElevatedButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('Icon'),
+            ),
+            colDivider,
+            FilledButton.icon(
+              onPressed: () {},
+              label: const Text('Icon'),
+              icon: const Icon(Icons.add),
+            ),
+            colDivider,
+            FilledButton.tonalIcon(
+              onPressed: () {},
+              label: const Text('Icon'),
+              icon: const Icon(Icons.add),
+            ),
+            colDivider,
+            OutlinedButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('Icon'),
+            ),
+            colDivider,
+            TextButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('Icon'),
+            )
+          ],
         ),
-        const SizedBox(width: tinySpacing),
-        FilledButton.icon(
-          onPressed: () {},
-          label: const Text('Icon'),
-          icon: const Icon(Icons.add),
-        ),
-        const SizedBox(width: tinySpacing),
-        FilledButton.tonalIcon(
-          onPressed: () {},
-          label: const Text('Icon'),
-          icon: const Icon(Icons.add),
-        ),
-        const SizedBox(width: tinySpacing),
-        OutlinedButton.icon(
-          onPressed: () {},
-          icon: const Icon(Icons.add),
-          label: const Text('Icon'),
-        ),
-        const SizedBox(width: tinySpacing),
-        TextButton.icon(
-          onPressed: () {},
-          icon: const Icon(Icons.add),
-          label: const Text('Icon'),
-        )
-      ],
+      ),
     );
   }
 }

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -1525,7 +1525,7 @@ class BottomAppBars extends StatelessWidget {
               bottomNavigationBar: BottomAppBar(
                 child: Row(
                   children: <Widget>[
-                    const MenuExample(),
+                    const IconButtonAnchorExample(),
                     IconButton(
                       tooltip: 'Search',
                       icon: const Icon(Icons.search),
@@ -1547,14 +1547,9 @@ class BottomAppBars extends StatelessWidget {
   }
 }
 
-class MenuExample extends StatefulWidget {
-  const MenuExample({super.key});
+class IconButtonAnchorExample extends StatelessWidget {
+  const IconButtonAnchorExample({super.key});
 
-  @override
-  State<MenuExample> createState() => _MenuExampleState();
-}
-
-class _MenuExampleState extends State<MenuExample> {
   @override
   Widget build(BuildContext context) {
     return MenuAnchor(
@@ -1595,6 +1590,45 @@ class _MenuExampleState extends State<MenuExample> {
             ),
           ],
           child: const Text('Menu 3'),
+        ),
+      ],
+    );
+  }
+}
+
+class ButtonAnchorExample extends StatelessWidget {
+  const ButtonAnchorExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MenuAnchor(
+      builder: (context, controller, child) {
+        return FilledButton.tonal(
+          onPressed: () {
+            if (controller.isOpen) {
+              controller.close();
+            } else {
+              controller.open();
+            }
+          },
+          child: const Text('Show menu'),
+        );
+      },
+      menuChildren: [
+        MenuItemButton(
+          leadingIcon: const Icon(Icons.people_alt_outlined),
+          child: const Text('Item 1'),
+          onPressed: () {},
+        ),
+        MenuItemButton(
+          leadingIcon: const Icon(Icons.remove_red_eye_outlined),
+          child: const Text('Item 2'),
+          onPressed: () {},
+        ),
+        MenuItemButton(
+          leadingIcon: const Icon(Icons.refresh),
+          onPressed: () {},
+          child: const Text('Item 3'),
         ),
       ],
     );
@@ -1787,43 +1821,59 @@ class _DropdownMenusState extends State<DropdownMenus> {
     }
 
     return ComponentDecoration(
-      label: 'Dropdown menus',
-      tooltipMessage: 'Use DropdownMenu<T>',
-      child: Wrap(
-        alignment: WrapAlignment.spaceAround,
-        runAlignment: WrapAlignment.start,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        spacing: smallSpacing,
-        runSpacing: smallSpacing,
+      label: 'Menus',
+      tooltipMessage: 'Use DropdownMenu<T> or MenuAnchor',
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          DropdownMenu<ColorLabel>(
-            controller: colorController,
-            label: const Text('Color'),
-            enableFilter: true,
-            dropdownMenuEntries: colorEntries,
-            inputDecorationTheme: const InputDecorationTheme(filled: true),
-            onSelected: (color) {
-              setState(() {
-                selectedColor = color;
-              });
-            },
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: const <Widget>[
+              ButtonAnchorExample(),
+              rowDivider,
+              IconButtonAnchorExample(),
+            ],
           ),
-          DropdownMenu<IconLabel>(
-            initialSelection: IconLabel.smile,
-            controller: iconController,
-            leadingIcon: const Icon(Icons.search),
-            label: const Text('Icon'),
-            dropdownMenuEntries: iconEntries,
-            onSelected: (icon) {
-              setState(() {
-                selectedIcon = icon;
-              });
-            },
+          colDivider,
+          Wrap(
+            alignment: WrapAlignment.spaceAround,
+            runAlignment: WrapAlignment.start,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: smallSpacing,
+            runSpacing: smallSpacing,
+            children: [
+              DropdownMenu<ColorLabel>(
+                controller: colorController,
+                label: const Text('Color'),
+                enableFilter: true,
+                dropdownMenuEntries: colorEntries,
+                inputDecorationTheme: const InputDecorationTheme(filled: true),
+                onSelected: (color) {
+                  setState(() {
+                    selectedColor = color;
+                  });
+                },
+              ),
+              DropdownMenu<IconLabel>(
+                initialSelection: IconLabel.smile,
+                controller: iconController,
+                leadingIcon: const Icon(Icons.search),
+                label: const Text('Icon'),
+                dropdownMenuEntries: iconEntries,
+                onSelected: (icon) {
+                  setState(() {
+                    selectedIcon = icon;
+                  });
+                },
+              ),
+              Icon(
+                selectedIcon?.icon,
+                color: selectedColor?.color ?? Colors.grey.withOpacity(0.5),
+              )
+            ],
           ),
-          Icon(
-            selectedIcon?.icon,
-            color: selectedColor?.color ?? Colors.grey.withOpacity(0.5),
-          )
         ],
       ),
     );


### PR DESCRIPTION
This PR is to add a menu example when the "more" button on the bottom app bar is clicked. 
This PR also changes the layout of the common buttons to three columns.

<img width="512" alt="Screenshot 2023-01-18 at 3 01 35 PM" src="https://user-images.githubusercontent.com/36861262/213314109-a25fba7e-3964-4efe-8ede-40b54ada92d9.png">


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
