### PR TITLE
Add a SearchAnchor example to experimental demo

### DIFF
--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -2248,7 +2248,7 @@ class _SearchAnchorsState extends State<SearchAnchors> {
       label: 'Search',
       tooltipMessage: 'Use SearchAnchor or SearchAnchor.bar',
       child: Column(
-        children: [
+        children: <Widget>[
           SearchAnchor.bar(
             barHintText: 'Search colors',
             suggestionsBuilder: (context, controller) {
@@ -2268,7 +2268,7 @@ class _SearchAnchorsState extends State<SearchAnchors> {
           ),
           const SizedBox(height: 20),
           if (selectedColor == null)
-            const Text('Search a color')
+            const Text('Select a color')
           else
             Text('Last selected color is $selectedColor')
         ],

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -140,8 +140,8 @@ class Navigation extends StatelessWidget {
       ),
       NavigationDrawers(scaffoldKey: scaffoldKey),
       const NavigationRails(),
-      // TODO: Add Search https://github.com/flutter/flutter/issues/117483
       const Tabs(),
+      const SearchAnchors(),
       const TopAppBars(),
     ]);
   }
@@ -2182,6 +2182,93 @@ class _SlidersState extends State<Sliders> {
   }
 }
 
+class SearchAnchors extends StatefulWidget {
+  const SearchAnchors({super.key});
+
+  @override
+  State<SearchAnchors> createState() => _SearchAnchorsState();
+}
+
+class _SearchAnchorsState extends State<SearchAnchors> {
+  String? selectedColorSeed;
+  List<ColorItem> searchHistory = <ColorItem>[];
+
+  Iterable<Widget> getHistoryList(SearchController controller) {
+    return searchHistory.map((color) => ListTile(
+      leading: const Icon(Icons.history),
+      title: Text(color.label),
+      trailing: IconButton(icon: const Icon(Icons.call_missed), onPressed: () {
+        controller.text = color.label;
+        controller.selection = TextSelection.collapsed(offset: controller.text.length);
+      }),
+      onTap: () {
+        controller.closeView(color.label);
+        handleSelection(color);
+      },
+    ));
+  }
+
+  Iterable<Widget> getSuggestions(SearchController controller) {
+    final String input = controller.value.text;
+    return ColorItem.values.where((color) => color.label.contains(input))
+      .map((filteredColor) =>
+      ListTile(
+        leading: CircleAvatar(backgroundColor: filteredColor.color),
+        title: Text(filteredColor.label),
+        trailing: IconButton(icon: const Icon(Icons.call_missed), onPressed: () {
+          controller.text = filteredColor.label;
+          controller.selection = TextSelection.collapsed(offset: controller.text.length);
+        }),
+        onTap: () {
+          controller.closeView(filteredColor.label);
+          handleSelection(filteredColor);
+        },
+      ));
+  }
+
+  void handleSelection(ColorItem selectedColor) {
+    setState(() {
+      selectedColorSeed = selectedColor.label;
+      if (searchHistory.length >= 5) {
+        searchHistory.removeLast();
+      }
+      searchHistory.insert(0, selectedColor);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ComponentDecoration(
+      label: 'Search',
+      tooltipMessage: 'Use SearchAnchor or SearchAnchor.bar',
+      child: Column(
+        children: [
+          SearchAnchor.bar(
+            barHintText: 'Search colors',
+            suggestionsBuilder: (context, controller) {
+              if (controller.text.isEmpty) {
+                if (searchHistory.isNotEmpty) {
+                  return getHistoryList(controller);
+                }
+                return <Widget>[
+                  const Center(child:
+                  Text('No search history.',
+                    style: TextStyle(color: Colors.grey)),
+                  )
+                ];
+              }
+              return getSuggestions(controller);
+            },
+          ),
+          const SizedBox(height: 20),
+          if (selectedColorSeed == null) const Text('Search a color')
+          else Text('Selected color is $selectedColorSeed')
+        ],
+      ),
+    );
+  }
+}
+
 class ComponentDecoration extends StatefulWidget {
   const ComponentDecoration({
     super.key,
@@ -2290,4 +2377,27 @@ class ComponentGroupDecoration extends StatelessWidget {
       ),
     );
   }
+}
+
+enum ColorItem {
+  red('red', Colors.red),
+  orange('orange', Colors.orange),
+  yellow('yellow', Colors.yellow),
+  green('green', Colors.green),
+  blue('blue', Colors.blue),
+  indigo('indigo', Colors.indigo),
+  violet('violet', Color(0xFF8F00FF)),
+  purple('purple', Colors.purple),
+  pink('pink', Colors.pink),
+  silver('silver', Color(0xFF808080)),
+  gold('gold', Color(0xFFFFD700)),
+  beige('beige', Color(0xFFF5F5DC)),
+  brown('brown', Colors.brown),
+  grey('grey', Colors.grey),
+  black('black', Colors.black),
+  white('white', Colors.white);
+
+  const ColorItem(this.label, this.color);
+  final String label;
+  final Color color;
 }

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -2190,7 +2190,7 @@ class SearchAnchors extends StatefulWidget {
 }
 
 class _SearchAnchorsState extends State<SearchAnchors> {
-  String? selectedColorSeed;
+  String? selectedColor;
   List<ColorItem> searchHistory = <ColorItem>[];
 
   Iterable<Widget> getHistoryList(SearchController controller) {
@@ -2232,13 +2232,13 @@ class _SearchAnchorsState extends State<SearchAnchors> {
             ));
   }
 
-  void handleSelection(ColorItem selectedColor) {
+  void handleSelection(ColorItem color) {
     setState(() {
-      selectedColorSeed = selectedColor.label;
+      selectedColor = color.label;
       if (searchHistory.length >= 5) {
         searchHistory.removeLast();
       }
-      searchHistory.insert(0, selectedColor);
+      searchHistory.insert(0, color);
     });
   }
 
@@ -2267,10 +2267,10 @@ class _SearchAnchorsState extends State<SearchAnchors> {
             },
           ),
           const SizedBox(height: 20),
-          if (selectedColorSeed == null)
+          if (selectedColor == null)
             const Text('Search a color')
           else
-            Text('Last selected color is $selectedColorSeed')
+            Text('Last selected color is $selectedColor')
         ],
       ),
     );

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -2262,7 +2262,7 @@ class _SearchAnchorsState extends State<SearchAnchors> {
           ),
           const SizedBox(height: 20),
           if (selectedColorSeed == null) const Text('Search a color')
