### PR TITLE
Enable Material 3 on `provider_shopper`

### DIFF
--- a/provider_shopper/lib/common/theme.dart
+++ b/provider_shopper/lib/common/theme.dart
@@ -5,7 +5,8 @@
 import 'package:flutter/material.dart';
 
 final appTheme = ThemeData(
-  primarySwatch: Colors.yellow,
+  colorSchemeSeed: Colors.yellow,
+  useMaterial3: true,
   textTheme: const TextTheme(
     displayLarge: TextStyle(
       fontFamily: 'Corben',

--- a/provider_shopper/lib/screens/cart.dart
+++ b/provider_shopper/lib/screens/cart.dart
@@ -85,7 +85,7 @@ class _CartTotal extends StatelessWidget {
                 builder: (context, cart, child) =>
                     Text('\$${cart.totalPrice}', style: hugeStyle)),
             const SizedBox(width: 24),
-            TextButton(
+            FilledButton(
               onPressed: () {
                 ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('Buying not supported yet.')));


### PR DESCRIPTION
Enabled Material 3 on provider_shopper.

Small change with the checkout 'BUY' button to FilledButton for major contrast.

#### Before Material 3

<details><summary>Screenshots</summary>

![Screenshot from 2023-02-05 14-34-32](https://user-images.githubusercontent.com/2494376/216822660-51f4479f-c5f5-4516-9d67-fb243a22dcf1.png)
![Screenshot from 2023-02-05 14-34-39](https://user-images.githubusercontent.com/2494376/216822663-aa7a3c48-abc2-4629-9a7f-e0cddc3373c7.png)
![Screenshot from 2023-02-05 14-34-49](https://user-images.githubusercontent.com/2494376/216822665-dac46b68-7981-450e-ad64-89e8e215adda.png)

</details>


#### With Material 3

<details><summary>Screenshots</summary>

![Screenshot from 2023-02-05 14-35-27](https://user-images.githubusercontent.com/2494376/216822677-4c33470f-16e0-4148-af4e-f8acd0b283a6.png)
![Screenshot from 2023-02-05 14-35-39](https://user-images.githubusercontent.com/2494376/216822679-6a068eab-eeff-4f79-9ad4-4611661e5dc3.png)
![Screenshot from 2023-02-05 14-36-55](https://user-images.githubusercontent.com/2494376/216822681-ba01c92c-d7ac-403b-8589-92ffb3160ce7.png)

</details>

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md