### PR TITLE
Fix spelling and cases

### DIFF
--- a/experimental/pedometer/README.md
+++ b/experimental/pedometer/README.md
@@ -3,7 +3,7 @@
 This is a demo for some of our tooling around calling platform APIs directly from dart code. This repository represents a demo of a plugin that leverages FFIgen & JNIgen. There is also an example pedometer app that uses the bindings generated from these tools. 
 
 - [FFIgen](https://pub.dev/packages/ffigen) is used to generate bindings for C, Objective-C and Swift APIs
-- [JNIgen](https://pub.dev/packages/jnigen) is used to generate bindings for Jave and Kotlin APIs
+- [JNIgen](https://pub.dev/packages/jnigen) is used to generate bindings for Java and Kotlin APIs
 
 **These tools are both experimental and are currently a work in progress.** If you find any issues or have feedback, please file it on the corresponding Github repositories. 
 
@@ -38,7 +38,7 @@ Note that step counting is only available on physical devices.
 
 ## Project stucture
 
-* `src`: Contains the native source code, and a CmakeFile.txt file for building
+* `src`: Contains the native source code, and a CMakeFile.txt file for building
   that source code into a dynamic library.
 
 * `lib`: Contains the Dart code that defines the API of the plugin, and which
@@ -47,7 +47,7 @@ Note that step counting is only available on physical devices.
 * platform folders (`ios` etc.): Contains the build files
   for building and bundling the native code library with the platform application.
 
-* `example`: Contains the native source code, and a CmakeFile.txt file for building
+* `example`: Contains the native source code, and a CMakeFile.txt file for building
   that source code into a dynamic library.
 
 


### PR DESCRIPTION

This PR will correct the grammar on README.md file. 

Fixes: 
- Jave to Java on Line 6
- CmakeFile.txt to CMakeFile.txt on Line 41 and 50

## Pre-launch Checklist

- [ NA ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ Y ] I signed the [CLA].
- [ Y ] I read the [Contributors Guide].
- [ NA ] I updated/added relevant documentation (doc comments with `///`).
- [ NA ] All existing and new tests are passing.
