### PR TITLE
migrate infinite_list to Material 3

### DIFF
--- a/infinite_list/lib/main.dart
+++ b/infinite_list/lib/main.dart
@@ -43,9 +43,10 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<Catalog>(
       create: (context) => Catalog(),
-      child: const MaterialApp(
+      child: MaterialApp(
         title: 'Infinite List Sample',
-        home: MyHomePage(),
+        theme: ThemeData.light(useMaterial3: true),
+        home: const MyHomePage(),
       ),
     );
   }


### PR DESCRIPTION
Migrated infinite_list to Material 3

#### Before Material 3
<img width="592" alt="Screenshot 2023-01-31 at 15 31 50" src="https://user-images.githubusercontent.com/2494376/215789449-3a29726e-37c4-4c98-bc0d-bc626f565a60.png">

#### With Material 3

<img width="592" alt="Screenshot 2023-01-31 at 15 33 07" src="https://user-images.githubusercontent.com/2494376/215789536-365185c7-c96a-4b59-902d-d227025fefbf.png">
<img width="592" alt="Screenshot 2023-01-31 at 15 33 13" src="https://user-images.githubusercontent.com/2494376/215789548-6dde2990-78f8-4dc6-bd1d-748c2c176cb7.png">

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md