### PR TITLE
enable material 3 on desktop_photo_search sample

### DIFF
--- a/desktop_photo_search/material/lib/main.dart
+++ b/desktop_photo_search/material/lib/main.dart
@@ -63,7 +63,8 @@ class UnsplashSearchApp extends StatelessWidget {
     return MaterialApp(
       title: 'Photo Search',
       theme: ThemeData(
-        primarySwatch: Colors.orange,
+        colorSchemeSeed: Colors.orange,
+        useMaterial3: true,
       ),
       home: const UnsplashHomePage(title: 'Photo Search'),
     );


### PR DESCRIPTION
Enabled Material 3 on the desktop_photo_search sample. There's another sample that uses FluentUI, which remains the same.

#### Before Material 3

<img width="912" alt="Screenshot 2023-01-27 at 13 55 43" src="https://user-images.githubusercontent.com/2494376/215092764-6acb1579-114b-4b6c-93cf-0e832bc0930b.png">

<img width="912" alt="Screenshot 2023-01-27 at 13 55 55" src="https://user-images.githubusercontent.com/2494376/215092766-69879113-d775-4f22-aa92-1311390746f0.png">

<img width="912" alt="Screenshot 2023-01-27 at 13 55 02" src="https://user-images.githubusercontent.com/2494376/215092761-0eb18911-3da6-4e6f-bd16-6c7a419134ae.png">

#### With Material 3

<img width="912" alt="Screenshot 2023-01-27 at 13 56 20" src="https://user-images.githubusercontent.com/2494376/215092802-934b3f64-91a8-4ec1-aa38-a048fd3b8856.png">

<img width="912" alt="Screenshot 2023-01-27 at 13 56 36" src="https://user-images.githubusercontent.com/2494376/215092804-3be1737a-5a5d-4074-9cd4-1a012e108fd8.png">

<img width="912" alt="Screenshot 2023-01-27 at 13 56 40" src="https://user-images.githubusercontent.com/2494376/215092807-d86a6ea7-e070-456c-b9fe-5768c91547cd.png">

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md