### PR TITLE
Enable Material 3 on `add_to_app/fullscreen`

### DIFF
--- a/add_to_app/fullscreen/flutter_module/lib/main.dart
+++ b/add_to_app/fullscreen/flutter_module/lib/main.dart
@@ -64,6 +64,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Module Title',
+      theme: ThemeData.light(useMaterial3: true),
       routes: {
         '/': (context) => const FullScreenView(),
         '/mini': (context) => const Contents(),


### PR DESCRIPTION
Enabled Material 3 on `add_to_app/fullscreen`.

#### Before Material 3

<details><summary>Screenshots</summary>

![Screenshot_20230207_161022](https://user-images.githubusercontent.com/2494376/217287762-d30d28e5-148c-45ba-9c25-0eb40d5a38c1.png)

</details>

#### With Material 3

<details><summary>Screenshots</summary>

![Screenshot_20230207_161130](https://user-images.githubusercontent.com/2494376/217287799-885616d7-71a5-4efd-8238-eb63894c3722.png)

</details>

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md