### PR TITLE
Enable Material 3 on `experimental/pedometer`

### DIFF
--- a/experimental/pedometer/example/lib/main.dart
+++ b/experimental/pedometer/example/lib/main.dart
@@ -17,6 +17,7 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
+        useMaterial3: true,
       ),
       home: const Home(),
     );


### PR DESCRIPTION
Enable Material 3.

Only the font changes slightly.

#### Before Material 3

![Screenshot_20230720_150747](https://github.com/flutter/samples/assets/2494376/8dc203bc-8aa6-41bb-bf48-6f23ba992e6f)


#### With Material 3

![Screenshot_20230720_150844](https://github.com/flutter/samples/assets/2494376/88dedbbd-0531-4163-84b1-319c65bd3896)


## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
