### PR TITLE
`experimental/web_dashboard` fix for deprecated annotations

### DIFF
--- a/experimental/web_dashboard/lib/src/api/api.dart
+++ b/experimental/web_dashboard/lib/src/api/api.dart
@@ -48,7 +48,7 @@ abstract class EntryApi {
 class Category {
   String name;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false)
   String? id;
 
   Category(this.name);
@@ -75,7 +75,7 @@ class Entry {
   @JsonKey(fromJson: _timestampToDateTime, toJson: _dateTimeToTimestamp)
   DateTime time;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false)
   String? id;
 
   Entry(this.value, this.time);


### PR DESCRIPTION
This is a break fix.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md