### PR TITLE
Mixin `TextInputClient` to include `insertContent` implementation

### DIFF
--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -40,8 +40,7 @@ class BasicTextInputClient extends StatefulWidget {
 }
 
 class BasicTextInputClientState extends State<BasicTextInputClient>
-    with TextSelectionDelegate, TextInputClient
-    implements DeltaTextInputClient {
+    with TextSelectionDelegate, TextInputClient, DeltaTextInputClient {
   final GlobalKey _textKey = GlobalKey();
   late AppStateWidgetState manager;
   final ClipboardStatusNotifier? _clipboardStatus =

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -40,7 +40,7 @@ class BasicTextInputClient extends StatefulWidget {
 }
 
 class BasicTextInputClientState extends State<BasicTextInputClient>
-    with TextSelectionDelegate
+    with TextSelectionDelegate, TextInputClient
     implements DeltaTextInputClient {
   final GlobalKey _textKey = GlobalKey();
   late AppStateWidgetState manager;

--- a/tool/flutter_ci_script_master.sh
+++ b/tool/flutter_ci_script_master.sh
@@ -50,8 +50,7 @@ declare -ar PROJECT_NAMES=(
     "provider_counter"
     "provider_shopper"
     "simplistic_calculator"
-    # TODO(DomesticMouse): https://github.com/flutter/samples/issues/1616
-    # "simplistic_editor"
+    "simplistic_editor"
     "testing_app"
     "veggieseasons"
     "web/_tool"


### PR DESCRIPTION
The new `insertContent` method is for rich content such as images from Android, so it doesn't seem like something a "simplistic" editor needs to handle for now. Including `TextInputClient` as a mixin allows us to incorporate its empty implementation of `insertContent`. This has the benefit of the sample working on both `stable` and `master`.

Fixes https://github.com/flutter/samples/issues/1616