### PR TITLE
Update `Simplistic_Editor`

### DIFF
--- a/simplistic_editor/lib/basic_text_field.dart
+++ b/simplistic_editor/lib/basic_text_field.dart
@@ -26,6 +26,7 @@ class BasicTextField extends StatefulWidget {
     VoidCallback? onCut,
     VoidCallback? onPaste,
     VoidCallback? onSelectAll,
+    VoidCallback? onLookUp,
     VoidCallback? onLiveTextInput,
     TextSelectionToolbarAnchors anchors,
   ) {
@@ -35,6 +36,7 @@ class BasicTextField extends StatefulWidget {
       onCut: onCut,
       onPaste: onPaste,
       onSelectAll: onSelectAll,
+      onLookUp: onLookUp,
       onLiveTextInput: onLiveTextInput,
       anchors: anchors,
     );

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -1220,7 +1220,7 @@ class _Editable extends MultiChildRenderObjectWidget {
       ..expands = expands
       ..strutStyle = strutStyle
       ..selectionColor = selectionColor
-      ..textScaler= textScaler
+      ..textScaler = textScaler
       ..textAlign = textAlign
       ..textDirection = textDirection
       ..locale = locale ?? Localizations.maybeLocaleOf(context)

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -1016,7 +1016,7 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
                 expands: false, // expands to height of parent.
                 strutStyle: null,
                 selectionColor: Colors.blue.withOpacity(0.40),
-                textScaleFactor: MediaQuery.textScaleFactorOf(context),
+                textScaler: MediaQuery.textScalerOf(context),
                 textAlign: TextAlign.left,
                 textDirection: _textDirection,
                 locale: Localizations.maybeLocaleOf(context),
@@ -1068,7 +1068,7 @@ class _Editable extends MultiChildRenderObjectWidget {
     required this.expands,
     this.strutStyle,
     this.selectionColor,
-    required this.textScaleFactor,
+    required this.textScaler,
     required this.textAlign,
     required this.textDirection,
     this.locale,
@@ -1117,7 +1117,7 @@ class _Editable extends MultiChildRenderObjectWidget {
   final bool expands;
   final StrutStyle? strutStyle;
   final Color? selectionColor;
-  final double textScaleFactor;
+  final TextScaler textScaler;
   final TextAlign textAlign;
   final TextDirection textDirection;
   final Locale? locale;
@@ -1156,7 +1156,7 @@ class _Editable extends MultiChildRenderObjectWidget {
       expands: expands,
       strutStyle: strutStyle,
       selectionColor: selectionColor,
-      textScaleFactor: textScaleFactor,
+      textScaler: textScaler,
       textAlign: textAlign,
       textDirection: textDirection,
       locale: locale ?? Localizations.maybeLocaleOf(context),
@@ -1197,7 +1197,7 @@ class _Editable extends MultiChildRenderObjectWidget {
       ..expands = expands
       ..strutStyle = strutStyle
       ..selectionColor = selectionColor
-      ..textScaleFactor = textScaleFactor
+      ..textScaler= textScaler
       ..textAlign = textAlign
       ..textDirection = textDirection
       ..locale = locale ?? Localizations.maybeLocaleOf(context)


### PR DESCRIPTION
Adds support for iOS lookup context menu button.
Migrate from `textScaleFactor` to `textScaler`.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.