### PR TITLE
Enable Material 3 on `experimental/varfont_shader_puzzle`

### DIFF
--- a/experimental/varfont_shader_puzzle/lib/main.dart
+++ b/experimental/varfont_shader_puzzle/lib/main.dart
@@ -19,6 +19,7 @@ class TypePuzzle extends StatelessWidget {
       title: 'Type Jam',
       theme: ThemeData(
         primarySwatch: Colors.grey,
+        useMaterial3: true,
       ),
       home: const Scaffold(
         appBar: null,


### PR DESCRIPTION
Enable Material 3.

Very small differences in the default font weight.

#### Before Material 3

<img width="912" alt="Screenshot 2023-07-20 at 15 16 57" src="https://github.com/flutter/samples/assets/2494376/3d5baeb8-9718-47ca-918f-61189305816b">

#### With Material 3

<img width="912" alt="Screenshot 2023-07-20 at 15 18 10" src="https://github.com/flutter/samples/assets/2494376/3026f8e4-4807-4c8c-a790-d3c7118474ce">

## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
