### PR TITLE
Enable Material 3 on `context_menus`

### DIFF
--- a/experimental/context_menus/lib/main.dart
+++ b/experimental/context_menus/lib/main.dart
@@ -62,6 +62,7 @@ class _MyAppState extends State<MyApp> {
       theme: ThemeData(
         primarySwatch: Colors.blue,
         platform: defaultTargetPlatform,
+        useMaterial3: true,
       ),
       initialRoute: '/',
       routes: <String, Widget Function(BuildContext)>{

--- a/experimental/context_menus/lib/platform_selector.dart
+++ b/experimental/context_menus/lib/platform_selector.dart
@@ -27,7 +27,7 @@ class _PlatformSelectorState extends State<PlatformSelector> {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 160.0,
+      width: 170.0,
       child: DropdownButton<TargetPlatform>(
         value: defaultTargetPlatform,
         icon: const Icon(Icons.arrow_downward),


### PR DESCRIPTION
Enable Material 3

#### Before Material 3

<img width="912" alt="Screenshot 2023-07-20 at 13 53 16" src="https://github.com/flutter/samples/assets/2494376/f2686f50-f08b-4810-a35b-62b7247a1327">
<img width="912" alt="Screenshot 2023-07-20 at 13 53 08" src="https://github.com/flutter/samples/assets/2494376/7b3882bd-ba32-4a29-b262-482b2af028a5">

#### With Material 3

<img width="912" alt="Screenshot 2023-07-20 at 13 54 12" src="https://github.com/flutter/samples/assets/2494376/15cb182d-8191-4afa-953b-cc037944ecee">
<img width="912" alt="Screenshot 2023-07-20 at 13 54 06" src="https://github.com/flutter/samples/assets/2494376/46151882-309f-4b7d-a2c3-a3700f6b8c17">


## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
