### PR TITLE
Enable Material 3 on `provider_counter`

### DIFF
--- a/provider_counter/lib/main.dart
+++ b/provider_counter/lib/main.dart
@@ -69,6 +69,7 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
+        useMaterial3: true,
       ),
       home: const MyHomePage(),
     );


### PR DESCRIPTION
Enable Material 3 on the provider_counter sample.

UI is the counter app.

![Screenshot from 2023-02-05 14-11-34](https://user-images.githubusercontent.com/2494376/216821251-ceee3c21-a8a8-4815-8e5f-53e5790f24c2.png)


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md