### PR TITLE
[Simplistic_Editor] Fix IME Candidate Menu on macOS/web

### DIFF
--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 import 'app_state.dart';
@@ -210,6 +211,10 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
         ),
       );
       final TextStyle style = widget.style;
+
+      _updateSizeAndTransform();
+      _schedulePeriodicPostFrameCallbacks();
+
       _textInputConnection!
         ..setStyle(
           fontFamily: style.fontFamily,
@@ -474,6 +479,54 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
       _textInputConnection!.setEditingState(_value);
       _lastKnownRemoteTextEditingValue = _value;
     }
+  }
+
+  // Sends the current composing rect to the iOS text input plugin via the text
+  // input channel. We need to keep sending the information even if no text is
+  // currently marked, as the information usually lags behind. The text input
+  // plugin needs to estimate the composing rect based on the latest caret rect,
+  // when the composing rect info didn't arrive in time.
+  void _updateComposingRectIfNeeded() {
+    final TextRange composingRange = _value.composing;
+    assert(mounted);
+    Rect? composingRect =
+        renderEditable.getRectForComposingRange(composingRange);
+    // Send the caret location instead if there's no marked text yet.
+    if (composingRect == null) {
+      assert(!composingRange.isValid || composingRange.isCollapsed);
+      final int offset = composingRange.isValid ? composingRange.start : 0;
+      composingRect =
+          renderEditable.getLocalRectForCaret(TextPosition(offset: offset));
+    }
+    _textInputConnection!.setComposingRect(composingRect);
+  }
+
+  void _updateCaretRectIfNeeded() {
+    final TextSelection? selection = renderEditable.selection;
+    if (selection == null || !selection.isValid || !selection.isCollapsed) {
+      return;
+    }
+    final TextPosition currentTextPosition =
+        TextPosition(offset: selection.baseOffset);
+    final Rect caretRect =
+        renderEditable.getLocalRectForCaret(currentTextPosition);
+    _textInputConnection!.setCaretRect(caretRect);
+  }
+
+  void _updateSizeAndTransform() {
+    final Size size = renderEditable.size;
+    final Matrix4 transform = renderEditable.getTransformTo(null);
+    _textInputConnection!.setEditableSizeAndTransform(size, transform);
+  }
+
+  void _schedulePeriodicPostFrameCallbacks([Duration? duration]) {
+    if (!_hasInputConnection) {
+      return;
+    }
+    _updateComposingRectIfNeeded();
+    _updateCaretRectIfNeeded();
+    SchedulerBinding.instance
+        .addPostFrameCallback(_schedulePeriodicPostFrameCallbacks);
   }
 
   /// [TextSelectionDelegate] method implementations.


### PR DESCRIPTION
Fixes #1648

This changes sends the caret rect and composing rects to the `TextInputPlugin` to be able to correctly position the IME candidate menu.

<img width="766" alt="Screenshot 2023-02-27 at 11 23 09 PM" src="https://user-images.githubusercontent.com/948037/221782776-6c797031-4c2d-45ec-9847-ebb037302370.png">

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.