### PR TITLE
Change deprecated setMockMethodCallHandler to TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler

### DIFF
--- a/experimental/federated_plugin/federated_plugin/example/test/widget_test.dart
+++ b/experimental/federated_plugin/federated_plugin/example/test/widget_test.dart
@@ -11,11 +11,16 @@ void main() {
   group('federated plugin demo tests', () {
     const batteryLevel = 45;
     setUpAll(() {
-      const MethodChannel('battery').setMockMethodCallHandler((call) async {
-        if (call.method == 'getBatteryLevel') {
-          return batteryLevel;
-        }
-      });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('battery'),
+        (message) async {
+          if (message.method == 'getBatteryLevel') {
+            return batteryLevel;
+          }
+          return null;
+        },
+      );
     });
 
     testWidgets('get current battery level from platform', (tester) async {

--- a/experimental/federated_plugin/federated_plugin/test/federated_plugin_test.dart
+++ b/experimental/federated_plugin/federated_plugin/test/federated_plugin_test.dart
@@ -11,11 +11,16 @@ void main() {
 
   group('Federated Plugin Test', () {
     const batteryLevel = 34;
-    const MethodChannel('battery').setMockMethodCallHandler((call) async {
-      if (call.method == 'getBatteryLevel') {
-        return batteryLevel;
-      }
-    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('battery'),
+      (message) async {
+        if (message.method == 'getBatteryLevel') {
+          return batteryLevel;
+        }
+        return null;
+      },
+    );
 
     test('getBatteryLevel method test', () async {
       final result = await getBatteryLevel();

--- a/experimental/federated_plugin/federated_plugin_platform_interface/test/federated_plugin_platform_interface_test.dart
+++ b/experimental/federated_plugin/federated_plugin_platform_interface/test/federated_plugin_platform_interface_test.dart
@@ -11,11 +11,16 @@ void main() {
 
   group('MethodChannel test', () {
     const batteryLevel = 89;
-    const MethodChannel('battery').setMockMethodCallHandler((call) async {
-      if (call.method == 'getBatteryLevel') {
-        return batteryLevel;
-      }
-    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('battery'),
+      (message) async {
+        if (message.method == 'getBatteryLevel') {
+          return batteryLevel;
+        }
+        return null;
+      },
+    );
 
     test('getBatteryLevel method test', () async {
       final locationMethodChannel = BatteryMethodChannel();


### PR DESCRIPTION
Changed deprecated setMockMethodCallHandler in experimental\federated_plugin\federated_plugin

to fix error : 'setMockMethodCallHandler' is deprecated and shouldn't be used. Use tester.binding.defaultBinaryMessenger.setMockMethodCallHandler or TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler instead. Pass the channel as the first argument. This feature was deprecated after v3.9.0-19.0.pre. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use in PR #1740 

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.