### PR TITLE
Migrate form_app to Material 3

### DIFF
--- a/form_app/lib/main.dart
+++ b/form_app/lib/main.dart
@@ -88,7 +88,10 @@ class FormApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'Form Samples',
-      theme: ThemeData(primarySwatch: Colors.teal),
+      theme: ThemeData(
+        colorSchemeSeed: Colors.teal,
+        useMaterial3: true,
+      ),
       routerConfig: router,
     );
   }

--- a/form_app/lib/src/validation.dart
+++ b/form_app/lib/src/validation.dart
@@ -27,7 +27,6 @@ class _FormValidationDemoState extends State<FormValidationDemo> {
           Padding(
             padding: const EdgeInsets.all(8),
             child: TextButton(
-              style: TextButton.styleFrom(foregroundColor: Colors.white),
               child: const Text('Submit'),
               onPressed: () {
                 // Validate the form by getting the FormState from the GlobalKey


### PR DESCRIPTION
Migrated form_app to Material 3

#### Before Material 3

<img width="592" alt="Screenshot 2023-01-31 at 14 47 35" src="https://user-images.githubusercontent.com/2494376/215778880-438ccb8e-251f-4750-97d5-b6c95e9d72f8.png">

#### With Material 3

<img width="592" alt="Screenshot 2023-01-31 at 14 50 15" src="https://user-images.githubusercontent.com/2494376/215778939-5d55df27-018a-45d5-9c81-1be922ae314a.png">

<img width="592" alt="Screenshot 2023-01-31 at 14 48 26" src="https://user-images.githubusercontent.com/2494376/215778933-99068e6f-4ffa-487e-9d0f-f4c5eb5aa3d9.png">

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md