### PR TITLE
`next_gen_ui_demo`: Dispose of old `AnimationController`s

### DIFF
--- a/next_gen_ui_demo/lib/main.dart
+++ b/next_gen_ui_demo/lib/main.dart
@@ -74,7 +74,17 @@ List<
 typedef ColorCallback = void Function(Color colorSchemeSeed);
 
 class _NextGenAppState extends State<NextGenApp> {
-  int step = 0;
+  int _step = 0;
+  int get step => _step;
+  set step(int i) {
+    _step = switch (i) {
+      (int a) when a < 0 => 0,
+      (int a) when a >= steps.length => steps.length - 1,
+      _ => i,
+    };
+    debugPrint('Step ${step + 1} of ${steps.length}');
+  }
+
   Color? colorSchemeSeed;
 
   @override
@@ -107,8 +117,7 @@ class _NextGenAppState extends State<NextGenApp> {
                 child: const Icon(Icons.arrow_back),
                 onPressed: () {
                   setState(() {
-                    if (step > 0) step--;
-                    debugPrint('Step = $step');
+                    step--;
                   });
                 },
               ),
@@ -123,8 +132,7 @@ class _NextGenAppState extends State<NextGenApp> {
                 child: const Icon(Icons.arrow_forward),
                 onPressed: () {
                   setState(() {
-                    if (step + 1 < steps.length) step++;
-                    debugPrint('Step = $step');
+                    step++;
                   });
                 },
               ),
@@ -140,7 +148,6 @@ class _NextGenAppState extends State<NextGenApp> {
                     onPressed: () {
                       setState(() {
                         step = 0;
-                        debugPrint('Step = $step');
                       });
                     },
                   ),

--- a/next_gen_ui_demo/lib/title_screen_4c/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_4c/title_screen_ui.dart
@@ -258,9 +258,8 @@ class _StartBtnState extends State<_StartBtn> {
               .animate(
                 autoPlay: false,
                 onInit: (c) {
-                  final btnAnim = _btnAnim;
-                  if (btnAnim != null && btnAnim != c) {
-                    btnAnim.dispose();
+                  if (_btnAnim != null && _btnAnim != c) {
+                    _btnAnim?.dispose();
                   }
                   _btnAnim = c;
                 },

--- a/next_gen_ui_demo/lib/title_screen_4c/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_4c/title_screen_ui.dart
@@ -255,7 +255,16 @@ class _StartBtnState extends State<_StartBtn> {
               ),
             ],
           )
-              .animate(autoPlay: false, onInit: (c) => _btnAnim = c)
+              .animate(
+                autoPlay: false,
+                onInit: (c) {
+                  final btnAnim = _btnAnim;
+                  if (btnAnim != null && btnAnim != c) {
+                    btnAnim.dispose();
+                  }
+                  _btnAnim = c;
+                },
+              )
               .shimmer(duration: .7.seconds, color: Colors.black),
         )
             .animate()

--- a/next_gen_ui_demo/lib/title_screen_4d/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_4d/title_screen_ui.dart
@@ -261,7 +261,16 @@ class _StartBtnState extends State<_StartBtn> {
               ),
             ],
           )
-              .animate(autoPlay: false, onInit: (c) => _btnAnim = c)
+              .animate(
+                autoPlay: false,
+                onInit: (c) {
+                  final btnAnim = _btnAnim;
+                  if (btnAnim != null && btnAnim != c) {
+                    btnAnim.dispose();
+                  }
+                  _btnAnim = c;
+                },
+              )
               .shimmer(duration: .7.seconds, color: Colors.black),
         )
             .animate()

--- a/next_gen_ui_demo/lib/title_screen_4d/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_4d/title_screen_ui.dart
@@ -264,9 +264,8 @@ class _StartBtnState extends State<_StartBtn> {
               .animate(
                 autoPlay: false,
                 onInit: (c) {
-                  final btnAnim = _btnAnim;
-                  if (btnAnim != null && btnAnim != c) {
-                    btnAnim.dispose();
+                  if (_btnAnim != null && _btnAnim != c) {
+                    _btnAnim?.dispose();
                   }
                   _btnAnim = c;
                 },

--- a/next_gen_ui_demo/lib/title_screen_4e/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_4e/title_screen_ui.dart
@@ -261,7 +261,16 @@ class _StartBtnState extends State<_StartBtn> {
               ),
             ],
           )
-              .animate(autoPlay: false, onInit: (c) => _btnAnim = c)
+              .animate(
+                autoPlay: false,
+                onInit: (c) {
+                  final btnAnim = _btnAnim;
+                  if (btnAnim != null && btnAnim != c) {
+                    btnAnim.dispose();
+                  }
+                  _btnAnim = c;
+                },
+              )
               .shimmer(duration: .7.seconds, color: Colors.black),
         )
             .animate()

