### PR TITLE
Enable Material 3 on code_sharing sample

### DIFF
--- a/code_sharing/client/lib/main.dart
+++ b/code_sharing/client/lib/main.dart
@@ -33,7 +33,8 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorSchemeSeed: Colors.blue,
+        useMaterial3: true,
       ),
       home: MyHomePage(
         title: 'Flutter Demo Home Page',


### PR DESCRIPTION
Enable Material 3 on code_sharing sample. The UI is a simple counter app.

<img width="868" alt="Screenshot 2023-01-27 at 13 44 18" src="https://user-images.githubusercontent.com/2494376/215091261-0873f9ea-862b-4bbd-a161-446af9bf6eec.png">

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md