### PR TITLE
Enable Material 3 on `linting_tool`

### DIFF
--- a/experimental/linting_tool/lib/theme/app_theme.dart
+++ b/experimental/linting_tool/lib/theme/app_theme.dart
@@ -45,6 +45,7 @@ abstract class AppTheme {
       textTheme: _buildReplyLightTextTheme(base.textTheme),
       scaffoldBackgroundColor: AppColors.blue50,
       bottomAppBarTheme: const BottomAppBarTheme(color: AppColors.blue700),
+      useMaterial3: true,
     );
   }
 


### PR DESCRIPTION
Enabled Material 3 on `linting_tool`.

#### Before Material 3

<details><summary>Screenshots</summary>

![Screenshot from 2023-02-06 20-14-17](https://user-images.githubusercontent.com/2494376/217064127-edea38cf-1ac2-48b6-a2ec-3412da0526d2.png)
![Screenshot from 2023-02-06 20-14-28](https://user-images.githubusercontent.com/2494376/217064130-2c9144a9-0db6-46ce-9a1d-50890ddc7754.png)
![Screenshot from 2023-02-06 20-14-36](https://user-images.githubusercontent.com/2494376/217064134-bbc605bd-d7dd-4468-9cd7-fb446e5353f6.png)


</details>

#### With Material 3

<details><summary>Screenshots</summary>

![Screenshot from 2023-02-06 20-14-47](https://user-images.githubusercontent.com/2494376/217064162-0b2f0248-c359-4ca4-b3fe-2c1bc3a8c0f9.png)
![Screenshot from 2023-02-06 20-14-54](https://user-images.githubusercontent.com/2494376/217064165-462a6776-8c00-4920-991b-c992e79bcfeb.png)
![Screenshot from 2023-02-06 20-15-01](https://user-images.githubusercontent.com/2494376/217064166-dd98631c-56a9-4b40-b5fd-be5b33098e8e.png)
![Screenshot from 2023-02-06 20-15-06](https://user-images.githubusercontent.com/2494376/217064169-d12aa629-1f77-4d9a-8004-b8a0c560446e.png)


</details>

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md