### PR TITLE
`web/samples_index` Drop unused `links` attribute from config

### DIFF
--- a/web/samples_index/lib/src/data.dart
+++ b/web/samples_index/lib/src/data.dart
@@ -68,9 +68,6 @@ class Sample {
   /// 'web'
   final List<String> platforms;
 
-  /// Links to display on the details page
-  final List<Link> links;
-
   /// The type of the sample. Supported values are either 'sample' or
   /// 'cookbook'.
   final String type;
@@ -94,7 +91,6 @@ class Sample {
     this.packages = const [],
     this.tags = const [],
     this.platforms = const [],
-    this.links = const [],
     required this.type,
     this.date,
     this.channel,
@@ -171,17 +167,4 @@ class Screenshot {
       _$ScreenshotFromJson(json);
 
   Map<String, dynamic> toJson() => _$ScreenshotToJson(this);
-}
-
-/// An external link displayed next to a sample
-@JsonSerializable(anyMap: true, checked: true)
-class Link {
-  final String text;
-  final String href;
-
-  Link(this.text, this.href);
-
-  factory Link.fromJson(Map<dynamic, dynamic> json) => _$LinkFromJson(json);
-
-  Map<String, dynamic> toJson() => _$LinkToJson(this);
 }

--- a/web/samples_index/lib/src/data.g.dart
+++ b/web/samples_index/lib/src/data.g.dart
@@ -62,13 +62,6 @@ Sample _$SampleFromJson(Map json) => $checkedCreate(
               (v) =>
                   (v as List<dynamic>?)?.map((e) => e as String).toList() ??
                   const []),
-          links: $checkedConvert(
-              'links',
-              (v) =>
-                  (v as List<dynamic>?)
-                      ?.map((e) => Link.fromJson(e as Map))
-                      .toList() ??
-                  const []),
           type: $checkedConvert('type', (v) => v as String),
           date: $checkedConvert(
               'date', (v) => v == null ? null : DateTime.parse(v as String)),
@@ -90,7 +83,6 @@ Map<String, dynamic> _$SampleToJson(Sample instance) => <String, dynamic>{
       'packages': instance.packages,
       'tags': instance.tags,
       'platforms': instance.platforms,
-      'links': instance.links,
       'type': instance.type,
       'date': instance.date?.toIso8601String(),
       'channel': instance.channel,
@@ -112,21 +104,4 @@ Map<String, dynamic> _$ScreenshotToJson(Screenshot instance) =>
     <String, dynamic>{
       'url': instance.url,
       'alt': instance.alt,
-    };
-
-Link _$LinkFromJson(Map json) => $checkedCreate(
-      'Link',
-      json,
-      ($checkedConvert) {
-        final val = Link(
-          $checkedConvert('text', (v) => v as String),
-          $checkedConvert('href', (v) => v as String),
-        );
-        return val;
-      },
-    );
-
-Map<String, dynamic> _$LinkToJson(Link instance) => <String, dynamic>{
-      'text': instance.text,
-      'href': instance.href,
     };

--- a/web/samples_index/lib/src/samples.yaml
+++ b/web/samples_index/lib/src/samples.yaml
@@ -83,7 +83,6 @@ samples:
       - scoped_model
     tags: ['intermediate', 'sample', 'gallery', 'material', 'design', 'vignettes']
     platforms: ['web', 'ios', 'android']
-    links: []
     type: demo
 
   - name: Add to App
@@ -106,7 +105,6 @@ samples:
       - provider
     tags: ['advanced', 'sample', 'add-to-app', 'android', 'ios', 'native', 'embedding']
     platforms: ['ios', 'android']
-    links: []
     type: sample
 
   - name: Code Sharing
@@ -124,7 +122,6 @@ samples:
       - shelf
     tags: ['intermediate', 'sample', 'code-sharing', 'dart', 'server']
     platforms: ['android', 'ios', 'linux', 'macos', 'web', 'windows']
-    links: []
     type: sample
 
   - name: Animations
@@ -153,7 +150,6 @@ samples:
       - flutter/material
     tags: ['intermediate', 'sample', 'animation']
     platforms: ['ios', 'android', 'web']
-    links: []
     type: sample
     web: web/animations
 
@@ -178,7 +174,6 @@ samples:
       - google_maps_webservice
     tags: ['intermediate', 'sample', 'firebase', 'maps']
     platforms: ['ios', 'android']
-    links: []
     type: sample
 
   - name: Isolate Example
@@ -203,7 +198,6 @@ samples:
       - dart:math
     tags: ['intermediate', 'sample', 'isolates', 'concurrency']
     platforms: ['ios', 'android']
-    links: []
     type: sample
 
   - name: jsonexample
@@ -232,7 +226,6 @@ samples:
       - built_value_generator
     tags: ['beginner', 'sample']
     platforms: ['ios', 'android']
-    links: []
     type: sample
 
   - name: Place Tracker
@@ -259,7 +252,6 @@ samples:
       - google_maps_flutter
     tags: ['intermediate', 'sample', 'json', 'serialization']
     platforms: ['android']
-    links: []
     type: sample
 
   - name: Platform Design
@@ -291,7 +283,6 @@ samples:
       - flutter/cupertino
     tags: ['advanced', 'sample', 'ios']
     platforms: ['ios', 'android']
-    links: []
     type: sample
 
   - name: Platform View Swift
@@ -313,7 +304,6 @@ samples:
       - flutter/services
     tags: ['advanced', 'sample', 'ios']
     platforms: ['ios']
-    links: []
     type: sample
 
   - name: Infinite List
@@ -338,7 +328,6 @@ samples:
       - meta
     tags: ['sample', 'material', 'design', 'android', 'ios']
     platforms: ['ios', 'android']
-    links: []
     type: sample
 
   - name: IOS App Clip
@@ -359,7 +348,6 @@ samples:
       - device_info
     tags: ['sample', 'Device Info', 'ios']
     platforms: ['ios']
-    links: []
     type: sample
 
   - name: Testing App
@@ -382,7 +370,6 @@ samples:
       - provider
     tags: ['sample', 'material', 'android', 'ios']
     platforms: ['ios', 'android']
-    links: []
     type: sample
 
   - name: Provider Shopper
@@ -406,7 +393,6 @@ samples:
       - provider
     tags: ['intermediate', 'sample', 'provider']
     platforms: ['ios', 'android', 'web']
-    links: []
     type: sample
     web: web/provider_shopper
 
@@ -433,7 +419,6 @@ samples:
       - firebase
     tags: ['intermediate', 'sample', 'firebase']
     platforms: ['ios', 'android', 'web']
-    links: []
     type: sample
     web: web/web_dashboard
 
@@ -455,7 +440,6 @@ samples:
     packages: []
     tags: ['intermediate', 'sample', 'forms']
     platforms: ['ios', 'android', 'web']
-    links: []
     type: sample
     web: web/form_app
     
@@ -480,7 +464,6 @@ samples:
     packages: []
     tags: ['advanced', 'sample', 'navigation', 'router']
     platforms: ['ios', 'android', 'web']
-    links: []
     type: sample
     web: web/navigation_and_routing
     
@@ -522,7 +505,6 @@ samples:
     widgets: []
     packages: []
     platforms: ['web']
-    links: []
     tags: ['demo', 'game']
     type: demo
 
@@ -546,7 +528,6 @@ samples:
     widgets:
       - TextInput
     packages: []
-    links: []
     tags: ["demo", "text"]
     platforms: ["ios", "android", "web", "windows", "macos", "linux"]
     type: demo
@@ -579,7 +560,6 @@ samples:
       - Card
       - AppBar
     packages: []
-    links: []
     tags: ["material", "design"]
     platforms: ["ios", "android", "web", "windows", "macos", "linux"]
     type: demo
@@ -611,7 +591,6 @@ samples:
       - logging
       - provider
       - shared_preferences
-    links: []
     tags: ["games", "firebase", "ads", "crashlytics", "routing"]
     platforms: ["ios", "android", "web", "windows", "macos", "linux"]
     type: demo
@@ -629,7 +608,6 @@ samples:
     widgets: []
     packages: []
     platforms: ['web']
-    links: []
     tags: ['demo', 'animation']
     web: https://z.flutter.gallery/#/dice
     type: demo
@@ -648,7 +626,6 @@ samples:
     widgets: []
     packages: []
     platforms: ['web']
-    links: []
     tags: ['demo', 'web', 'add-to-app', 'embedding']
     web: https://flutter-angular.web.app/
     type: sample
@@ -665,8 +642,5 @@ samples:
       - flutter_animate
     platforms:
       - Windows, macOS, Linux, web, Android, iOS
-    links:
-      - href: https://codelabs.developers.google.com/codelabs/flutter-next-gen-uis
-        text: Codelab
     type: sample
     web: web/next_gen_ui_demo

--- a/web/samples_index/test/samples_index_test.dart
+++ b/web/samples_index/test/samples_index_test.dart
@@ -38,9 +38,6 @@ void main() {
       expect(sample.tags, hasLength(3));
       expect(sample.tags[1], 'kittens');
       expect(sample.platforms, hasLength(3));
-      expect(sample.links, hasLength(2));
-      expect(sample.links[1].text, 'author');
-      expect(sample.links[1].href, 'https://jpryan.me');
       expect(sample.type, 'sample');
       expect(sample.date, DateTime.parse('2019-12-15T02:59:43.1Z'));
       expect(sample.channel, 'stable');

--- a/web/samples_index/test/yaml/single.yaml
+++ b/web/samples_index/test/yaml/single.yaml
@@ -16,11 +16,6 @@ samples:
       - path
     tags: ['beginner', 'kittens', 'cats']
     platforms: ['web', 'ios', 'android']
-    links:
-      - text: inspiration
-        href: https://apps.apple.com/us/app/neko-atsume-kitty-collector/id923917775
-      - text: author
-        href: https://jpryan.me
     type: sample # sample, app, or cookbook
     date: 2019-12-15T02:59:43.1Z
     channel: stable


### PR DESCRIPTION
I've confirmed that the `links` configuration attribute is indeed unused: https://flutter.github.io/samples/next_gen_u_i_demo.html

Dropping unused configuration sounds like a good move. We can re-introduce it if/when we start displaying the content.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md