### PR TITLE
Reduce dependabot pull requests for web_embedding

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -224,4 +224,6 @@ updates:
   - package-ecosystem: "npm"
     directory: "web_embedding/ng-flutter"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    allow:
+      - dependency-type: "direct"


### PR DESCRIPTION
This configures dependabot to check for out-of-date NPM packages weekly instead of daily, and limits it to direct dependencies. There could be more we could do if we dig through the [Configuration options for the dependabot.yml file](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) documentation.

cc: @ditman 

fixes #1809
