### PR TITLE
Migrate `platform_view_swift` to Material 3

### DIFF
--- a/platform_view_swift/lib/main.dart
+++ b/platform_view_swift/lib/main.dart
@@ -20,6 +20,7 @@ class PlatformView extends StatelessWidget {
       title: 'Platform View',
       theme: ThemeData(
         primarySwatch: Colors.grey,
+        useMaterial3: true,
       ),
       home: const HomePage(),
     );


### PR DESCRIPTION
Migrated platform_view_swift to Material 3

#### Before Material 3

<details><summary>Screenshots</summary>

![Simulator Screen Shot - iPhone 14 - 2023-02-05 at 14 06 19](https://user-images.githubusercontent.com/2494376/216820725-4cb6f5ac-dfcf-4979-b83d-a1a320cd4a16.png)

</details>

#### With Material 3

<details><summary>Screenshots</summary>

![Simulator Screen Shot - iPhone 14 - 2023-02-05 at 14 07 07](https://user-images.githubusercontent.com/2494376/216820733-13545a7f-12ff-4fd5-8778-dbe56fb60eaf.png)

</details>

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md