### PR TITLE
Make element embedding demo show up under "Web Demos" section

### DIFF
--- a/web/samples_index/lib/src/samples.yaml
+++ b/web/samples_index/lib/src/samples.yaml
@@ -628,7 +628,7 @@ samples:
     platforms: ['web']
     tags: ['demo', 'web', 'add-to-app', 'embedding']
     web: https://flutter-angular.web.app/
-    type: sample
+    type: demo
 
   - name: Next Gen UI demo
     author: Flutter


### PR DESCRIPTION
Using the "demo" type will make the sample visible under the [Web Demos](https://flutter.github.io/samples/#?platform=web) section of the site.