### PR TITLE
enable material 3 on flutter_maps_firestore

### DIFF
--- a/flutter_maps_firestore/lib/main.dart
+++ b/flutter_maps_firestore/lib/main.dart
@@ -34,8 +34,9 @@ class App extends StatelessWidget {
       title: 'Ice Creams FTW',
       home: const HomePage(title: 'Ice Cream Stores in SF'),
       theme: ThemeData(
-        primarySwatch: Colors.pink,
+        colorSchemeSeed: Colors.pink,
         scaffoldBackgroundColor: Colors.pink[50],
+        useMaterial3: true,
       ),
     );
   }


### PR DESCRIPTION
Enabling Material 3 on flutter_maps_firestore sample.

A bit complicated to have this sample up and running, somehow I was unable to get images from the maps API, I may report this one to the maps plugin repo.

I'm not super-convinced about the color scheme, but that's just how Material 3 is.

#### Before Material 3

![Simulator Screen Shot - iPhone 14 - 2023-01-27 at 16 03 26](https://user-images.githubusercontent.com/2494376/215124494-4da12036-8da9-40b1-bc1a-def17026a8aa.png)

#### With Material 3

![Simulator Screen Shot - iPhone 14 - 2023-01-27 at 16 25 04](https://user-images.githubusercontent.com/2494376/215124528-8a2679b7-adac-43ef-a64a-93ffed676809.png)

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md