### PR TITLE
enable Material 3 on jsonexample

### DIFF
--- a/jsonexample/lib/main.dart
+++ b/jsonexample/lib/main.dart
@@ -33,7 +33,8 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorSchemeSeed: Colors.blue,
+        useMaterial3: true,
       ),
       home: const MyHomePage(),
     );


### PR DESCRIPTION
Enabled Material 3 on the jsonexample project.

#### Before Material 3

<img width="912" alt="Screenshot 2023-02-01 at 15 17 38" src="https://user-images.githubusercontent.com/2494376/216069134-f59f6520-cd82-4773-8f77-ccf2ccc7977c.png">

#### With Material 3

<img width="912" alt="Screenshot 2023-02-01 at 15 18 29" src="https://user-images.githubusercontent.com/2494376/216069143-bc060cd4-50c2-48d2-b10b-4e3b33b39ad2.png">

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md