### PR TITLE
More natural placement of actions in the material_3_demo dialog

### DIFF
--- a/material_3_demo/lib/component_screen.dart
+++ b/material_3_demo/lib/component_screen.dart
@@ -608,11 +608,11 @@ class _DialogsState extends State<Dialogs> {
             'A dialog is a type of modal window that appears in front of app content to provide critical information, or prompt for a decision to be made.'),
         actions: <Widget>[
           TextButton(
-            child: const Text('Okay'),
+            child: const Text('Dismiss'),
             onPressed: () => Navigator.of(context).pop(),
           ),
           FilledButton(
-            child: const Text('Dismiss'),
+            child: const Text('Okay'),
             onPressed: () => Navigator.of(context).pop(),
           ),
         ],


### PR DESCRIPTION
I think the After looks more natural.

### Before:
![Screenshot_1681787834](https://user-images.githubusercontent.com/50433979/232663358-08f725e1-3db3-4ea8-ac53-1df5f1269267.png)

### After:
![Screenshot_1681787924](https://user-images.githubusercontent.com/50433979/232663371-f56cfe23-0b0b-468b-a17f-4f5ca51cbc3f.png)

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.