### PR TITLE
`desktop_photo_search`: `getSavePath` is deprecated

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -58,6 +58,10 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"
+    directory: "deeplink_store_example/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pub"
     directory: "desktop_photo_search/fluent_ui/"
     schedule:
       interval: "daily"
@@ -67,10 +71,6 @@ updates:
       interval: "daily"
   - package-ecosystem: "pub"
     directory: "experimental/context_menus/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "pub"
-    directory: "experimental/element_embedding_demo/"
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"
@@ -162,6 +162,10 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"
+    directory: "next_gen_ui_demo/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pub"
     directory: "place_tracker/"
     schedule:
       interval: "daily"
@@ -214,11 +218,11 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"
-    directory: "web_embedding/element_embedding_demo"
+    directory: "web_embedding/element_embedding_demo/"
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"
-    directory: "web_embedding/ng-flutter/flutter"
+    directory: "web_embedding/ng-flutter/flutter/"
     schedule:
       interval: "daily"
   - package-ecosystem: "npm"

--- a/desktop_photo_search/fluent_ui/lib/src/widgets/unsplash_search_content.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/widgets/unsplash_search_content.dart
@@ -48,7 +48,7 @@ class _UnsplashSearchContentState extends State<UnsplashSearchContent> {
             ? PhotoDetails(
                 photo: photoSearchModel.selectedPhoto!,
                 onPhotoSave: (photo) async {
-                  final path = await getSavePath(
+                  final saveLocation = await getSaveLocation(
                     suggestedName: '${photo.id}.jpg',
                     acceptedTypeGroups: [
                       const XTypeGroup(
@@ -58,12 +58,12 @@ class _UnsplashSearchContentState extends State<UnsplashSearchContent> {
                       ),
                     ],
                   );
-                  if (path != null) {
+                  if (saveLocation != null) {
                     final fileData =
                         await photoSearchModel.download(photo: photo);
                     final photoFile =
                         XFile.fromData(fileData, mimeType: 'image/jpeg');
-                    await photoFile.saveTo(path);
+                    await photoFile.saveTo(saveLocation.path);
                   }
                 },
               )

--- a/desktop_photo_search/material/lib/src/widgets/unsplash_search_content.dart
+++ b/desktop_photo_search/material/lib/src/widgets/unsplash_search_content.dart
@@ -50,7 +50,7 @@ class _UnsplashSearchContentState extends State<UnsplashSearchContent> {
             ? PhotoDetails(
                 photo: photoSearchModel.selectedPhoto!,
                 onPhotoSave: (photo) async {
-                  final path = await getSavePath(
+                  final saveLocation = await getSaveLocation(
                     suggestedName: '${photo.id}.jpg',
                     acceptedTypeGroups: [
                       const XTypeGroup(
@@ -60,12 +60,12 @@ class _UnsplashSearchContentState extends State<UnsplashSearchContent> {
                       ),
                     ],
                   );
-                  if (path != null) {
+                  if (saveLocation != null) {
                     final fileData =
                         await photoSearchModel.download(photo: photo);
                     final photoFile =
                         XFile.fromData(fileData, mimeType: 'image/jpeg');
-                    await photoFile.saveTo(path);
+                    await photoFile.saveTo(saveLocation.path);
                   }
                 },
               )

--- a/experimental/linting_tool/lib/model/profiles_store.dart
+++ b/experimental/linting_tool/lib/model/profiles_store.dart
@@ -140,7 +140,7 @@ class ProfilesStore extends ChangeNotifier {
     const name = 'analysis_options.yaml';
 
     /// Get file path using file picker.
-    final savePath = await file_selector.getSavePath(
+    final saveLocation = await file_selector.getSaveLocation(
       suggestedName: name,
     );
 
@@ -148,8 +148,8 @@ class ProfilesStore extends ChangeNotifier {
     final file = file_selector.XFile.fromData(data, name: name);
 
     /// Save file to disk if path was provided.
-    if (savePath != null) {
-      await file.saveTo(savePath);
+    if (saveLocation != null) {
+      await file.saveTo(saveLocation.path);
       return true;
     }
 


### PR DESCRIPTION
This PR fixes a [CI breakage](https://github.com/flutter/samples/actions/runs/5362518576/jobs/9729453534):

```console
Analyzing fluent_ui...

   info - lib/src/widgets/unsplash_search_content.dart:51:38 - 'getSavePath' is deprecated and shouldn't be used. Use getSaveLocation instead. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use

1 issue found.
Error: Process completed with exit code 1.
```

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md