### PR TITLE
Use SliverList and cache content height

### DIFF
--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -49,19 +49,22 @@ class FirstComponentList extends StatelessWidget {
       child: CustomScrollView(
         slivers: [
           SliverPadding(
-              padding: showSecondList
-                  ? const EdgeInsetsDirectional.only(end: smallSpacing)
-                  : EdgeInsets.zero,
-              sliver: SliverList(
-                  delegate: BuildSlivers(
-                      heights: heights,
-                      builder: (context, index) {
-                        return _CacheHeight(
-                          heights: heights,
-                          index: index,
-                          child: children[index],
-                        );
-                      }))),
+            padding: showSecondList
+                ? const EdgeInsetsDirectional.only(end: smallSpacing)
+                : EdgeInsets.zero,
+            sliver: SliverList(
+              delegate: BuildSlivers(
+                heights: heights,
+                builder: (context, index) {
+                  return _CacheHeight(
+                    heights: heights,
+                    index: index,
+                    child: children[index],
+                  );
+                },
+              ),
+            ),
+          ),
         ],
       ),
     );
@@ -95,14 +98,15 @@ class SecondComponentList extends StatelessWidget {
             padding: const EdgeInsetsDirectional.only(end: smallSpacing),
             sliver: SliverList(
               delegate: BuildSlivers(
-                  heights: heights,
-                  builder: (context, index) {
-                    return _CacheHeight(
-                      heights: heights,
-                      index: index,
-                      child: children[index],
-                    );
-                  }),
+                heights: heights,
+                builder: (context, index) {
+                  return _CacheHeight(
+                    heights: heights,
+                    index: index,
+                    child: children[index],
+                  );
+                },
+              ),
             ),
           ),
         ],

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
 const rowDivider = SizedBox(width: 20);
