### PR TITLE
enable Material 3 on `context_menus` 

### DIFF
--- a/experimental/context_menus/lib/main.dart
+++ b/experimental/context_menus/lib/main.dart
@@ -43,6 +43,7 @@ class _MyAppState extends State<MyApp> {
       theme: ThemeData(
         primarySwatch: Colors.blue,
         platform: defaultTargetPlatform,
+        useMaterial3: true,
       ),
       initialRoute: '/',
       routes: <String, Widget Function(BuildContext)>{


### PR DESCRIPTION
Enabled Material 3 on `context_menus`.

#### Before Material 3

<details><summary>Screenshots</summary>

![Screenshot from 2023-02-06 20-06-57](https://user-images.githubusercontent.com/2494376/217063120-ebd6d29a-28a4-418b-a268-d8a89b199c99.png)
![Screenshot from 2023-02-06 20-07-18](https://user-images.githubusercontent.com/2494376/217063151-5da4b38b-0cb8-413c-a6b0-eb0beaa3d223.png)

</details>

#### With Material 3

<details><summary>Screenshots</summary>

![Screenshot from 2023-02-06 20-07-36](https://user-images.githubusercontent.com/2494376/217063274-08b37568-1372-4cc5-8e80-ff26d9727834.png)
![Screenshot from 2023-02-06 20-07-48](https://user-images.githubusercontent.com/2494376/217063295-61ad4a8d-11f4-4c59-9ef3-29c12e039e86.png)


</details>

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md