### PR TITLE
Migrate isolate_example to Material 3

### DIFF
--- a/isolate_example/lib/data_transfer_page.dart
+++ b/isolate_example/lib/data_transfer_page.dart
@@ -62,7 +62,7 @@ class DataTransferPage extends StatelessWidget {
                 style: ElevatedButton.styleFrom(
                     foregroundColor: (controller.runningTest == 1)
                         ? Colors.blueAccent
-                        : Colors.grey[300]),
+                        : Colors.blueGrey),
                 onPressed: () => controller.generateRandomNumbers(false),
                 child: const Text('Transfer Data to 2nd Isolate'),
               ),
@@ -70,7 +70,7 @@ class DataTransferPage extends StatelessWidget {
                 style: ElevatedButton.styleFrom(
                     foregroundColor: (controller.runningTest == 2)
                         ? Colors.blueAccent
-                        : Colors.grey[300]),
+                        : Colors.blueGrey),
                 onPressed: () => controller.generateRandomNumbers(true),
                 child: const Text('Transfer Data with TransferableTypedData'),
               ),
@@ -78,7 +78,7 @@ class DataTransferPage extends StatelessWidget {
                 style: ElevatedButton.styleFrom(
                     foregroundColor: (controller.runningTest == 3)
                         ? Colors.blueAccent
-                        : Colors.grey[300]),
+                        : Colors.blueGrey),
                 onPressed: controller.generateOnSecondaryIsolate,
                 child: const Text('Generate on 2nd Isolate'),
               ),

--- a/isolate_example/lib/main.dart
+++ b/isolate_example/lib/main.dart
@@ -48,6 +48,7 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: ThemeData.light(useMaterial3: true),
       home: DefaultTabController(
         length: 3,
         child: Scaffold(


### PR DESCRIPTION
Migrated isolate_example to Material 3.

In one case the button text color was changed to offer a bit more contrast, otherwise the rest of the app remains the same.

#### Before Material 3

<img width="912" alt="Screenshot 2023-02-01 at 12 45 57" src="https://user-images.githubusercontent.com/2494376/216038737-e3c44b43-b10f-422d-a2ed-3633b1aafb42.png">


<img width="912" alt="Screenshot 2023-02-01 at 12 46 03" src="https://user-images.githubusercontent.com/2494376/216038743-47001e8e-47ac-4a8c-aa21-aab8c175a8e9.png">

<img width="912" alt="Screenshot 2023-02-01 at 12 46 08" src="https://user-images.githubusercontent.com/2494376/216038747-8804e86d-ad45-4ea1-be64-1ae73decba23.png">
 
##### With Material 3

<img width="912" alt="Screenshot 2023-02-01 at 12 51 50" src="https://user-images.githubusercontent.com/2494376/216038805-41d9b9e0-42d4-423b-b96b-aace50679fd3.png">
<img width="912" alt="Screenshot 2023-02-01 at 12 51 55" src="https://user-images.githubusercontent.com/2494376/216038807-85f80a89-0620-4252-b735-4f7b7d3ebcf6.png">
<img width="912" alt="Screenshot 2023-02-01 at 12 53 10" src="https://user-images.githubusercontent.com/2494376/216038809-35786c6e-5ee6-4651-a081-9a2089d71500.png">


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md