### PR TITLE
Enable Material 3 on `add_to_app/plugin`

### DIFF
--- a/add_to_app/plugin/flutter_module_using_plugin/lib/main.dart
+++ b/add_to_app/plugin/flutter_module_using_plugin/lib/main.dart
@@ -75,6 +75,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Module Title',
+      theme: ThemeData.light(useMaterial3: true),
       routes: {
         '/': (context) => const FullScreenView(),
         '/mini': (context) => const Contents(),


### PR DESCRIPTION
Enabled Material 3 on `add_to_app/plugin`.

#### Before Material 3

<details><summary>Screenshots</summary>

![Screenshot_20230207_171307](https://user-images.githubusercontent.com/2494376/217300701-91014292-88c2-4e5a-908a-9becc43fcbef.png)

</details>

#### With Material 3

<details><summary>Screenshots</summary>

![Screenshot_20230207_171424](https://user-images.githubusercontent.com/2494376/217300717-9eb9336a-50f2-4e00-a94d-4a466d4ef667.png)

</details>

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md