### PR TITLE
enable Material 3 on android_splash_screen sample

### DIFF
--- a/android_splash_screen/lib/main.dart
+++ b/android_splash_screen/lib/main.dart
@@ -30,6 +30,7 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
+        useMaterial3: true,
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );


### PR DESCRIPTION
Enable Material 3 on android_splash_screen sample

#### Without Material 3

![telegram-cloud-photo-size-2-5377304711520175486-y](https://user-images.githubusercontent.com/2494376/215068358-3dad7ade-1e18-4dc1-a181-e0bcb43e8860.jpg)

#### With Material 3

![telegram-cloud-photo-size-2-5377304711520175485-y](https://user-images.githubusercontent.com/2494376/215068038-9e21711c-0f5d-4370-bcb3-78a32e09b43a.jpg)


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