@@ -26,26 +27,44 @@ class FirstComponentList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    List<Widget> children = [
+      const Actions(),
+      colDivider,
+      const Communication(),
+      colDivider,
+      const Containment(),
+      if (!showSecondList) ...[
+        colDivider,
+        Navigation(scaffoldKey: scaffoldKey),
+        colDivider,
+        const Selection(),
+        colDivider,
+        const TextInputs()
+      ],
+    ];
+    List<double?> heights = List.filled(children.length, null);
+
     // Fully traverse this list before moving on.
     return FocusTraversalGroup(
-      child: ListView(
-        padding: showSecondList
-            ? const EdgeInsetsDirectional.only(end: smallSpacing)
-            : EdgeInsets.zero,
-        children: [
-          const Actions(),
-          colDivider,
-          const Communication(),
-          colDivider,
-          const Containment(),
-          if (!showSecondList) ...[
-            colDivider,
-            Navigation(scaffoldKey: scaffoldKey),
-            colDivider,
-            const Selection(),
-            colDivider,
-            const TextInputs()
-          ],
+      child: CustomScrollView(
+        slivers: [
+          SliverPadding(
+            padding: showSecondList
+              ? const EdgeInsetsDirectional.only(end: smallSpacing)
+              : EdgeInsets.zero,
+            sliver: SliverList(
+              delegate: BuildSlivers(
+                heights: heights,
+                builder: (context, index) {
+                  return _CacheHeight(
+                    heights: heights,
+                    index: index,
+                    child: children[index],
+                  );
+                }
+              )
+            )
+          ),
         ],
       ),
     );
@@ -62,19 +81,118 @@ class SecondComponentList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    List<Widget> children = [
+      Navigation(scaffoldKey: scaffoldKey),
+      colDivider,
+      const Selection(),
+      colDivider,
+      const TextInputs(),
+    ];
+    List<double?> heights = List.filled(children.length, null);
+
     // Fully traverse this list before moving on.
     return FocusTraversalGroup(
-      child: ListView(
-        padding: const EdgeInsetsDirectional.only(end: smallSpacing),
-        children: <Widget>[
-          Navigation(scaffoldKey: scaffoldKey),
-          colDivider,
-          const Selection(),
-          colDivider,
-          const TextInputs(),
+      child: CustomScrollView(
+        slivers: [
+          SliverPadding(
+            padding: const EdgeInsetsDirectional.only(end: smallSpacing),
+            sliver: SliverList(
+              delegate: BuildSlivers(
+                heights: heights,
+                builder: (context, index) {
+                  return _CacheHeight(
+                    heights: heights,
+                    index: index,
+                    child: children[index],
+                  );
+                }
+              ),
+            ),
+          ),
         ],
       ),
     );
+  }
+}
+
+// Based on the fact that the list content is fixed, we cache
+// the height of the content during the first-time scrolling.
+// The cached height can be used to override
+// `SliverChildDelegate.estimateMaxScrollOffset`, to avoid a shaking scrollbar.
+class _CacheHeight extends SingleChildRenderObjectWidget {
+  const _CacheHeight({
+    super.child,
+    required this.heights,
+    required this.index,
+  });
+
+  final List<double?> heights;
+  final int index;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderCacheHeight(
+      heights: heights,
+      index: index,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, _RenderCacheHeight renderObject) {
+    renderObject
+      ..heights = heights
+      ..index = index;
+  }
+}
+
+class _RenderCacheHeight extends RenderProxyBox {
+  _RenderCacheHeight({
+    required List<double?> heights,
+    required int index,
+  }) : _heights = heights,
+        _index = index,
+        super();
+
+  List<double?> _heights;
+  List<double?> get heights => _heights;
+  set heights(List<double?> value) {
+    if (value == _heights) {
+      return;
+    }
+    _heights = value;
+    markNeedsLayout();
+  }
+
+  int _index;
+  int get index => _index;
+  set index(int value) {
+    if (value == index) {
+      return;
+    }
+    _index = value;
+    markNeedsLayout();
+  }
+
+  @override
+  void performLayout() {
+    super.performLayout();
+    heights[index] = size.height;
+  }
+}
+
+// The heights information is used to override the `estimateMaxScrollOffset` and
+// provide a more accurate estimation for the max scroll offset.
+class BuildSlivers extends SliverChildBuilderDelegate {
+  BuildSlivers({
+    required NullableIndexedWidgetBuilder builder,
+    required this.heights,
+  }) : super(builder, childCount: heights.length);
+
+  final List<double?> heights;
+
+  @override
+  double? estimateMaxScrollOffset(int firstIndex, int lastIndex, double leadingScrollOffset, double trailingScrollOffset) {
+    return heights.reduce((sum, height) => (sum ?? 0) + (height ?? 0))!;
   }
 }
 

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -49,22 +49,19 @@ class FirstComponentList extends StatelessWidget {
       child: CustomScrollView(
         slivers: [
           SliverPadding(
-            padding: showSecondList
-              ? const EdgeInsetsDirectional.only(end: smallSpacing)
-              : EdgeInsets.zero,
-            sliver: SliverList(
-              delegate: BuildSlivers(
-                heights: heights,
-                builder: (context, index) {
-                  return _CacheHeight(
-                    heights: heights,
-                    index: index,
-                    child: children[index],
-                  );
-                }
-              )
-            )
-          ),
+              padding: showSecondList
+                  ? const EdgeInsetsDirectional.only(end: smallSpacing)
+                  : EdgeInsets.zero,
+              sliver: SliverList(
+                  delegate: BuildSlivers(
+                      heights: heights,
+                      builder: (context, index) {
+                        return _CacheHeight(
+                          heights: heights,
+                          index: index,
+                          child: children[index],
+                        );
+                      }))),
         ],
       ),
     );
@@ -98,15 +95,14 @@ class SecondComponentList extends StatelessWidget {
             padding: const EdgeInsetsDirectional.only(end: smallSpacing),
             sliver: SliverList(
               delegate: BuildSlivers(
-                heights: heights,
-                builder: (context, index) {
-                  return _CacheHeight(
-                    heights: heights,
-                    index: index,
-                    child: children[index],
-                  );
-                }
-              ),
+                  heights: heights,
+                  builder: (context, index) {
+                    return _CacheHeight(
+                      heights: heights,
+                      index: index,
+                      child: children[index],
+                    );
+                  }),
             ),
           ),
         ],
