### PR TITLE
Enable Material 3 on `add_to_app/books`

### DIFF
--- a/add_to_app/books/flutter_module_books/lib/main.dart
+++ b/add_to_app/books/flutter_module_books/lib/main.dart
@@ -15,6 +15,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData(
         primaryColor: const Color(0xff6200ee),
+        useMaterial3: true,
       ),
       home: const BookDetail(),
     );


### PR DESCRIPTION
Enabled Material 3 on `add_to_app/books`.

#### Before Material 3

<details><summary>Screenshots</summary>

![Screenshot_20230207_160738](https://user-images.githubusercontent.com/2494376/217286057-dd5aa6f1-76ce-4e96-a854-027cc8330454.png)


</details>

#### With Material 3

<details><summary>Screenshots</summary>

![Screenshot_20230207_160640](https://user-images.githubusercontent.com/2494376/217286016-c9cfc784-8ab7-440d-81ad-0f6f93a34e44.png)


</details>

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md