### PR TITLE
[Simplistic_Editor] Use new context menu API

### DIFF
--- a/simplistic_editor/lib/basic_text_field.dart
+++ b/simplistic_editor/lib/basic_text_field.dart
@@ -143,26 +143,6 @@ class _BasicTextFieldState extends State<BasicTextField> {
           _renderEditable.handleTapDown(tapDownDetails);
           _renderEditable.selectPosition(cause: SelectionChangedCause.tap);
         },
-        onLongPressStart: (longPressStartDetails) {
-          switch (Theme.of(this.context).platform) {
-            case TargetPlatform.iOS:
-            case TargetPlatform.macOS:
-              _renderEditable.selectPositionAt(
-                from: longPressStartDetails.globalPosition,
-                cause: SelectionChangedCause.longPress,
-              );
-              break;
-            case TargetPlatform.android:
-            case TargetPlatform.fuchsia:
-            case TargetPlatform.linux:
-            case TargetPlatform.windows:
-              _renderEditable.selectWordsInRange(
-                from: longPressStartDetails.globalPosition,
-                cause: SelectionChangedCause.longPress,
-              );
-              break;
-          }
-        },
         onLongPressMoveUpdate: (longPressMoveUpdateDetails) {
           switch (Theme.of(this.context).platform) {
             case TargetPlatform.iOS:

--- a/simplistic_editor/lib/basic_text_field.dart
+++ b/simplistic_editor/lib/basic_text_field.dart
@@ -131,6 +131,9 @@ class _BasicTextFieldState extends State<BasicTextField> {
         onPanStart: (dragStartDetails) => _onDragStart(dragStartDetails),
         onPanUpdate: (dragUpdateDetails) => _onDragUpdate(dragUpdateDetails),
         onSecondaryTapDown: (secondaryTapDownDetails) {
+          _renderEditable.selectWordsInRange(
+              from: secondaryTapDownDetails.globalPosition,
+              cause: SelectionChangedCause.tap);
           _renderEditable.handleSecondaryTapDown(secondaryTapDownDetails);
           _textInputClient!.hideToolbar();
           _textInputClient!.showToolbar();

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -640,6 +640,7 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
       ),
       cause,
     );
+    if (cause == SelectionChangedCause.toolbar) hideToolbar();
   }
 
   @override

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -545,6 +545,20 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
   }
 
   @override
+  bool get cutEnabled => !textEditingValue.selection.isCollapsed;
+
+  @override
+  bool get copyEnabled => !textEditingValue.selection.isCollapsed;
+
+  @override
+  bool get pasteEnabled =>
+      _clipboardStatus == null ||
+      _clipboardStatus!.value == ClipboardStatus.pasteable;
+
+  @override
+  bool get selectAllEnabled => textEditingValue.text.isNotEmpty;
+
+  @override
   void copySelection(SelectionChangedCause cause) {
     final TextSelection copyRange = textEditingValue.selection;
     if (!copyRange.isValid || copyRange.isCollapsed) return;
@@ -789,10 +803,18 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
               return widget.contextMenuBuilder!(
                 context,
                 _clipboardStatus!.value,
-                () => copySelection(SelectionChangedCause.toolbar),
-                () => cutSelection(SelectionChangedCause.toolbar),
-                () => pasteText(SelectionChangedCause.toolbar),
-                () => selectAll(SelectionChangedCause.toolbar),
+                copyEnabled
+                    ? () => copySelection(SelectionChangedCause.toolbar)
+                    : null,
+                cutEnabled
+                    ? () => cutSelection(SelectionChangedCause.toolbar)
+                    : null,
+                pasteEnabled
+                    ? () => pasteText(SelectionChangedCause.toolbar)
+                    : null,
+                selectAllEnabled
+                    ? () => selectAll(SelectionChangedCause.toolbar)
+                    : null,
                 _contextMenuAnchors,
               );
             },

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -58,12 +58,13 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
     with TextSelectionDelegate, TextInputClient, DeltaTextInputClient {
   final GlobalKey _textKey = GlobalKey();
   late AppStateWidgetState manager;
-  final ClipboardStatusNotifier clipboardStatus = ClipboardStatusNotifier();
+  final ClipboardStatusNotifier? _clipboardStatus =
+      kIsWeb ? null : ClipboardStatusNotifier();
 
   @override
   void initState() {
     super.initState();
-    clipboardStatus.addListener(_onChangedClipboardStatus);
+    _clipboardStatus?.addListener(_onChangedClipboardStatus);
     widget.focusNode.addListener(_handleFocusChanged);
     widget.controller.addListener(_didChangeTextEditingValue);
   }
@@ -77,8 +78,8 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
   @override
   void dispose() {
     widget.controller.removeListener(_didChangeTextEditingValue);
-    clipboardStatus.removeListener(_onChangedClipboardStatus);
-    clipboardStatus.dispose();
+    _clipboardStatus?.removeListener(_onChangedClipboardStatus);
+    _clipboardStatus?.dispose();
     super.dispose();
   }
 
@@ -597,7 +598,7 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
       }
       hideToolbar();
     }
-    clipboardStatus.update();
+    _clipboardStatus?.update();
   }
 
   @override
@@ -620,7 +621,7 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
       cause,
     );
     if (cause == SelectionChangedCause.toolbar) hideToolbar();
