### PR TITLE
Change deprecated TextButton to HyperlinkButton

### DIFF
--- a/desktop_photo_search/fluent_ui/lib/src/widgets/photo_details.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/widgets/photo_details.dart
@@ -37,7 +37,7 @@ class _PhotoDetailsState extends State<PhotoDetails> {
         Link(
           uri: Uri.parse(
               'https://unsplash.com/@${widget.photo.user!.username}?utm_source=$unsplashAppName&utm_medium=referral'),
-          builder: (context, followLink) => TextButton(
+          builder: (context, followLink) => HyperlinkButton(
             onPressed: followLink,
             child: Text(widget.photo.user!.name),
           ),
@@ -45,7 +45,7 @@ class _PhotoDetailsState extends State<PhotoDetails> {
         const Text('on'),
         Link(
           uri: _unsplashHomepage,
-          builder: (context, followLink) => TextButton(
+          builder: (context, followLink) => HyperlinkButton(
             onPressed: followLink,
             child: const Text('Unsplash'),
           ),


### PR DESCRIPTION
Change the deprecated use of `TextButton` to `HyperlinkButton` in `fluent_ui` sample.

The error was:

```
Analyzing fluent_ui...

   info - lib/src/widgets/photo_details.dart:40:45 - 'TextButton' is deprecated and shouldn't be used. Deprecated in 4.4.3. Use HypelinkButton instead. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use
   info - lib/src/widgets/photo_details.dart:48:45 - 'TextButton' is deprecated and shouldn't be used. Deprecated in 4.4.3. Use HypelinkButton instead. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use
```

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
