### PR TITLE
Enable Material 3 in `simplistic_calculator`

### DIFF
--- a/simplistic_calculator/lib/main.dart
+++ b/simplistic_calculator/lib/main.dart
@@ -347,6 +347,7 @@ class CalculatorApp extends ConsumerWidget {
 
     return MaterialApp(
       debugShowCheckedModeBanner: false,
+      theme: ThemeData.light(useMaterial3: true),
       home: Scaffold(
         body: Container(
           color: Colors.white,


### PR DESCRIPTION
Enabled Material 3 in `simplistic_calculator`.

- Tempted to change the `ElevatedButton` to a `FilledButton`, what do you think?
- Also thinking about the new button shape, maybe we should change it to squared buttons?

#### Before Material 3

<img width="868" alt="Screenshot 2023-07-24 at 14 47 35" src="https://github.com/flutter/samples/assets/2494376/faf91aa7-9c18-4f11-97db-e498f2240e83">

#### With Material 3

<img width="868" alt="Screenshot 2023-07-24 at 14 47 43" src="https://github.com/flutter/samples/assets/2494376/8cb1f26a-2af8-4e94-8885-a56fa69f7af6">

## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
