### PR TITLE
Enable material 3 on `deeplink_store_example`

### DIFF
--- a/deeplink_store_example/lib/main.dart
+++ b/deeplink_store_example/lib/main.dart
@@ -28,6 +28,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
+      theme: ThemeData.light(useMaterial3: true),
       routerConfig: GoRouter(
         routes: [
           GoRoute(


### PR DESCRIPTION
Enabling Material 3

Change is very subtle.

#### Before Material 3
<img width="868" alt="Screenshot 2023-07-20 at 13 48 29" src="https://github.com/flutter/samples/assets/2494376/fce79132-5fe1-4a77-be29-68cac36364dd">

#### With Material 3


<img width="912" alt="Screenshot 2023-07-20 at 13 48 39" src="https://github.com/flutter/samples/assets/2494376/b48b3671-381c-4836-9b55-cfe1c90d57ab">


## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
