### PR TITLE
Enable Material 3 on `add_to_app/multiple_flutters`

### DIFF
--- a/add_to_app/multiple_flutters/multiple_flutters_module/lib/main.dart
+++ b/add_to_app/multiple_flutters/multiple_flutters_module/lib/main.dart
@@ -24,7 +24,13 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        primarySwatch: color,
+        colorSchemeSeed: color,
+        useMaterial3: true,
+        appBarTheme: AppBarTheme(
+          backgroundColor: color,
+          foregroundColor: Colors.white,
+          elevation: 8,
+        ),
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );


### PR DESCRIPTION
Enabled Material 3 on `add_to_app/multiple_flutters`.

In this case, I had to modify a bit the AppBarTheme, so it didn't default to the Material 3 white background and the demo still worked visually.

#### Before Material 3

<details><summary>Screenshots</summary>

![Screenshot_20230207_161552](https://user-images.githubusercontent.com/2494376/217290276-d1d71f26-0363-4ecb-9bff-5fdd829e06af.png)

![Screenshot_20230207_161600](https://user-images.githubusercontent.com/2494376/217290309-8bce9674-8bcd-473f-b19e-e8af3ec22f2a.png)


</details>

#### With Material 3

<details><summary>Screenshots</summary>

![Screenshot_20230207_163310](https://user-images.githubusercontent.com/2494376/217290339-2ae691a3-e462-4242-b997-7f69c87bce89.png)

![Screenshot_20230207_163325](https://user-images.githubusercontent.com/2494376/217290361-4c2404d2-d254-4350-92a5-293badcca8e0.png)

</details>

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md