### PR TITLE
`next_gen_ui_demo`: Make the tape player analogy complete

### DIFF
--- a/next_gen_ui_demo/lib/main.dart
+++ b/next_gen_ui_demo/lib/main.dart
@@ -111,9 +111,17 @@ class _NextGenAppState extends State<NextGenApp> {
         floatingActionButton: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Visibility(
-              visible: step > 0,
-              child: FloatingActionButton(
+            if (step > 0) ...[
+              FloatingActionButton(
+                child: const Icon(Icons.first_page),
+                onPressed: () {
+                  setState(() {
+                    step = 0;
+                  });
+                },
+              ),
+              const Gap(24),
+              FloatingActionButton(
                 child: const Icon(Icons.arrow_back),
                 onPressed: () {
                   setState(() {
@@ -121,14 +129,10 @@ class _NextGenAppState extends State<NextGenApp> {
                   });
                 },
               ),
-            ),
-            Visibility(
-              visible: step > 0 && step + 1 < steps.length,
-              child: const Gap(24),
-            ),
-            Visibility(
-              visible: step + 1 < steps.length,
-              child: FloatingActionButton(
+            ],
+            if (step > 0 && step + 1 < steps.length) const Gap(24),
+            if (step + 1 < steps.length) ...[
+              FloatingActionButton(
                 child: const Icon(Icons.arrow_forward),
                 onPressed: () {
                   setState(() {
@@ -136,24 +140,16 @@ class _NextGenAppState extends State<NextGenApp> {
                   });
                 },
               ),
-            ),
-            Visibility(
-              visible: step + 1 == steps.length,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Gap(24),
-                  FloatingActionButton(
-                    child: const Icon(Icons.restart_alt),
-                    onPressed: () {
-                      setState(() {
-                        step = 0;
-                      });
-                    },
-                  ),
-                ],
+              const Gap(24),
+              FloatingActionButton(
+                child: const Icon(Icons.last_page),
+                onPressed: () {
+                  setState(() {
+                    step = steps.length - 1;
+                  });
+                },
               ),
-            ),
+            ],
           ],
         ),
         backgroundColor: Colors.black,


### PR DESCRIPTION
Now we can skip to start and end, as well as single step. If only `FloatingActionButton`s could be disabled.

<img width="912" alt="Screenshot 2023-06-01 at 10 38 48 am" src="https://github.com/flutter/samples/assets/30503/0fee4056-a206-49ce-bad9-7c015558d88f">

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md