### PR TITLE
Fix Android CI

### DIFF
--- a/add_to_app/fullscreen/android_fullscreen/app/build.gradle
+++ b/add_to_app/fullscreen/android_fullscreen/app/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
     compileSdkVersion 33
     defaultConfig {
@@ -31,13 +29,13 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation project(':flutter')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation project(':espresso')
-    androidTestImplementation "com.google.truth:truth:0.42"
-    androidTestImplementation 'androidx.test:runner:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    api 'androidx.test:core:1.2.0'
+    androidTestImplementation "com.google.truth:truth:1.1.3"
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    api 'androidx.test:core:1.5.0'
 }

--- a/add_to_app/fullscreen/android_fullscreen/build.gradle
+++ b/add_to_app/fullscreen/android_fullscreen/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.0'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         mavenCentral()

--- a/add_to_app/multiple_flutters/multiple_flutters_android/build.gradle
+++ b/add_to_app/multiple_flutters/multiple_flutters_android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.6.0"
+    ext.kotlin_version = "1.8.22"
     repositories {
         google()
         mavenCentral()

--- a/add_to_app/plugin/android_using_plugin/app/build.gradle
+++ b/add_to_app/plugin/android_using_plugin/app/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
     compileSdkVersion 33
     defaultConfig {
@@ -28,10 +26,10 @@ android {
 dependencies {
     implementation project(':flutter')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/add_to_app/plugin/android_using_plugin/build.gradle
+++ b/add_to_app/plugin/android_using_plugin/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.0'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         mavenCentral()

--- a/add_to_app/prebuilt_module/android_using_prebuilt_module/app/build.gradle
+++ b/add_to_app/prebuilt_module/android_using_prebuilt_module/app/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
     compileSdkVersion 33
     defaultConfig {
@@ -50,12 +48,12 @@ dependencies {
 
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation "com.google.truth:truth:0.42"
-    androidTestImplementation 'androidx.test:runner:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    api 'androidx.test:core:1.2.0'
+    androidTestImplementation "com.google.truth:truth:1.1.3"
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    api 'androidx.test:core:1.5.0'
 }

--- a/add_to_app/prebuilt_module/android_using_prebuilt_module/build.gradle
+++ b/add_to_app/prebuilt_module/android_using_prebuilt_module/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
- kotlin version to 1.8.22
- remove deprecated kotlin-android-extensions and upgrade dependencies

Running the PR from the flutter/samples repo instead from a fork, so the Firebase device test step runs.

## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md