### PR TITLE
Enable material 3 on `navigation_and_routing`

### DIFF
--- a/navigation_and_routing/lib/src/app.dart
+++ b/navigation_and_routing/lib/src/app.dart
@@ -67,6 +67,7 @@ class _BookstoreState extends State<Bookstore> {
             // Revert back to pre-Flutter-2.5 transition behavior:
             // https://github.com/flutter/flutter/issues/82053
             theme: ThemeData(
+              useMaterial3: true,
               pageTransitionsTheme: const PageTransitionsTheme(
                 builders: {
                   TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),

--- a/navigation_and_routing/lib/src/screens/books.dart
+++ b/navigation_and_routing/lib/src/screens/books.dart
@@ -52,6 +52,7 @@ class _BooksScreenState extends State<BooksScreen>
   Widget build(BuildContext context) => Scaffold(
         appBar: AppBar(
           title: const Text('Books'),
+          elevation: 8,
           bottom: TabBar(
             controller: _tabController,
             tabs: const [

--- a/navigation_and_routing/lib/src/screens/settings.dart
+++ b/navigation_and_routing/lib/src/screens/settings.dart
@@ -50,7 +50,7 @@ class SettingsContent extends StatelessWidget {
               'Settings',
               style: Theme.of(context).textTheme.headlineMedium,
             ),
-            ElevatedButton(
+            FilledButton(
               onPressed: () {
                 BookstoreAuthScope.of(context).signOut();
               },


### PR DESCRIPTION
Enabled Material 3.

Replaced the `ElevatedButton` to `FilledButton` for better visibility.

Added elevation to the top app bar to add contrast to the top navigation tabs.

#### Before Material 3

<img width="592" alt="Screenshot 2023-07-21 at 15 32 49" src="https://github.com/flutter/samples/assets/2494376/88c9ac77-3f74-4ebb-ad2e-c55cc761ec11">

#### With Material 3

<img width="592" alt="Screenshot 2023-07-21 at 15 47 55" src="https://github.com/flutter/samples/assets/2494376/37854329-0313-46fa-a945-401ffbae5fe6">

## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
