### PR TITLE
Enable Material 3 on add_to_app/flutter_module_using_plugin

### DIFF
--- a/add_to_app/android_view/flutter_module_using_plugin/lib/main.dart
+++ b/add_to_app/android_view/flutter_module_using_plugin/lib/main.dart
@@ -76,7 +76,10 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Module Title',
-      theme: ThemeData(useMaterial3: true),
+      theme: ThemeData(
+        colorSchemeSeed: Colors.blue,
+        useMaterial3: true,
+      ),
       routes: {
         '/': (context) => const FullScreenView(),
         '/mini': (context) => const Contents(),

--- a/add_to_app/android_view/flutter_module_using_plugin/lib/main.dart
+++ b/add_to_app/android_view/flutter_module_using_plugin/lib/main.dart
@@ -76,6 +76,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Module Title',
+      theme: ThemeData(useMaterial3: true),
       routes: {
         '/': (context) => const FullScreenView(),
         '/mini': (context) => const Contents(),
@@ -155,13 +156,13 @@ class Contents extends StatelessWidget {
                 const SizedBox(height: 16),
                 Consumer<CounterModel>(
                   builder: (context, model, child) {
-                    return ElevatedButton(
+                    return FilledButton(
                       onPressed: () => model.increment(),
                       child: const Text('Tap me!'),
                     );
                   },
                 ),
-                ElevatedButton(
+                FilledButton(
                   onPressed: () async {
                     // Use the url_launcher plugin to open the Flutter docs in
                     // a browser.
@@ -174,7 +175,7 @@ class Contents extends StatelessWidget {
                 ),
                 if (showExit) ...[
                   const SizedBox(height: 16),
-                  ElevatedButton(
+                  FilledButton(
                     onPressed: () => SystemNavigator.pop(),
                     child: const Text('Exit this screen'),
                   ),


### PR DESCRIPTION
- Enabled Material 3 on add_to_app/flutter_module_using_plugin.
- Changed `ElevatedButton` by `FilledButton`

#### Before Material 3

![telegram-cloud-photo-size-2-5373116143448999062-y](https://user-images.githubusercontent.com/2494376/214590228-72d8c364-a69d-44d7-b431-bcbb707d2864.jpg)

#### With Material 3

![telegram-cloud-photo-size-2-5373116143448999061-y](https://user-images.githubusercontent.com/2494376/214590313-f0f81567-83e1-4a0a-84de-f527504331e8.jpg)



## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
