### PR TITLE
Enable Material 3 on `background_isolate_channels`

### DIFF
--- a/background_isolate_channels/lib/main.dart
+++ b/background_isolate_channels/lib/main.dart
@@ -31,6 +31,7 @@ class MyApp extends StatelessWidget {
       title: 'Background Isolate Channels',
       theme: ThemeData(
         primarySwatch: Colors.blue,
+        useMaterial3: true,
       ),
       home: const MyHomePage(title: 'Background Isolate Channels'),
     );

--- a/background_isolate_channels/lib/main.dart
+++ b/background_isolate_channels/lib/main.dart
@@ -125,26 +125,24 @@ class _MyHomePageState extends State<MyHomePage> {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
+        bottom: PreferredSize(
+          preferredSize: const Size(double.infinity, kToolbarHeight),
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: SearchBar(
+              hintText: 'Search',
+              onChanged:
+                  _database == null ? null : (query) => _refresh(query: query),
+              trailing: const [Icon(Icons.search), SizedBox(width: 8)],
+            ),
+          ),
+        ),
       ),
-      body: Column(
-        children: [
-          TextField(
-            onChanged:
-                _database == null ? null : (query) => _refresh(query: query),
-            decoration: const InputDecoration(
-              labelText: 'Search',
-              suffixIcon: Icon(Icons.search),
-            ),
-          ),
-          Expanded(
-            child: ListView.builder(
-              itemBuilder: (context, index) {
-                return ListTile(title: Text(_entries![index]));
-              },
-              itemCount: _entries?.length ?? 0,
-            ),
-          ),
-        ],
+      body: ListView.builder(
+        itemBuilder: (context, index) {
+          return ListTile(title: Text(_entries![index]));
+        },
+        itemCount: _entries?.length ?? 0,
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _database == null ? null : _addDate,

--- a/background_isolate_channels/lib/main.dart
+++ b/background_isolate_channels/lib/main.dart
@@ -126,9 +126,9 @@ class _MyHomePageState extends State<MyHomePage> {
       appBar: AppBar(
         title: Text(widget.title),
         bottom: PreferredSize(
-          preferredSize: const Size(double.infinity, kToolbarHeight),
+          preferredSize: const Size.fromHeight(kToolbarHeight),
           child: Padding(
-            padding: const EdgeInsets.all(8.0),
+            padding: const EdgeInsets.symmetric(horizontal: 8.0),
             child: SearchBar(
               hintText: 'Search',
               onChanged:


### PR DESCRIPTION
Enabling Material 3 on `background_isolate_channels` sample

#### Before

<img width="912" alt="Screenshot 2023-07-20 at 13 41 54" src="https://github.com/flutter/samples/assets/2494376/f07aee8d-93da-4d5b-af26-acc72ecd48e7">

#### With Material 3

<img width="912" alt="Screenshot 2023-07-20 at 13 42 12" src="https://github.com/flutter/samples/assets/2494376/d160db4c-a303-4d99-acd5-916d586a8519">

## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