-          else Text('Selected color is $selectedColorSeed')
+          else Text('Last selected color is $selectedColorSeed')
         ],
       ),
     );

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -2195,35 +2195,41 @@ class _SearchAnchorsState extends State<SearchAnchors> {
 
   Iterable<Widget> getHistoryList(SearchController controller) {
     return searchHistory.map((color) => ListTile(
-      leading: const Icon(Icons.history),
-      title: Text(color.label),
-      trailing: IconButton(icon: const Icon(Icons.call_missed), onPressed: () {
-        controller.text = color.label;
-        controller.selection = TextSelection.collapsed(offset: controller.text.length);
-      }),
-      onTap: () {
-        controller.closeView(color.label);
-        handleSelection(color);
-      },
-    ));
+          leading: const Icon(Icons.history),
+          title: Text(color.label),
+          trailing: IconButton(
+              icon: const Icon(Icons.call_missed),
+              onPressed: () {
+                controller.text = color.label;
+                controller.selection =
+                    TextSelection.collapsed(offset: controller.text.length);
+              }),
+          onTap: () {
+            controller.closeView(color.label);
+            handleSelection(color);
+          },
+        ));
   }
 
   Iterable<Widget> getSuggestions(SearchController controller) {
     final String input = controller.value.text;
-    return ColorItem.values.where((color) => color.label.contains(input))
-      .map((filteredColor) =>
-      ListTile(
-        leading: CircleAvatar(backgroundColor: filteredColor.color),
-        title: Text(filteredColor.label),
-        trailing: IconButton(icon: const Icon(Icons.call_missed), onPressed: () {
-          controller.text = filteredColor.label;
-          controller.selection = TextSelection.collapsed(offset: controller.text.length);
-        }),
-        onTap: () {
-          controller.closeView(filteredColor.label);
-          handleSelection(filteredColor);
-        },
-      ));
+    return ColorItem.values
+        .where((color) => color.label.contains(input))
+        .map((filteredColor) => ListTile(
+              leading: CircleAvatar(backgroundColor: filteredColor.color),
+              title: Text(filteredColor.label),
+              trailing: IconButton(
+                  icon: const Icon(Icons.call_missed),
+                  onPressed: () {
+                    controller.text = filteredColor.label;
+                    controller.selection =
+                        TextSelection.collapsed(offset: controller.text.length);
+                  }),
+              onTap: () {
+                controller.closeView(filteredColor.label);
+                handleSelection(filteredColor);
+              },
+            ));
   }
 
   void handleSelection(ColorItem selectedColor) {
@@ -2251,9 +2257,9 @@ class _SearchAnchorsState extends State<SearchAnchors> {
                   return getHistoryList(controller);
                 }
                 return <Widget>[
-                  const Center(child:
-                  Text('No search history.',
-                    style: TextStyle(color: Colors.grey)),
+                  const Center(
+                    child: Text('No search history.',
+                        style: TextStyle(color: Colors.grey)),
                   )
                 ];
               }
@@ -2261,8 +2267,10 @@ class _SearchAnchorsState extends State<SearchAnchors> {
             },
           ),
           const SizedBox(height: 20),
-          if (selectedColorSeed == null) const Text('Search a color')
-          else Text('Last selected color is $selectedColorSeed')
+          if (selectedColorSeed == null)
+            const Text('Search a color')
+          else
+            Text('Last selected color is $selectedColorSeed')
         ],
       ),
     );

--- a/experimental/material_3_demo/test/component_screen_test.dart
+++ b/experimental/material_3_demo/test/component_screen_test.dart
@@ -93,6 +93,9 @@ void main() {
     // Tabs
     expect(find.byType(TabBar), findsOneWidget);
 
+    // Search
+    expect(find.byType(SearchBar), findsOneWidget);
+
     // Top app bars
     expect(find.byType(AppBar), findsNWidgets(6));
 


### PR DESCRIPTION
This PR is to add an example for `SearchAnchor` widget.

<img width="250" alt="Screenshot 2023-04-03 at 4 33 53 PM" src="https://user-images.githubusercontent.com/36861262/229649079-ccb171fc-dd44-47d4-88cd-b043d5793589.png"><img width="250" alt="Screenshot 2023-04-03 at 4 34 23 PM" src="https://user-images.githubusercontent.com/36861262/229649101-033db9be-0ed1-4f3d-92a1-794b9ed86306.png">



## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