@@ -138,7 +134,8 @@ class _CacheHeight extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, _RenderCacheHeight renderObject) {
+  void updateRenderObject(
+      BuildContext context, _RenderCacheHeight renderObject) {
     renderObject
       ..heights = heights
       ..index = index;
@@ -149,7 +146,7 @@ class _RenderCacheHeight extends RenderProxyBox {
   _RenderCacheHeight({
     required List<double?> heights,
     required int index,
-  }) : _heights = heights,
+  })  : _heights = heights,
         _index = index,
         super();
 
@@ -191,7 +188,8 @@ class BuildSlivers extends SliverChildBuilderDelegate {
   final List<double?> heights;
 
   @override
-  double? estimateMaxScrollOffset(int firstIndex, int lastIndex, double leadingScrollOffset, double trailingScrollOffset) {
+  double? estimateMaxScrollOffset(int firstIndex, int lastIndex,
+      double leadingScrollOffset, double trailingScrollOffset) {
     return heights.reduce((sum, height) => (sum ?? 0) + (height ?? 0))!;
   }
 }

--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -115,10 +115,15 @@ class SecondComponentList extends StatelessWidget {
   }
 }
 
-// Based on the fact that the list content is fixed, we cache
-// the height of the content during the first-time scrolling.
-// The cached height can be used to override
-// `SliverChildDelegate.estimateMaxScrollOffset`, to avoid a shaking scrollbar.
+// If the content of a CustomScrollView does not change, then it's
+// safe to cache the heights of each item as they are laid out. The
+// sum of the cached heights are returned by an override of
+// `SliverChildDelegate.estimateMaxScrollOffset`. The default version
+// of this method bases its estimate on the average height of the
+// visible items. The override ensures that the scrollbar thumb's
+// size, which depends on the max scroll offset, will shrink smoothly
+// as the contents of the list are exposed for the first time, and
+// then remain fixed.
 class _CacheHeight extends SingleChildRenderObjectWidget {
   const _CacheHeight({
     super.child,

--- a/experimental/material_3_demo/lib/home.dart
+++ b/experimental/material_3_demo/lib/home.dart
@@ -129,11 +129,6 @@ class _HomeState extends State<Home> with SingleTickerProviderStateMixin {
         return const TypographyScreen();
       case ScreenSelected.elevation:
         return const ElevationScreen();
-      default:
-        return FirstComponentList(
-            showNavBottomBar: showNavBarExample,
-            scaffoldKey: scaffoldKey,
-            showSecondList: showMediumSizeLayout || showLargeSizeLayout);
     }
   }
 

--- a/material_3_demo/lib/component_screen.dart
+++ b/material_3_demo/lib/component_screen.dart
@@ -49,19 +49,22 @@ class FirstComponentList extends StatelessWidget {
       child: CustomScrollView(
         slivers: [
           SliverPadding(
-              padding: showSecondList
-                  ? const EdgeInsetsDirectional.only(end: smallSpacing)
-                  : EdgeInsets.zero,
-              sliver: SliverList(
-                  delegate: BuildSlivers(
-                      heights: heights,
-                      builder: (context, index) {
-                        return _CacheHeight(
-                          heights: heights,
-                          index: index,
-                          child: children[index],
-                        );
-                      }))),
+            padding: showSecondList
+                ? const EdgeInsetsDirectional.only(end: smallSpacing)
+                : EdgeInsets.zero,
+            sliver: SliverList(
+              delegate: BuildSlivers(
+                heights: heights,
+                builder: (context, index) {
+                  return _CacheHeight(
+                    heights: heights,
+                    index: index,
+                    child: children[index],
+                  );
+                },
+              ),
+            ),
+          ),
         ],
       ),
     );
@@ -95,14 +98,15 @@ class SecondComponentList extends StatelessWidget {
             padding: const EdgeInsetsDirectional.only(end: smallSpacing),
             sliver: SliverList(
               delegate: BuildSlivers(
-                  heights: heights,
-                  builder: (context, index) {
-                    return _CacheHeight(
-                      heights: heights,
-                      index: index,
-                      child: children[index],
-                    );
-                  }),
+                heights: heights,
+                builder: (context, index) {
+                  return _CacheHeight(
+                    heights: heights,
+                    index: index,
+                    child: children[index],
+                  );
+                },
+              ),
             ),
           ),
         ],

