### PR TITLE
Add null safety check before displaying SnackBar

### DIFF
--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -1475,9 +1475,12 @@ class _TimePickersState extends State<TimePickers> {
           );
           setState(() {
             selectedTime = time;
-            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-              content: Text('Selected time: ${selectedTime!.format(context)}'),
-            ));
+            if (selectedTime != null) {
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                content:
+                    Text('Selected time: ${selectedTime!.format(context)}'),
+              ));
+            }
           });
         },
         child: const Text(

--- a/material_3_demo/lib/component_screen.dart
+++ b/material_3_demo/lib/component_screen.dart
@@ -1475,9 +1475,12 @@ class _TimePickersState extends State<TimePickers> {
           );
           setState(() {
             selectedTime = time;
-            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-              content: Text('Selected time: ${selectedTime!.format(context)}'),
-            ));
+            if (selectedTime != null) {
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                content:
+                    Text('Selected time: ${selectedTime!.format(context)}'),
+              ));
+            }
           });
         },
         child: const Text(


### PR DESCRIPTION
## Description

This PR adds a null check before showing a SnackBar with the selected time in `component_screen.dart`. Previously, the SnackBar was displayed regardless of whether the selected time was null, which could have caused a null exception. 

## Issue

*This PR fixes a potential issue where a null exception could be thrown if the selected time was null.*

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