--- a/next_gen_ui_demo/lib/title_screen_4e/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_4e/title_screen_ui.dart
@@ -264,9 +264,8 @@ class _StartBtnState extends State<_StartBtn> {
               .animate(
                 autoPlay: false,
                 onInit: (c) {
-                  final btnAnim = _btnAnim;
-                  if (btnAnim != null && btnAnim != c) {
-                    btnAnim.dispose();
+                  if (_btnAnim != null && _btnAnim != c) {
+                    _btnAnim?.dispose();
                   }
                   _btnAnim = c;
                 },

--- a/next_gen_ui_demo/lib/title_screen_5a/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_5a/title_screen_ui.dart
@@ -287,7 +287,16 @@ class _StartBtnState extends State<_StartBtn> {
               ),
             ],
           )
-              .animate(autoPlay: false, onInit: (c) => _btnAnim = c)
+              .animate(
+                autoPlay: false,
+                onInit: (c) {
+                  final btnAnim = _btnAnim;
+                  if (btnAnim != null && btnAnim != c) {
+                    btnAnim.dispose();
+                  }
+                  _btnAnim = c;
+                },
+              )
               .shimmer(duration: .7.seconds, color: Colors.black),
         )
             .animate()

--- a/next_gen_ui_demo/lib/title_screen_5a/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_5a/title_screen_ui.dart
@@ -290,9 +290,8 @@ class _StartBtnState extends State<_StartBtn> {
               .animate(
                 autoPlay: false,
                 onInit: (c) {
-                  final btnAnim = _btnAnim;
-                  if (btnAnim != null && btnAnim != c) {
-                    btnAnim.dispose();
+                  if (_btnAnim != null && _btnAnim != c) {
+                    _btnAnim?.dispose();
                   }
                   _btnAnim = c;
                 },

--- a/next_gen_ui_demo/lib/title_screen_5b/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_5b/title_screen_ui.dart
@@ -289,7 +289,16 @@ class _StartBtnState extends State<_StartBtn> {
               ),
             ],
           )
-              .animate(autoPlay: false, onInit: (c) => _btnAnim = c)
+              .animate(
+                autoPlay: false,
+                onInit: (c) {
+                  final btnAnim = _btnAnim;
+                  if (btnAnim != null && btnAnim != c) {
+                    btnAnim.dispose();
+                  }
+                  _btnAnim = c;
+                },
+              )
               .shimmer(duration: .7.seconds, color: Colors.black),
         )
             .animate()

--- a/next_gen_ui_demo/lib/title_screen_5b/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_5b/title_screen_ui.dart
@@ -292,9 +292,8 @@ class _StartBtnState extends State<_StartBtn> {
               .animate(
                 autoPlay: false,
                 onInit: (c) {
-                  final btnAnim = _btnAnim;
-                  if (btnAnim != null && btnAnim != c) {
-                    btnAnim.dispose();
+                  if (_btnAnim != null && _btnAnim != c) {
+                    _btnAnim?.dispose();
                   }
                   _btnAnim = c;
                 },

--- a/next_gen_ui_demo/lib/title_screen_6/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_6/title_screen_ui.dart
@@ -289,7 +289,16 @@ class _StartBtnState extends State<_StartBtn> {
               ),
             ],
           )
-              .animate(autoPlay: false, onInit: (c) => _btnAnim = c)
+              .animate(
+                autoPlay: false,
+                onInit: (c) {
+                  final btnAnim = _btnAnim;
+                  if (btnAnim != null && btnAnim != c) {
+                    btnAnim.dispose();
+                  }
+                  _btnAnim = c;
+                },
+              )
               .shimmer(duration: .7.seconds, color: Colors.black),
         )
             .animate()

--- a/next_gen_ui_demo/lib/title_screen_6/title_screen_ui.dart
+++ b/next_gen_ui_demo/lib/title_screen_6/title_screen_ui.dart
@@ -292,9 +292,8 @@ class _StartBtnState extends State<_StartBtn> {
               .animate(
                 autoPlay: false,
                 onInit: (c) {
-                  final btnAnim = _btnAnim;
-                  if (btnAnim != null && btnAnim != c) {
-                    btnAnim.dispose();
+                  if (_btnAnim != null && _btnAnim != c) {
+                    _btnAnim?.dispose();
                   }
                   _btnAnim = c;
                 },


### PR DESCRIPTION
Stop some leaks by disposing old `AnimationController`s.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md