### PR TITLE
Migrate game_template to Material 3

### DIFF
--- a/game_template/lib/main.dart
+++ b/game_template/lib/main.dart
@@ -255,6 +255,7 @@ class MyApp extends StatelessWidget {
                   color: palette.ink,
                 ),
               ),
+              useMaterial3: true,
             ),
             routeInformationProvider: _router.routeInformationProvider,
             routeInformationParser: _router.routeInformationParser,

--- a/game_template/lib/src/level_selection/level_selection_screen.dart
+++ b/game_template/lib/src/level_selection/level_selection_screen.dart
@@ -59,7 +59,7 @@ class LevelSelectionScreen extends StatelessWidget {
             ),
           ],
         ),
-        rectangularMenuArea: ElevatedButton(
+        rectangularMenuArea: FilledButton(
           onPressed: () {
             GoRouter.of(context).go('/');
           },

--- a/game_template/lib/src/main_menu/main_menu_screen.dart
+++ b/game_template/lib/src/main_menu/main_menu_screen.dart
@@ -44,7 +44,7 @@ class MainMenuScreen extends StatelessWidget {
         rectangularMenuArea: Column(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            ElevatedButton(
+            FilledButton(
               onPressed: () {
                 audioController.playSfx(SfxType.buttonTap);
                 GoRouter.of(context).go('/play');
@@ -55,7 +55,7 @@ class MainMenuScreen extends StatelessWidget {
             if (gamesServicesController != null) ...[
               _hideUntilReady(
                 ready: gamesServicesController.signedIn,
-                child: ElevatedButton(
+                child: FilledButton(
                   onPressed: () => gamesServicesController.showAchievements(),
                   child: const Text('Achievements'),
                 ),
@@ -63,14 +63,14 @@ class MainMenuScreen extends StatelessWidget {
               _gap,
               _hideUntilReady(
                 ready: gamesServicesController.signedIn,
-                child: ElevatedButton(
+                child: FilledButton(
                   onPressed: () => gamesServicesController.showLeaderboard(),
                   child: const Text('Leaderboard'),
                 ),
               ),
               _gap,
             ],
-            ElevatedButton(
+            FilledButton(
               onPressed: () => GoRouter.of(context).push('/settings'),
               child: const Text('Settings'),
             ),

--- a/game_template/lib/src/play_session/play_session_screen.dart
+++ b/game_template/lib/src/play_session/play_session_screen.dart
@@ -93,7 +93,7 @@ class _PlaySessionScreenState extends State<PlaySessionScreen> {
                       padding: const EdgeInsets.all(8.0),
                       child: SizedBox(
                         width: double.infinity,
-                        child: ElevatedButton(
+                        child: FilledButton(
                           onPressed: () => GoRouter.of(context).go('/play'),
                           child: const Text('Back'),
                         ),

--- a/game_template/lib/src/settings/settings_screen.dart
+++ b/game_template/lib/src/settings/settings_screen.dart
@@ -101,7 +101,7 @@ class SettingsScreen extends StatelessWidget {
             _gap,
           ],
         ),
-        rectangularMenuArea: ElevatedButton(
+        rectangularMenuArea: FilledButton(
           onPressed: () {
             GoRouter.of(context).pop();
           },

--- a/game_template/lib/src/settings/settings_screen.dart
+++ b/game_template/lib/src/settings/settings_screen.dart
@@ -169,14 +169,19 @@ class _SettingsLine extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            Text(title,
+            Expanded(
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
                 style: const TextStyle(
                   fontFamily: 'Permanent Marker',
                   fontSize: 30,
-                )),
-            const Spacer(),
+                ),
+              ),
+            ),
             icon,
           ],
         ),

--- a/game_template/lib/src/win_game/win_game_screen.dart
+++ b/game_template/lib/src/win_game/win_game_screen.dart
@@ -61,7 +61,7 @@ class WinGameScreen extends StatelessWidget {
             ),
           ],
         ),
-        rectangularMenuArea: ElevatedButton(
+        rectangularMenuArea: FilledButton(
           onPressed: () {
             GoRouter.of(context).go('/play');
           },


### PR DESCRIPTION
Migrated game_template to Material 3

Basically, the only thing that changes is the `ElevatedButton` that has been replaced by a `FilledButton`.

#### Before Material 3

<img width="912" alt="Screenshot 2023-01-31 at 14 56 28" src="https://user-images.githubusercontent.com/2494376/215785097-ced60ecf-a21a-4aa8-a005-0b03a8c3d6bb.png">

<img width="912" alt="Screenshot 2023-01-31 at 14 56 32" src="https://user-images.githubusercontent.com/2494376/215785113-6e05869a-40a1-4e36-b61b-e0ddb4b3e582.png">
<img width="912" alt="Screenshot 2023-01-31 at 14 56 41" src="https://user-images.githubusercontent.com/2494376/215785121-47ec73fb-226f-4950-a418-42f5bf89b1d9.png">
<img width="912" alt="Screenshot 2023-01-31 at 14 56 55" src="https://user-images.githubusercontent.com/2494376/215785128-a9083679-d442-4d75-8e2a-f8a84586515c.png">

#### With Material 3

<img width="912" alt="Screenshot 2023-01-31 at 15 15 59" src="https://user-images.githubusercontent.com/2494376/215785193-f8430763-29d7-4471-9f25-aeaa3e7a9d56.png">
<img width="912" alt="Screenshot 2023-01-31 at 15 15 47" src="https://user-images.githubusercontent.com/2494376/215785199-c07653d4-cc24-4f16-beda-13f01abd1b00.png">
<img width="912" alt="Screenshot 2023-01-31 at 15 15 43" src="https://user-images.githubusercontent.com/2494376/215785202-38873acb-b3e0-464f-b4fd-d98fca63de6d.png">

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md