### PR TITLE
Enable Material 3 in `web_embedding`

### DIFF
--- a/web_embedding/element_embedding_demo/lib/main.dart
+++ b/web_embedding/element_embedding_demo/lib/main.dart
@@ -64,7 +64,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Element embedding',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
         useMaterial3: true,
       ),
       debugShowCheckedModeBanner: false,

--- a/web_embedding/element_embedding_demo/lib/main.dart
+++ b/web_embedding/element_embedding_demo/lib/main.dart
@@ -65,6 +65,7 @@ class _MyAppState extends State<MyApp> {
       title: 'Element embedding',
       theme: ThemeData(
         primarySwatch: Colors.blue,
+        useMaterial3: true,
       ),
       debugShowCheckedModeBanner: false,
       home: demoScreenRouter(_currentDemoScreen),


### PR DESCRIPTION
Enable Material 3 in `web_embedding` sample

The app shows an embedded "counter sample" inside a website.

<img width="1010" alt="Screenshot 2023-07-24 at 15 11 42" src="https://github.com/flutter/samples/assets/2494376/2cb72a38-7108-4ed5-8a21-384364e8236d">

## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
