### PR TITLE
`simple_shader`: Utilise `flutter_shaders`

### DIFF
--- a/simple_shader/lib/main.dart
+++ b/simple_shader/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:flutter_shaders/flutter_shaders.dart';
 
 void main() {
   runApp(const MyApp());
@@ -22,21 +23,8 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyHomePage extends StatefulWidget {
+class MyHomePage extends StatelessWidget {
   const MyHomePage({super.key});
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  late Future<ui.FragmentProgram> program;
-
-  @override
-  void initState() {
-    super.initState();
-    program = ui.FragmentProgram.fromAsset('shaders/simple.frag');
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -44,22 +32,17 @@ class _MyHomePageState extends State<MyHomePage> {
       appBar: AppBar(
         title: const Text('Simple Shader Demo'),
       ),
-      body: FutureBuilder<ui.FragmentProgram>(
-        future: program,
-        builder: (context, snapshot) {
-          if (snapshot.hasData) {
-            return CustomPaint(
-              size: MediaQuery.of(context).size,
-              painter: ShaderPainter(
-                shader: snapshot.data!.fragmentShader(),
-              ),
-            );
-          }
-          if (snapshot.hasError) {
-            return Center(child: Text('${snapshot.error}'));
-          }
-          return const Center(child: CircularProgressIndicator());
-        },
+      body: ShaderBuilder(
+        assetKey: 'shaders/simple.frag',
+        (context, shader, child) => CustomPaint(
+          size: MediaQuery.of(context).size,
+          painter: ShaderPainter(
+            shader: shader,
+          ),
+        ),
+        child: const Center(
+          child: CircularProgressIndicator(),
+        ),
       ),
     );
   }

--- a/simple_shader/pubspec.yaml
+++ b/simple_shader/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_shaders: ^0.0.6
 
 dev_dependencies:
   analysis_defaults:


### PR DESCRIPTION
Trying out `flutter_shaders` to simplify the code. Thoughts?

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md