### PR TITLE
Replace `MaterialButton` in the `AnimatedBuilder` sample

### DIFF
--- a/animations/lib/src/basics/animated_builder.dart
+++ b/animations/lib/src/basics/animated_builder.dart
@@ -23,7 +23,6 @@ class _AnimatedBuilderDemoState extends State<AnimatedBuilderDemo>
   @override
   void initState() {
     super.initState();
-
     controller = AnimationController(vsync: this, duration: duration);
     animation =
         ColorTween(begin: beginColor, end: endColor).animate(controller);
@@ -49,10 +48,10 @@ class _AnimatedBuilderDemoState extends State<AnimatedBuilderDemo>
         child: AnimatedBuilder(
           animation: animation,
           builder: (context, child) {
-            return MaterialButton(
-              color: animation.value,
-              height: 50,
-              minWidth: 100,
+            return ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: animation.value,
+              ),
               child: child,
               onPressed: () {
                 if (controller.status == AnimationStatus.completed) {

--- a/animations/test/basics/animated_builder_test.dart
+++ b/animations/test/basics/animated_builder_test.dart
@@ -17,7 +17,8 @@ void main() {
 
       // Get the initial color of the button.
       ElevatedButton button = tester.widget(find.byType(ElevatedButton));
-      MaterialStateProperty<Color?>? initialColor = button.style!.backgroundColor;
+      MaterialStateProperty<Color?>? initialColor =
+          button.style!.backgroundColor;
 
       // Tap the button.
       await tester.tap(find.byType(ElevatedButton));
@@ -25,7 +26,8 @@ void main() {
 
       // Get the updated color of the button.
       button = tester.widget(find.byType(ElevatedButton));
-      MaterialStateProperty<Color?>? updatedColor = button.style!.backgroundColor;
+      MaterialStateProperty<Color?>? updatedColor =
+          button.style!.backgroundColor;
 
       // Check if the color has changed.
       expect(initialColor, isNot(updatedColor));
@@ -36,7 +38,8 @@ void main() {
 
       // Get the initial color of the button.
       ElevatedButton button = tester.widget(find.byType(ElevatedButton));
-      MaterialStateProperty<Color?>? initialColor = button.style!.backgroundColor;
+      MaterialStateProperty<Color?>? initialColor =
+          button.style!.backgroundColor;
 
       // Tap the button to trigger the animation but don't wait for it to finish.
       await tester.tap(find.byType(ElevatedButton));
@@ -45,7 +48,8 @@ void main() {
 
       // Check that the color has changed but not to the final color.
       button = tester.widget(find.byType(ElevatedButton));
-      MaterialStateProperty<Color?>? changedColor = button.style!.backgroundColor;
+      MaterialStateProperty<Color?>? changedColor =
+          button.style!.backgroundColor;
       expect(initialColor, isNot(changedColor));
 
       // Wait for the animation to finish.

--- a/animations/test/basics/animated_builder_test.dart
+++ b/animations/test/basics/animated_builder_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter team. All rights reserved.
+// Copyright 2023 The Flutter team. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/animations/test/basics/animated_builder_test.dart
+++ b/animations/test/basics/animated_builder_test.dart
@@ -1,0 +1,60 @@
+// Copyright 2020 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:animations/src/basics/basics.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget createAnimatedBuilderDemoScreen() => const MaterialApp(
+      home: AnimatedBuilderDemo(),
+    );
+
+void main() {
+  group('AnimatedBuilder Tests', () {
+    testWidgets('AnimatedBuilder changes button color', (tester) async {
+      await tester.pumpWidget(createAnimatedBuilderDemoScreen());
+
+      // Get the initial color of the button.
+      ElevatedButton button = tester.widget(find.byType(ElevatedButton));
+      MaterialStateProperty<Color?>? initialColor = button.style!.backgroundColor;
+
+      // Tap the button.
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      // Get the updated color of the button.
+      button = tester.widget(find.byType(ElevatedButton));
+      MaterialStateProperty<Color?>? updatedColor = button.style!.backgroundColor;
+
+      // Check if the color has changed.
+      expect(initialColor, isNot(updatedColor));
+    });
+
+    testWidgets('AnimatedBuilder animates button color', (tester) async {
+      await tester.pumpWidget(createAnimatedBuilderDemoScreen());
+
+      // Get the initial color of the button.
+      ElevatedButton button = tester.widget(find.byType(ElevatedButton));
+      MaterialStateProperty<Color?>? initialColor = button.style!.backgroundColor;
+
+      // Tap the button to trigger the animation but don't wait for it to finish.
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // Check that the color has changed but not to the final color.
+      button = tester.widget(find.byType(ElevatedButton));
+      MaterialStateProperty<Color?>? changedColor = button.style!.backgroundColor;
+      expect(initialColor, isNot(changedColor));
+
+      // Wait for the animation to finish.
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // Check that the color has changed to the final color.
+      button = tester.widget(find.byType(ElevatedButton));
+      MaterialStateProperty<Color?>? finalColor = button.style!.backgroundColor;
+      expect(changedColor, isNot(finalColor));
+    });
+  });
+}


### PR DESCRIPTION
This replaces the planned to be deprecated [MaterialButton](https://master-api.flutter.dev/flutter/material/MaterialButton-class.html) with [ElevatedButton](https://master-api.flutter.dev/flutter/material/ElevatedButton-class.html).

| Before | After |
| --------------- | --------------- |
 | <img src="https://user-images.githubusercontent.com/48603081/230678932-7f0c08fd-4816-48c2-9791-db860827fda7.gif" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/230678928-bebd5b48-82d6-4e3c-a17e-05c0512ba773.gif" height="450" /> |


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md