### PR TITLE
Account for new generated rules.json location in linter tool

### DIFF
--- a/experimental/linting_tool/lib/repository/api_provider.dart
+++ b/experimental/linting_tool/lib/repository/api_provider.dart
@@ -14,7 +14,7 @@ class APIProvider {
 
   Future<List<Rule>> getRulesList() async {
     final response = await httpClient.get(Uri.parse(
-      'https://raw.githubusercontent.com/dart-lang/linter/main/tool/machine/rules.json',
+      'https://raw.githubusercontent.com/dart-lang/site-www/main/src/_data/linter_rules.json',
     ));
 
     if (response.statusCode == 200) {

--- a/experimental/linting_tool/lib/repository/api_provider.dart
+++ b/experimental/linting_tool/lib/repository/api_provider.dart
@@ -8,15 +8,14 @@ import 'package:linting_tool/model/rule.dart';
 import 'package:yaml/yaml.dart';
 
 class APIProvider {
-  static const String _baseURL = 'https://dart-lang.github.io/linter';
-
   final http.Client httpClient;
 
   APIProvider(this.httpClient);
 
   Future<List<Rule>> getRulesList() async {
-    final response =
-        await httpClient.get(Uri.parse('$_baseURL/lints/machine/rules.json'));
+    final response = await httpClient.get(Uri.parse(
+      'https://raw.githubusercontent.com/dart-lang/linter/main/tool/machine/rules.json',
+    ));
 
     if (response.statusCode == 200) {
       final data = json.decode(response.body) as List;

--- a/experimental/linting_tool/test/widget_test.dart
+++ b/experimental/linting_tool/test/widget_test.dart
@@ -75,8 +75,8 @@ void main() {
         '''[{"name": "always_use_package_imports","description": "Avoid relative imports for files in `lib/`.","group": "errors","state": "stable","incompatible": [],"sets": [],"details": "*DO* avoid relative imports for files in `lib/`.\n\nWhen mixing relative and absolute imports it's possible to create confusion\nwhere the same member gets imported in two different ways. One way to avoid\nthat is to ensure you consistently use absolute imports for files withing the\n`lib/` directory.\n\nThis is the opposite of 'prefer_relative_imports'.\nMight be used with 'avoid_relative_lib_imports' to avoid relative imports of\nfiles within `lib/` directory outside of it. (for example `test/`)\n\n**GOOD:**\n\n```dart\nimport 'package:foo/bar.dart';\n\nimport 'package:foo/baz.dart';\n\nimport 'package:foo/src/baz.dart';\n...\n```\n\n**BAD:**\n\n```dart\nimport 'baz.dart';\n\nimport 'src/bag.dart'\n\nimport '../lib/baz.dart';\n\n...\n```\n\n"}]''';
 
     when(_mockClient.get(Uri.parse(
-            'https://dart-lang.github.io/linter/lints/machine/rules.json')))
-        .thenAnswer(
+      'https://raw.githubusercontent.com/dart-lang/linter/main/tool/machine/rules.json',
+    ))).thenAnswer(
       (_) async => http.Response(responseBody, 400),
     );
 

--- a/experimental/linting_tool/test/widget_test.dart
+++ b/experimental/linting_tool/test/widget_test.dart
@@ -75,7 +75,7 @@ void main() {
         '''[{"name": "always_use_package_imports","description": "Avoid relative imports for files in `lib/`.","group": "errors","state": "stable","incompatible": [],"sets": [],"details": "*DO* avoid relative imports for files in `lib/`.\n\nWhen mixing relative and absolute imports it's possible to create confusion\nwhere the same member gets imported in two different ways. One way to avoid\nthat is to ensure you consistently use absolute imports for files withing the\n`lib/` directory.\n\nThis is the opposite of 'prefer_relative_imports'.\nMight be used with 'avoid_relative_lib_imports' to avoid relative imports of\nfiles within `lib/` directory outside of it. (for example `test/`)\n\n**GOOD:**\n\n```dart\nimport 'package:foo/bar.dart';\n\nimport 'package:foo/baz.dart';\n\nimport 'package:foo/src/baz.dart';\n...\n```\n\n**BAD:**\n\n```dart\nimport 'baz.dart';\n\nimport 'src/bag.dart'\n\nimport '../lib/baz.dart';\n\n...\n```\n\n"}]''';
 
     when(_mockClient.get(Uri.parse(
-      'https://raw.githubusercontent.com/dart-lang/linter/main/tool/machine/rules.json',
+      'https://raw.githubusercontent.com/dart-lang/site-www/main/src/_data/linter_rules.json',
     ))).thenAnswer(
       (_) async => http.Response(responseBody, 400),
     );


### PR DESCRIPTION
In preparation for the linter moving to the SDK, the `rules.json` file is no longer generated to its own location. The site-www version is better guaranteed to be up to date and match the `stable` release of Dart.