### PR TITLE
Explain the pedometer example directory in its README

### DIFF
--- a/experimental/pedometer/README.md
+++ b/experimental/pedometer/README.md
@@ -24,6 +24,9 @@ Configuration for JNIgen is [here](/jnigen.yaml) for the [HealthConnect API](htt
 
 
 ## Running the example app
+The example app is located in the `experimental/pedometer/example` directory,
+and the commands below assume they are being run from that location.
+
 Note that step counting is only available on physical devices. 
 
 ### iOS
@@ -49,6 +52,3 @@ Note that step counting is only available on physical devices.
 
 * `example`: Contains the native source code for building
   that source code into a dynamic library.
-
-
-


### PR DESCRIPTION
I was tripped up when trying to run the pedometer example because I didn't realize it was a plugin.  The actual example app is in the `example` directory.

In case anyone else is as oblivious as me, this will avoid similar confusion.

Fixes https://github.com/flutter/samples/issues/1595