### PR TITLE
Add `experimental/material_3_demo` back to `beta` and `master` CI

### DIFF
--- a/experimental/material_3_demo/lib/main.dart
+++ b/experimental/material_3_demo/lib/main.dart
@@ -32,7 +32,7 @@ class _AppState extends State<App> {
   bool get useLightMode {
     switch (themeMode) {
       case ThemeMode.system:
-        return SchedulerBinding.instance.window.platformBrightness ==
+        return View.of(context).platformDispatcher.platformBrightness ==
             Brightness.light;
       case ThemeMode.light:
         return true;

--- a/tool/flutter_ci_script_beta.sh
+++ b/tool/flutter_ci_script_beta.sh
@@ -49,8 +49,7 @@ declare -ar PROJECT_NAMES=(
     "ios_app_clip"
     "isolate_example"
     "jsonexample"
-    # TODO(DomesticMouse): Use 'const' with the constructor to improve performance.
-    # "material_3_demo"
+    "material_3_demo"
     "navigation_and_routing"
     # TODO(DomesticMouse): Use 'const' with the constructor to improve performance.
     # "place_tracker"

--- a/tool/flutter_ci_script_beta.sh
+++ b/tool/flutter_ci_script_beta.sh
@@ -36,8 +36,7 @@ declare -ar PROJECT_NAMES=(
     "experimental/federated_plugin/federated_plugin_web"
     "experimental/federated_plugin/federated_plugin_windows"
     "experimental/linting_tool"
-    # TODO(DomesticMouse): Use 'const' with the constructor to improve performance.
-    # "experimental/material_3_demo"
+    "experimental/material_3_demo"
     "experimental/pedometer"
     "experimental/varfont_shader_puzzle"
     "experimental/web_dashboard"

--- a/tool/flutter_ci_script_master.sh
+++ b/tool/flutter_ci_script_master.sh
@@ -37,8 +37,7 @@ declare -ar PROJECT_NAMES=(
     "experimental/federated_plugin/federated_plugin_web"
     "experimental/federated_plugin/federated_plugin_windows"
     "experimental/linting_tool"
-    # TODO(DomesticMouse): Use 'const' with the constructor to improve performance.
-    # "experimental/material_3_demo"
+    "experimental/material_3_demo"
     "experimental/pedometer"
     "experimental/varfont_shader_puzzle"
     "experimental/web_dashboard"

--- a/tool/flutter_ci_script_master.sh
+++ b/tool/flutter_ci_script_master.sh
@@ -49,8 +49,7 @@ declare -ar PROJECT_NAMES=(
     "ios_app_clip"
     "isolate_example"
     "jsonexample"
-    # TODO(DomesticMouse): Use 'const' with the constructor to improve performance.
-    # "material_3_demo"
+    "material_3_demo"
     # TODO(DomesticMouse): The '!' will have no effect because the receiver can't be null.
     # "navigation_and_routing"
     # TODO(DomesticMouse): Use 'const' with the constructor to improve performance.


### PR DESCRIPTION
Hey @QuncCccccc I'm seeing a bunch of warnings for `window` deprecation. It looks like I turned off CI for `experimental/material_3_demo` but I'd like to turn it back on. Can you look at the warnings on the CI for this PR and suggest appropriate fixes?

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md