-    clipboardStatus.update();
+    _clipboardStatus?.update();
   }
 
   @override
@@ -790,7 +791,7 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
 
   TextSelectionOverlay _createSelectionOverlay() {
     final TextSelectionOverlay selectionOverlay = TextSelectionOverlay(
-      clipboardStatus: clipboardStatus,
+      clipboardStatus: _clipboardStatus,
       context: context,
       value: _value,
       debugRequiredFor: widget,
@@ -804,12 +805,12 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
       onSelectionHandleTapped: () {
         _toggleToolbar();
       },
-      contextMenuBuilder: widget.contextMenuBuilder == null
+      contextMenuBuilder: widget.contextMenuBuilder == null || kIsWeb
           ? null
           : (context) {
               return widget.contextMenuBuilder!(
                 context,
-                clipboardStatus.value,
+                _clipboardStatus!.value,
                 () => copySelection(SelectionChangedCause.toolbar),
                 () => cutSelection(SelectionChangedCause.toolbar),
                 () => pasteText(SelectionChangedCause.toolbar),

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -83,12 +83,6 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
     super.dispose();
   }
 
-  void _onChangedClipboardStatus() {
-    setState(() {
-      // Inform the widget that the value of clipboardStatus has changed.
-    });
-  }
-
   /// [DeltaTextInputClient] method implementations.
   @override
   void connectionClosed() {
@@ -317,6 +311,12 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
       style: widget.style,
       withComposing: true,
     );
+  }
+
+  void _onChangedClipboardStatus() {
+    setState(() {
+      // Inform the widget that the value of clipboardStatus has changed.
+    });
   }
 
   /// Keyboard text editing actions.

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -793,7 +793,7 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
                 () => cutSelection(SelectionChangedCause.toolbar),
                 () => pasteText(SelectionChangedCause.toolbar),
                 () => selectAll(SelectionChangedCause.toolbar),
-                contextMenuAnchors,
+                _contextMenuAnchors,
               );
             },
       magnifierConfiguration: TextMagnifierConfiguration.disabled,
@@ -870,7 +870,7 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
   }
 
   /// Returns the anchor points for the default context menu.
-  TextSelectionToolbarAnchors get contextMenuAnchors {
+  TextSelectionToolbarAnchors get _contextMenuAnchors {
     if (renderEditable.lastSecondaryTapDownPosition != null) {
       return TextSelectionToolbarAnchors(
         primaryAnchor: renderEditable.lastSecondaryTapDownPosition!,

--- a/simplistic_editor/lib/main.dart
+++ b/simplistic_editor/lib/main.dart
@@ -100,6 +100,27 @@ class _MyHomePageState extends State<MyHomePage> {
                   padding: const EdgeInsets.symmetric(horizontal: 35.0),
                   child: BasicTextField(
                     controller: _replacementTextEditingController,
+                    contextMenuBuilder: (context, clipboardStatus, onCopy,
+                        onCut, onPaste, onSelectAll, anchors) {
+                      final List<ContextMenuButtonItem> buttonItems =
+                          EditableText.getEditableButtonItems(
+                        clipboardStatus: clipboardStatus,
+                        onCopy: onCopy,
+                        onCut: onCut,
+                        onPaste: onPaste,
+                        onSelectAll: onSelectAll,
+                      );
+                      buttonItems.insert(
+                          buttonItems.length,
+                          ContextMenuButtonItem(
+                            label: 'Clear Formatting',
+                            onPressed: () {},
+                          ));
+                      return AdaptiveTextSelectionToolbar.buttonItems(
+                        anchors: anchors,
+                        buttonItems: buttonItems,
+                      );
+                    },
                     style: const TextStyle(
                       fontSize: 18.0,
                       color: Colors.black,

--- a/simplistic_editor/lib/main.dart
+++ b/simplistic_editor/lib/main.dart
@@ -100,27 +100,6 @@ class _MyHomePageState extends State<MyHomePage> {
                   padding: const EdgeInsets.symmetric(horizontal: 35.0),
                   child: BasicTextField(
                     controller: _replacementTextEditingController,
-                    contextMenuBuilder: (context, clipboardStatus, onCopy,
-                        onCut, onPaste, onSelectAll, anchors) {
-                      final List<ContextMenuButtonItem> buttonItems =
-                          EditableText.getEditableButtonItems(
-                        clipboardStatus: clipboardStatus,
-                        onCopy: onCopy,
-                        onCut: onCut,
-                        onPaste: onPaste,
-                        onSelectAll: onSelectAll,
-                      );
-                      buttonItems.insert(
-                          buttonItems.length,
-                          ContextMenuButtonItem(
-                            label: 'Clear Formatting',
-                            onPressed: () {},
-                          ));
-                      return AdaptiveTextSelectionToolbar.buttonItems(
-                        anchors: anchors,
-                        buttonItems: buttonItems,
-                      );
-                    },
                     style: const TextStyle(
                       fontSize: 18.0,
                       color: Colors.black,


### PR DESCRIPTION
This change migrates the implementation of `BasicTextField` and `BasicTextInputClient` to use the new `ContextMenu` API more info at this link: https://docs.flutter.dev/release/breaking-changes/context-menus

Other changes:
- Context menus now show on right click when on desktop platforms.
- Some methods were moved around in `BasicTextInputClient` to improve the organization.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.