### PR TITLE
Elide `simplistic_editor` from `master` channel

### DIFF
--- a/tool/flutter_ci_script_master.sh
+++ b/tool/flutter_ci_script_master.sh
@@ -50,7 +50,8 @@ declare -ar PROJECT_NAMES=(
     "provider_counter"
     "provider_shopper"
     "simplistic_calculator"
-    "simplistic_editor"
+    # TODO(DomesticMouse): https://github.com/flutter/samples/issues/1616
+    # "simplistic_editor"
     "testing_app"
     "veggieseasons"
     "web/_tool"


### PR DESCRIPTION
This is a break fix. 

Context: https://github.com/flutter/samples/issues/1616

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md