### PR TITLE
Enable Material 3 in `experimental/web_dashboard`

### DIFF
--- a/experimental/web_dashboard/lib/src/app.dart
+++ b/experimental/web_dashboard/lib/src/app.dart
@@ -66,6 +66,7 @@ class _DashboardAppState extends State<DashboardApp> {
     return Provider.value(
       value: _appState,
       child: MaterialApp(
+        theme: ThemeData.light(useMaterial3: true),
         home: SignInSwitcher(
           appState: _appState,
           apiBuilder: widget.apiBuilder,

--- a/experimental/web_dashboard/lib/src/pages/sign_in.dart
+++ b/experimental/web_dashboard/lib/src/pages/sign_in.dart
@@ -88,7 +88,7 @@ class _SignInButtonState extends State<SignInButton> {
           _showError();
         }
 
-        return ElevatedButton(
+        return FilledButton(
           child: const Text('Sign In with Google'),
           onPressed: () => _signIn(),
         );

--- a/experimental/web_dashboard/lib/src/widgets/category_forms.dart
+++ b/experimental/web_dashboard/lib/src/widgets/category_forms.dart
@@ -79,7 +79,7 @@ class _EditCategoryFormState extends State<EditCategoryForm> {
             children: [
               Padding(
                 padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-                child: ElevatedButton(
+                child: FilledButton(
                   child: const Text('Cancel'),
                   onPressed: () {
                     widget.onDone(false);
@@ -88,7 +88,7 @@ class _EditCategoryFormState extends State<EditCategoryForm> {
               ),
               Padding(
                 padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-                child: ElevatedButton(
+                child: FilledButton(
                   child: const Text('OK'),
                   onPressed: () {
                     if (_formKey.currentState!.validate()) {

--- a/experimental/web_dashboard/lib/src/widgets/edit_entry.dart
+++ b/experimental/web_dashboard/lib/src/widgets/edit_entry.dart
@@ -103,7 +103,7 @@ class _EditEntryFormState extends State<EditEntryForm> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(intl.DateFormat('MM/dd/yyyy').format(widget.entry!.time)),
-                ElevatedButton(
+                FilledButton(
                   child: const Text('Edit'),
                   onPressed: () async {
                     var result = await showDatePicker(
@@ -128,7 +128,7 @@ class _EditEntryFormState extends State<EditEntryForm> {
             children: [
               Padding(
                 padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-                child: ElevatedButton(
+                child: FilledButton(
                   child: const Text('Cancel'),
                   onPressed: () {
                     widget.onDone(false);
@@ -137,7 +137,7 @@ class _EditEntryFormState extends State<EditEntryForm> {
               ),
               Padding(
                 padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-                child: ElevatedButton(
+                child: FilledButton(
                   child: const Text('OK'),
                   onPressed: () {
                     if (_formKey.currentState!.validate()) {


### PR DESCRIPTION
Enabled Material 3.

Replaced the `ElevatedButton` by `FilledButton` for better contrast.

#### Before Material 3

<img width="1392" alt="Screenshot 2023-07-21 at 15 26 44" src="https://github.com/flutter/samples/assets/2494376/dea484eb-cb0f-46e1-a6b0-bdfef7bab519">

#### With Material 3

<img width="1392" alt="Screenshot 2023-07-21 at 15 28 22" src="https://github.com/flutter/samples/assets/2494376/a2a449c1-3a73-4bc0-a270-33b6b9d91fa3">


## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
