### PR TITLE
Fix links to material 3 demo assets

### DIFF
--- a/experimental/material_3_demo/lib/constants.dart
+++ b/experimental/material_3_demo/lib/constants.dart
@@ -38,17 +38,17 @@ enum ColorSeed {
 
 enum ColorImageProvider {
   leaves('Leaves',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_1.png'),
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_1.png?raw=true'),
   peonies('Peonies',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_2.png'),
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_2.png?raw=true'),
   bubbles('Bubbles',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_3.png'),
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_3.png?raw=true'),
   seaweed('Seaweed',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_4.png'),
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_4.png?raw=true'),
   seagrapes('Sea Grapes',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_5.png'),
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_5.png?raw=true'),
   petals('Petals',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_6.png');
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_6.png?raw=true');
 
   const ColorImageProvider(this.label, this.url);
   final String label;

--- a/material_3_demo/lib/constants.dart
+++ b/material_3_demo/lib/constants.dart
@@ -38,17 +38,17 @@ enum ColorSeed {
 
 enum ColorImageProvider {
   leaves('Leaves',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_1.png'),
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_1.png?raw=true'),
   peonies('Peonies',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_2.png'),
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_2.png?raw=true'),
   bubbles('Bubbles',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_3.png'),
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_3.png?raw=true'),
   seaweed('Seaweed',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_4.png'),
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_4.png?raw=true'),
   seagrapes('Sea Grapes',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_5.png'),
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_5.png?raw=true'),
   petals('Petals',
-      'https://flutter.github.io/assets-for-api-docs/assets/material/content_based_color_scheme_6.png');
+      'https://github.com/flutter/assets-for-api-docs/blob/main/assets/material/content_based_color_scheme_6.png?raw=true');
 
   const ColorImageProvider(this.label, this.url);
   final String label;


### PR DESCRIPTION
This fixes the URLs for the material 3 image assets

See https://github.com/flutter/samples/issues/1844 for more details