--- a/material_3_demo/lib/component_screen.dart
+++ b/material_3_demo/lib/component_screen.dart
@@ -61,10 +61,7 @@ class FirstComponentList extends StatelessWidget {
                           index: index,
                           child: children[index],
                         );
-                      }
-                  )
-              )
-          ),
+                      }))),
         ],
       ),
     );
@@ -105,8 +102,7 @@ class SecondComponentList extends StatelessWidget {
                       index: index,
                       child: children[index],
                     );
-                  }
-              ),
+                  }),
             ),
           ),
         ],
@@ -138,7 +134,8 @@ class _CacheHeight extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, _RenderCacheHeight renderObject) {
+  void updateRenderObject(
+      BuildContext context, _RenderCacheHeight renderObject) {
     renderObject
       ..heights = heights
       ..index = index;
@@ -149,7 +146,7 @@ class _RenderCacheHeight extends RenderProxyBox {
   _RenderCacheHeight({
     required List<double?> heights,
     required int index,
-  }) : _heights = heights,
+  })  : _heights = heights,
         _index = index,
         super();
 
@@ -191,7 +188,8 @@ class BuildSlivers extends SliverChildBuilderDelegate {
   final List<double?> heights;
 
   @override
-  double? estimateMaxScrollOffset(int firstIndex, int lastIndex, double leadingScrollOffset, double trailingScrollOffset) {
+  double? estimateMaxScrollOffset(int firstIndex, int lastIndex,
+      double leadingScrollOffset, double trailingScrollOffset) {
     return heights.reduce((sum, height) => (sum ?? 0) + (height ?? 0))!;
   }
 }

--- a/material_3_demo/lib/component_screen.dart
+++ b/material_3_demo/lib/component_screen.dart
@@ -115,10 +115,15 @@ class SecondComponentList extends StatelessWidget {
   }
 }
 
-// Based on the fact that the list content is fixed, we cache
-// the height of the content during the first-time scrolling.
-// The cached height can be used to override
-// `SliverChildDelegate.estimateMaxScrollOffset`, to avoid a shaking scrollbar.
+// If the content of a CustomScrollView does not change, then it's
+// safe to cache the heights of each item as they are laid out. The
+// sum of the cached heights are returned by an override of
+// `SliverChildDelegate.estimateMaxScrollOffset`. The default version
+// of this method bases its estimate on the average height of the
+// visible items. The override ensures that the scrollbar thumb's
+// size, which depends on the max scroll offset, will shrink smoothly
+// as the contents of the list are exposed for the first time, and
+// then remain fixed.
 class _CacheHeight extends SingleChildRenderObjectWidget {
   const _CacheHeight({
     super.child,

--- a/material_3_demo/lib/home.dart
+++ b/material_3_demo/lib/home.dart
@@ -129,11 +129,6 @@ class _HomeState extends State<Home> with SingleTickerProviderStateMixin {
         return const TypographyScreen();
       case ScreenSelected.elevation:
         return const ElevationScreen();
-      default:
-        return FirstComponentList(
-            showNavBottomBar: showNavBarExample,
-            scaffoldKey: scaffoldKey,
-            showSecondList: showMediumSizeLayout || showLargeSizeLayout);
     }
   }
 


### PR DESCRIPTION
Fixes #1694
This PR is to fix the shaking scrollbar problem. We replace the `ListView`s with `CustomScrollView` and cache the content height to provide a better estimation for the max scroll offset.

Same changes are applied to both Material 3 demo in the root directory and the M3 demo in the `/experimental/`


https://github.com/flutter/samples/assets/36861262/24041a84-64e7-480e-8ea3-0d0811038818


https://github.com/flutter/samples/assets/36861262/9f274109-f698-4522-8316-7c75b2596c8b



## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
