### PR TITLE
Fix master CI for `simplistic_editor`

### DIFF
--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -957,7 +957,6 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
                 obscureText:
                     false, // This is a non-private text field that does not require obfuscation.
                 offset: position,
-                onCaretChanged: null,
                 rendererIgnoresPointer: true,
                 cursorWidth: 2.0,
                 cursorHeight: null,
@@ -1007,7 +1006,6 @@ class _Editable extends MultiChildRenderObjectWidget {
     required this.obscuringCharacter,
     required this.obscureText,
     required this.offset,
-    this.onCaretChanged,
     this.rendererIgnoresPointer = false,
     required this.cursorWidth,
     this.cursorHeight,
@@ -1059,7 +1057,6 @@ class _Editable extends MultiChildRenderObjectWidget {
   final TextHeightBehavior? textHeightBehavior;
   final TextWidthBasis textWidthBasis;
   final ViewportOffset offset;
-  final CaretChangedHandler? onCaretChanged;
   final bool rendererIgnoresPointer;
   final double cursorWidth;
   final double? cursorHeight;
@@ -1096,7 +1093,6 @@ class _Editable extends MultiChildRenderObjectWidget {
       locale: locale ?? Localizations.maybeLocaleOf(context),
       selection: value.selection,
       offset: offset,
-      onCaretChanged: onCaretChanged,
       ignorePointer: rendererIgnoresPointer,
       obscuringCharacter: obscuringCharacter,
       obscureText: obscureText,
@@ -1138,7 +1134,6 @@ class _Editable extends MultiChildRenderObjectWidget {
       ..locale = locale ?? Localizations.maybeLocaleOf(context)
       ..selection = value.selection
       ..offset = offset
-      ..onCaretChanged = onCaretChanged
       ..ignorePointer = rendererIgnoresPointer
       ..textHeightBehavior = textHeightBehavior
       ..textWidthBasis = textWidthBasis

--- a/tool/flutter_ci_script_master.sh
+++ b/tool/flutter_ci_script_master.sh
@@ -63,8 +63,7 @@ declare -ar PROJECT_NAMES=(
     "simple_shader"
     # TODO(DomesticMouse): Dependency 'flutter_layout_grid' fails to compile. https://github.com/shyndman/flutter_layout_grid/issues/91
     # "simplistic_calculator"
-    # TODO(DomesticMouse): Undefined class 'CaretChangedHandler'. https://github.com/flutter/samples/issues/1923
-    # "simplistic_editor"
+    "simplistic_editor"
     "testing_app"
     "veggieseasons"
     "web_embedding/element_embedding_demo"


### PR DESCRIPTION
This change removes an unused parameter that was recently removed in the `RenderEditable` on the `master` branch https://github.com/flutter/flutter/pull/109114.

Fixes #1923 

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.