### PR TITLE
Enable Material 3 on `federated_plugin`

### DIFF
--- a/experimental/federated_plugin/federated_plugin/example/lib/main.dart
+++ b/experimental/federated_plugin/federated_plugin/example/lib/main.dart
@@ -14,8 +14,9 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: HomePage(),
+    return MaterialApp(
+      theme: ThemeData.light(useMaterial3: true),
+      home: const HomePage(),
     );
   }
 }
@@ -49,7 +50,7 @@ class _HomePageState extends State<HomePage> {
                     style: Theme.of(context).textTheme.headlineSmall,
                   ),
             const SizedBox(height: 16),
-            ElevatedButton(
+            FilledButton(
               onPressed: () async {
                 try {
                   final result = await getBatteryLevel();

--- a/experimental/federated_plugin/federated_plugin/example/test/widget_test.dart
+++ b/experimental/federated_plugin/federated_plugin/example/test/widget_test.dart
@@ -22,7 +22,7 @@ void main() {
       await tester.pumpWidget(const MyApp());
 
       // Tap button to retrieve current battery level from platform.
-      await tester.tap(find.byType(ElevatedButton));
+      await tester.tap(find.byType(FilledButton));
       await tester.pumpAndSettle();
 
       expect(find.text('Battery Level: $batteryLevel'), findsOneWidget);


### PR DESCRIPTION
Enabled Material 3 on `federated_plugin`.

#### Before Material 3

<details><summary>Screenshots</summary>

![Screenshot from 2023-02-06 20-19-15](https://user-images.githubusercontent.com/2494376/217065107-0ff1822e-2ed5-4b28-ab4f-b18e42eab18b.png)


</details>

#### With Material 3

<details><summary>Screenshots</summary>

![Screenshot from 2023-02-06 20-20-17](https://user-images.githubusercontent.com/2494376/217065139-cbce0791-b8e8-4cab-b40a-c0fdacaf6c3b.png)


</details>

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md