### PR TITLE
Set `showDragHandle` to true for `BottomSheet`

### DIFF
--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -1546,6 +1546,7 @@ class _BottomSheetSectionState extends State<BottomSheetSection> {
             ),
             onPressed: () {
               showModalBottomSheet<void>(
+                showDragHandle: true,
                 context: context,
                 // TODO: Remove when this is in the framework https://github.com/flutter/flutter/issues/118619
                 constraints: const BoxConstraints(maxWidth: 640),


### PR DESCRIPTION
One line change to show the drag handle on the `ModalBottomSheetRoute`.

<img width="611" alt="Screenshot 2023-04-18 at 4 56 49 PM" src="https://user-images.githubusercontent.com/36861262/232929589-492434b9-7c87-43a0-8378-45ee3ca53782.png">


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
