### PR TITLE
Enable Material 3 on `add_to_app/prebuilt_module`

### DIFF
--- a/add_to_app/prebuilt_module/flutter_module/lib/main.dart
+++ b/add_to_app/prebuilt_module/flutter_module/lib/main.dart
@@ -64,6 +64,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Module Title',
+      theme: ThemeData.light(useMaterial3: true),
       routes: {
         '/': (context) => const FullScreenView(),
         '/mini': (context) => const Contents(),


### PR DESCRIPTION
Enabled Material 3 on `add_to_app/prebuilt_module`.

#### Before Material 3

<details><summary>Screenshots</summary>

![Screenshot_20230207_171902](https://user-images.githubusercontent.com/2494376/217302788-1e0ac1f3-d78a-4ba6-ac5a-285afea551ab.png)

</details>

#### With Material 3

<details><summary>Screenshots</summary>

![Screenshot_20230207_172152](https://user-images.githubusercontent.com/2494376/217302800-f01695a9-a3bd-4e0a-840c-55800fe3866d.png)

</details>

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md