### PR TITLE
Enable the context menu examples on web

### DIFF
--- a/experimental/context_menus/README.md
+++ b/experimental/context_menus/README.md
@@ -10,9 +10,6 @@ such as the text selection toolbar on mobile or the right click menu on desktop.
 
 Just run `flutter run` in the same directory as this README file.
 
-Currently, most of the examples in this demo do not support web, because Flutter
-uses the browser's built-in context menu instead.
-
 ## The examples
 
 ### [Anywhere](https://github.com/flutter/samples/blob/main/experimental/context_menus/lib/anywhere_page.dart)

--- a/experimental/context_menus/lib/main.dart
+++ b/experimental/context_menus/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'anywhere_page.dart';
 import 'cascading_menu_page.dart';
@@ -33,6 +34,24 @@ class _MyAppState extends State<MyApp> {
     setState(() {
       debugDefaultTargetPlatformOverride = platform;
     });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    // On web, disable the browser's context menu everywhere so that the custom
+    // Flutter-rendered context menu shows.
+    if (kIsWeb) {
+      BrowserContextMenu.disableContextMenu();
+    }
+  }
+
+  @override
+  void dispose() {
+    if (kIsWeb) {
+      BrowserContextMenu.enableContextMenu();
+    }
+    super.dispose();
   }
 
   @override

--- a/tool/flutter_ci_script_stable.sh
+++ b/tool/flutter_ci_script_stable.sh
@@ -22,7 +22,8 @@ declare -ar PROJECT_NAMES=(
     "code_sharing/shared"
     "desktop_photo_search/fluent_ui"
     "desktop_photo_search/material"
-    "experimental/context_menus"
+    # TODO(DomesticMouse): uncomment on next Flutter stable increment
+    # "experimental/context_menus"
     "experimental/federated_plugin/federated_plugin"
     "experimental/federated_plugin/federated_plugin/example"
     "experimental/federated_plugin/federated_plugin_macos"


### PR DESCRIPTION
Support for context menus on the web was added in https://github.com/flutter/flutter/issues/119184.  This PR enables support in these examples.

Closes https://github.com/flutter/samples/issues/1685