### PR TITLE
[desktop_photo_search] Tighten constraints then regenerate files

### DIFF
--- a/desktop_photo_search/fluent_ui/analysis_options.yaml
+++ b/desktop_photo_search/fluent_ui/analysis_options.yaml
@@ -1,8 +1,5 @@
 include: package:analysis_defaults/flutter.yaml
 
-analyzer:
-  exclude: [lib/src/**.g.dart]
-
 linter:
   rules:
     sort_pub_dependencies: true

--- a/desktop_photo_search/fluent_ui/lib/src/model/search.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/model/search.g.dart
@@ -41,13 +41,13 @@ class _$SearchSerializer implements StructuredSerializer<Search> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'query':
           result.query = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'results':
           result.results.replace(serializers.deserialize(value,
@@ -69,11 +69,11 @@ class _$Search extends Search {
   final BuiltList<Photo> results;
 
   factory _$Search([void Function(SearchBuilder)? updates]) =>
-      (new SearchBuilder()..update(updates)).build();
+      (new SearchBuilder()..update(updates))._build();
 
   _$Search._({required this.query, required this.results}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(query, 'Search', 'query');
-    BuiltValueNullFieldError.checkNotNull(results, 'Search', 'results');
+    BuiltValueNullFieldError.checkNotNull(query, r'Search', 'query');
+    BuiltValueNullFieldError.checkNotNull(results, r'Search', 'results');
   }
 
   @override
@@ -91,12 +91,16 @@ class _$Search extends Search {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, query.hashCode), results.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, query.hashCode);
+    _$hash = $jc(_$hash, results.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Search')
+    return (newBuiltValueToStringHelper(r'Search')
           ..add('query', query)
           ..add('results', results))
         .toString();
@@ -139,13 +143,15 @@ class SearchBuilder implements Builder<Search, SearchBuilder> {
   }
 
   @override
-  _$Search build() {
+  Search build() => _build();
+
+  _$Search _build() {
     _$Search _$result;
     try {
       _$result = _$v ??
           new _$Search._(
               query: BuiltValueNullFieldError.checkNotNull(
-                  query, 'Search', 'query'),
+                  query, r'Search', 'query'),
               results: results.build());
     } catch (_) {
       late String _$failedField;
@@ -154,7 +160,7 @@ class SearchBuilder implements Builder<Search, SearchBuilder> {
         results.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'Search', _$failedField, e.toString());
+            r'Search', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -163,4 +169,4 @@ class SearchBuilder implements Builder<Search, SearchBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/serializers.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/serializers.g.dart
@@ -41,4 +41,4 @@ Serializers _$serializers = (new Serializers().toBuilder()
           () => new ListBuilder<CurrentUserCollections>()))
     .build();
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/api_error.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/api_error.g.dart
@@ -41,7 +41,7 @@ class _$ApiErrorSerializer implements StructuredSerializer<ApiError> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -63,7 +63,7 @@ class _$ApiError extends ApiError {
   final BuiltList<String>? errors;
 
   factory _$ApiError([void Function(ApiErrorBuilder)? updates]) =>
-      (new ApiErrorBuilder()..update(updates)).build();
+      (new ApiErrorBuilder()..update(updates))._build();
 
   _$ApiError._({this.errors}) : super._();
 
@@ -82,12 +82,15 @@ class _$ApiError extends ApiError {
 
   @override
   int get hashCode {
-    return $jf($jc(0, errors.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, errors.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('ApiError')..add('errors', errors))
+    return (newBuiltValueToStringHelper(r'ApiError')..add('errors', errors))
         .toString();
   }
 }
@@ -123,7 +126,9 @@ class ApiErrorBuilder implements Builder<ApiError, ApiErrorBuilder> {
   }
 
   @override
-  _$ApiError build() {
+  ApiError build() => _build();
+
+  _$ApiError _build() {
     _$ApiError _$result;
     try {
       _$result = _$v ?? new _$ApiError._(errors: _errors?.build());
@@ -134,7 +139,7 @@ class ApiErrorBuilder implements Builder<ApiError, ApiErrorBuilder> {
         _errors?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'ApiError', _$failedField, e.toString());
+            r'ApiError', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -143,4 +148,4 @@ class ApiErrorBuilder implements Builder<ApiError, ApiErrorBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/current_user_collections.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/current_user_collections.g.dart
@@ -64,13 +64,13 @@ class _$CurrentUserCollectionsSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'id':
           result.id = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'title':
           result.title = serializers.deserialize(value,
@@ -103,12 +103,12 @@ class _$CurrentUserCollections extends CurrentUserCollections {
 
   factory _$CurrentUserCollections(
           [void Function(CurrentUserCollectionsBuilder)? updates]) =>
-      (new CurrentUserCollectionsBuilder()..update(updates)).build();
+      (new CurrentUserCollectionsBuilder()..update(updates))._build();
 
   _$CurrentUserCollections._(
       {required this.id, this.title, this.publishedAt, this.updatedAt})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(id, 'CurrentUserCollections', 'id');
+    BuiltValueNullFieldError.checkNotNull(id, r'CurrentUserCollections', 'id');
   }
 
   @override
@@ -132,14 +132,18 @@ class _$CurrentUserCollections extends CurrentUserCollections {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, id.hashCode), title.hashCode), publishedAt.hashCode),
-        updatedAt.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jc(_$hash, publishedAt.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('CurrentUserCollections')
+    return (newBuiltValueToStringHelper(r'CurrentUserCollections')
           ..add('id', id)
           ..add('title', title)
           ..add('publishedAt', publishedAt)
@@ -194,11 +198,13 @@ class CurrentUserCollectionsBuilder
   }
 
   @override
-  _$CurrentUserCollections build() {
+  CurrentUserCollections build() => _build();
+
+  _$CurrentUserCollections _build() {
     final _$result = _$v ??
         new _$CurrentUserCollections._(
             id: BuiltValueNullFieldError.checkNotNull(
-                id, 'CurrentUserCollections', 'id'),
+                id, r'CurrentUserCollections', 'id'),
             title: title,
             publishedAt: publishedAt,
             updatedAt: updatedAt);
@@ -207,4 +213,4 @@ class CurrentUserCollectionsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/exif.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/exif.g.dart
@@ -74,7 +74,7 @@ class _$ExifSerializer implements StructuredSerializer<Exif> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -124,7 +124,7 @@ class _$Exif extends Exif {
   final int? iso;
 
   factory _$Exif([void Function(ExifBuilder)? updates]) =>
-      (new ExifBuilder()..update(updates)).build();
+      (new ExifBuilder()..update(updates))._build();
 
   _$Exif._(
       {this.make,
@@ -156,19 +156,20 @@ class _$Exif extends Exif {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc($jc($jc(0, make.hashCode), model.hashCode),
-                    exposureTime.hashCode),
-                aperture.hashCode),
-            focalLength.hashCode),
-        iso.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, make.hashCode);
+    _$hash = $jc(_$hash, model.hashCode);
+    _$hash = $jc(_$hash, exposureTime.hashCode);
+    _$hash = $jc(_$hash, aperture.hashCode);
+    _$hash = $jc(_$hash, focalLength.hashCode);
+    _$hash = $jc(_$hash, iso.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Exif')
+    return (newBuiltValueToStringHelper(r'Exif')
           ..add('make', make)
           ..add('model', model)
           ..add('exposureTime', exposureTime)
@@ -234,7 +235,9 @@ class ExifBuilder implements Builder<Exif, ExifBuilder> {
   }
 
   @override
-  _$Exif build() {
+  Exif build() => _build();
+
+  _$Exif _build() {
     final _$result = _$v ??
         new _$Exif._(
             make: make,
@@ -248,4 +251,4 @@ class ExifBuilder implements Builder<Exif, ExifBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/links.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/links.g.dart
@@ -61,7 +61,7 @@ class _$LinksSerializer implements StructuredSerializer<Links> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -99,7 +99,7 @@ class _$Links extends Links {
   final String? downloadLocation;
 
   factory _$Links([void Function(LinksBuilder)? updates]) =>
-      (new LinksBuilder()..update(updates)).build();
+      (new LinksBuilder()..update(updates))._build();
 
   _$Links._({this.self, this.html, this.download, this.downloadLocation})
       : super._();
@@ -123,14 +123,18 @@ class _$Links extends Links {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, self.hashCode), html.hashCode), download.hashCode),
-        downloadLocation.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, self.hashCode);
+    _$hash = $jc(_$hash, html.hashCode);
+    _$hash = $jc(_$hash, download.hashCode);
+    _$hash = $jc(_$hash, downloadLocation.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Links')
+    return (newBuiltValueToStringHelper(r'Links')
           ..add('self', self)
           ..add('html', html)
           ..add('download', download)
@@ -185,7 +189,9 @@ class LinksBuilder implements Builder<Links, LinksBuilder> {
   }
 
   @override
-  _$Links build() {
+  Links build() => _build();
+
+  _$Links _build() {
     final _$result = _$v ??
         new _$Links._(
             self: self,
@@ -197,4 +203,4 @@ class LinksBuilder implements Builder<Links, LinksBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/location.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/location.g.dart
@@ -54,7 +54,7 @@ class _$LocationSerializer implements StructuredSerializer<Location> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -86,7 +86,7 @@ class _$Location extends Location {
   final Position? position;
 
   factory _$Location([void Function(LocationBuilder)? updates]) =>
-      (new LocationBuilder()..update(updates)).build();
+      (new LocationBuilder()..update(updates))._build();
 
   _$Location._({this.city, this.country, this.position}) : super._();
 
@@ -108,13 +108,17 @@ class _$Location extends Location {
 
   @override
   int get hashCode {
-    return $jf(
-        $jc($jc($jc(0, city.hashCode), country.hashCode), position.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, city.hashCode);
+    _$hash = $jc(_$hash, country.hashCode);
+    _$hash = $jc(_$hash, position.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Location')
+    return (newBuiltValueToStringHelper(r'Location')
           ..add('city', city)
           ..add('country', country)
           ..add('position', position))
@@ -162,7 +166,9 @@ class LocationBuilder implements Builder<Location, LocationBuilder> {
   }
 
   @override
-  _$Location build() {
+  Location build() => _build();
+
+  _$Location _build() {
     _$Location _$result;
     try {
       _$result = _$v ??
@@ -175,7 +181,7 @@ class LocationBuilder implements Builder<Location, LocationBuilder> {
         _position?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'Location', _$failedField, e.toString());
+            r'Location', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -184,4 +190,4 @@ class LocationBuilder implements Builder<Location, LocationBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/photo.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/photo.g.dart
@@ -146,13 +146,13 @@ class _$PhotoSerializer implements StructuredSerializer<Photo> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'id':
           result.id = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'created_at':
           result.createdAt = serializers.deserialize(value,
@@ -266,7 +266,7 @@ class _$Photo extends Photo {
   final User? user;
 
   factory _$Photo([void Function(PhotoBuilder)? updates]) =>
-      (new PhotoBuilder()..update(updates)).build();
+      (new PhotoBuilder()..update(updates))._build();
 
   _$Photo._(
       {required this.id,
@@ -287,7 +287,7 @@ class _$Photo extends Photo {
       this.links,
       this.user})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(id, 'Photo', 'id');
+    BuiltValueNullFieldError.checkNotNull(id, r'Photo', 'id');
   }
 
   @override
@@ -322,49 +322,31 @@ class _$Photo extends Photo {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc(
-                                $jc(
-                                    $jc(
-                                        $jc(
-                                            $jc(
-                                                $jc(
-                                                    $jc(
-                                                        $jc(
-                                                            $jc(
-                                                                $jc(
-                                                                    $jc(
-                                                                        0,
-                                                                        id
-                                                                            .hashCode),
-                                                                    createdAt
-                                                                        .hashCode),
-                                                                updatedAt
-                                                                    .hashCode),
-                                                            width.hashCode),
-                                                        height.hashCode),
-                                                    color.hashCode),
-                                                downloads.hashCode),
-                                            likes.hashCode),
-                                        likedByUser.hashCode),
-                                    description.hashCode),
-                                exif.hashCode),
-                            location.hashCode),
-                        tags.hashCode),
-                    currentUserCollections.hashCode),
-                urls.hashCode),
-            links.hashCode),
-        user.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jc(_$hash, width.hashCode);
+    _$hash = $jc(_$hash, height.hashCode);
+    _$hash = $jc(_$hash, color.hashCode);
+    _$hash = $jc(_$hash, downloads.hashCode);
+    _$hash = $jc(_$hash, likes.hashCode);
+    _$hash = $jc(_$hash, likedByUser.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, exif.hashCode);
+    _$hash = $jc(_$hash, location.hashCode);
+    _$hash = $jc(_$hash, tags.hashCode);
+    _$hash = $jc(_$hash, currentUserCollections.hashCode);
+    _$hash = $jc(_$hash, urls.hashCode);
+    _$hash = $jc(_$hash, links.hashCode);
+    _$hash = $jc(_$hash, user.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Photo')
+    return (newBuiltValueToStringHelper(r'Photo')
           ..add('id', id)
           ..add('createdAt', createdAt)
           ..add('updatedAt', updatedAt)
@@ -500,12 +482,14 @@ class PhotoBuilder implements Builder<Photo, PhotoBuilder> {
   }
 
   @override
-  _$Photo build() {
+  Photo build() => _build();
+
+  _$Photo _build() {
     _$Photo _$result;
     try {
       _$result = _$v ??
           new _$Photo._(
-              id: BuiltValueNullFieldError.checkNotNull(id, 'Photo', 'id'),
+              id: BuiltValueNullFieldError.checkNotNull(id, r'Photo', 'id'),
               createdAt: createdAt,
               updatedAt: updatedAt,
               width: width,
@@ -541,7 +525,7 @@ class PhotoBuilder implements Builder<Photo, PhotoBuilder> {
         _user?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'Photo', _$failedField, e.toString());
+            r'Photo', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -550,4 +534,4 @@ class PhotoBuilder implements Builder<Photo, PhotoBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/position.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/position.g.dart
@@ -40,17 +40,17 @@ class _$PositionSerializer implements StructuredSerializer<Position> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'latitude':
           result.latitude = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double;
+              specifiedType: const FullType(double))! as double;
           break;
         case 'longitude':
           result.longitude = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double;
+              specifiedType: const FullType(double))! as double;
           break;
       }
     }
@@ -66,11 +66,11 @@ class _$Position extends Position {
   final double longitude;
 
   factory _$Position([void Function(PositionBuilder)? updates]) =>
-      (new PositionBuilder()..update(updates)).build();
+      (new PositionBuilder()..update(updates))._build();
 
   _$Position._({required this.latitude, required this.longitude}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(latitude, 'Position', 'latitude');
-    BuiltValueNullFieldError.checkNotNull(longitude, 'Position', 'longitude');
+    BuiltValueNullFieldError.checkNotNull(latitude, r'Position', 'latitude');
+    BuiltValueNullFieldError.checkNotNull(longitude, r'Position', 'longitude');
   }
 
   @override
@@ -90,12 +90,16 @@ class _$Position extends Position {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, latitude.hashCode), longitude.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, latitude.hashCode);
+    _$hash = $jc(_$hash, longitude.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Position')
+    return (newBuiltValueToStringHelper(r'Position')
           ..add('latitude', latitude)
           ..add('longitude', longitude))
         .toString();
@@ -137,16 +141,18 @@ class PositionBuilder implements Builder<Position, PositionBuilder> {
   }
 
   @override
-  _$Position build() {
+  Position build() => _build();
+
+  _$Position _build() {
     final _$result = _$v ??
         new _$Position._(
             latitude: BuiltValueNullFieldError.checkNotNull(
-                latitude, 'Position', 'latitude'),
+                latitude, r'Position', 'latitude'),
             longitude: BuiltValueNullFieldError.checkNotNull(
-                longitude, 'Position', 'longitude'));
+                longitude, r'Position', 'longitude'));
     replace(_$result);
     return _$result;
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/search_photos_response.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/search_photos_response.g.dart
@@ -57,7 +57,7 @@ class _$SearchPhotosResponseSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -92,12 +92,12 @@ class _$SearchPhotosResponse extends SearchPhotosResponse {
 
   factory _$SearchPhotosResponse(
           [void Function(SearchPhotosResponseBuilder)? updates]) =>
-      (new SearchPhotosResponseBuilder()..update(updates)).build();
+      (new SearchPhotosResponseBuilder()..update(updates))._build();
 
   _$SearchPhotosResponse._({this.total, this.totalPages, required this.results})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
-        results, 'SearchPhotosResponse', 'results');
+        results, r'SearchPhotosResponse', 'results');
   }
 
   @override
@@ -120,13 +120,17 @@ class _$SearchPhotosResponse extends SearchPhotosResponse {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc(0, total.hashCode), totalPages.hashCode), results.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, total.hashCode);
+    _$hash = $jc(_$hash, totalPages.hashCode);
+    _$hash = $jc(_$hash, results.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('SearchPhotosResponse')
+    return (newBuiltValueToStringHelper(r'SearchPhotosResponse')
           ..add('total', total)
           ..add('totalPages', totalPages)
           ..add('results', results))
@@ -176,7 +180,9 @@ class SearchPhotosResponseBuilder
   }
 
   @override
-  _$SearchPhotosResponse build() {
+  SearchPhotosResponse build() => _build();
+
+  _$SearchPhotosResponse _build() {
     _$SearchPhotosResponse _$result;
     try {
       _$result = _$v ??
@@ -189,7 +195,7 @@ class SearchPhotosResponseBuilder
         results.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'SearchPhotosResponse', _$failedField, e.toString());
+            r'SearchPhotosResponse', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -198,4 +204,4 @@ class SearchPhotosResponseBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/tags.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/tags.g.dart
@@ -37,13 +37,13 @@ class _$TagsSerializer implements StructuredSerializer<Tags> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'title':
           result.title = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -57,10 +57,10 @@ class _$Tags extends Tags {
   final String title;
 
   factory _$Tags([void Function(TagsBuilder)? updates]) =>
-      (new TagsBuilder()..update(updates)).build();
+      (new TagsBuilder()..update(updates))._build();
 
   _$Tags._({required this.title}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(title, 'Tags', 'title');
+    BuiltValueNullFieldError.checkNotNull(title, r'Tags', 'title');
   }
 
   @override
@@ -78,12 +78,15 @@ class _$Tags extends Tags {
 
   @override
   int get hashCode {
-    return $jf($jc(0, title.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Tags')..add('title', title))
+    return (newBuiltValueToStringHelper(r'Tags')..add('title', title))
         .toString();
   }
 }
@@ -118,14 +121,16 @@ class TagsBuilder implements Builder<Tags, TagsBuilder> {
   }
 
   @override
-  _$Tags build() {
+  Tags build() => _build();
+
+  _$Tags _build() {
     final _$result = _$v ??
         new _$Tags._(
             title:
-                BuiltValueNullFieldError.checkNotNull(title, 'Tags', 'title'));
+                BuiltValueNullFieldError.checkNotNull(title, r'Tags', 'title'));
     replace(_$result);
     return _$result;
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/urls.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/urls.g.dart
@@ -68,7 +68,7 @@ class _$UrlsSerializer implements StructuredSerializer<Urls> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -112,7 +112,7 @@ class _$Urls extends Urls {
   final String? thumb;
 
   factory _$Urls([void Function(UrlsBuilder)? updates]) =>
-      (new UrlsBuilder()..update(updates)).build();
+      (new UrlsBuilder()..update(updates))._build();
 
   _$Urls._({this.raw, this.full, this.regular, this.small, this.thumb})
       : super._();
@@ -137,15 +137,19 @@ class _$Urls extends Urls {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc($jc(0, raw.hashCode), full.hashCode), regular.hashCode),
-            small.hashCode),
-        thumb.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, raw.hashCode);
+    _$hash = $jc(_$hash, full.hashCode);
+    _$hash = $jc(_$hash, regular.hashCode);
+    _$hash = $jc(_$hash, small.hashCode);
+    _$hash = $jc(_$hash, thumb.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Urls')
+    return (newBuiltValueToStringHelper(r'Urls')
           ..add('raw', raw)
           ..add('full', full)
           ..add('regular', regular)
@@ -205,7 +209,9 @@ class UrlsBuilder implements Builder<Urls, UrlsBuilder> {
   }
 
   @override
-  _$Urls build() {
+  Urls build() => _build();
+
+  _$Urls _build() {
     final _$result = _$v ??
         new _$Urls._(
             raw: raw, full: full, regular: regular, small: small, thumb: thumb);
@@ -214,4 +220,4 @@ class UrlsBuilder implements Builder<Urls, UrlsBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/lib/src/unsplash/user.g.dart
+++ b/desktop_photo_search/fluent_ui/lib/src/unsplash/user.g.dart
@@ -94,13 +94,13 @@ class _$UserSerializer implements StructuredSerializer<User> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'id':
           result.id = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'updated_at':
           result.updatedAt = serializers.deserialize(value,
@@ -108,11 +108,11 @@ class _$UserSerializer implements StructuredSerializer<User> {
           break;
         case 'username':
           result.username = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'name':
           result.name = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'portfolio_url':
           result.portfolioUrl = serializers.deserialize(value,
@@ -174,7 +174,7 @@ class _$User extends User {
   final Links? links;
 
   factory _$User([void Function(UserBuilder)? updates]) =>
-      (new UserBuilder()..update(updates)).build();
+      (new UserBuilder()..update(updates))._build();
 
   _$User._(
       {required this.id,
@@ -189,9 +189,9 @@ class _$User extends User {
       this.totalCollections,
       this.links})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(id, 'User', 'id');
-    BuiltValueNullFieldError.checkNotNull(username, 'User', 'username');
-    BuiltValueNullFieldError.checkNotNull(name, 'User', 'name');
+    BuiltValueNullFieldError.checkNotNull(id, r'User', 'id');
+    BuiltValueNullFieldError.checkNotNull(username, r'User', 'username');
+    BuiltValueNullFieldError.checkNotNull(name, r'User', 'name');
   }
 
   @override
@@ -220,31 +220,25 @@ class _$User extends User {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc(
-                                $jc(
-                                    $jc(
-                                        $jc($jc(0, id.hashCode),
-                                            updatedAt.hashCode),
-                                        username.hashCode),
-                                    name.hashCode),
-                                portfolioUrl.hashCode),
-                            bio.hashCode),
-                        location.hashCode),
-                    totalLikes.hashCode),
-                totalPhotos.hashCode),
-            totalCollections.hashCode),
-        links.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jc(_$hash, username.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, portfolioUrl.hashCode);
+    _$hash = $jc(_$hash, bio.hashCode);
+    _$hash = $jc(_$hash, location.hashCode);
+    _$hash = $jc(_$hash, totalLikes.hashCode);
+    _$hash = $jc(_$hash, totalPhotos.hashCode);
+    _$hash = $jc(_$hash, totalCollections.hashCode);
+    _$hash = $jc(_$hash, links.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('User')
+    return (newBuiltValueToStringHelper(r'User')
           ..add('id', id)
           ..add('updatedAt', updatedAt)
           ..add('username', username)
@@ -341,16 +335,19 @@ class UserBuilder implements Builder<User, UserBuilder> {
   }
 
   @override
-  _$User build() {
+  User build() => _build();
+
+  _$User _build() {
     _$User _$result;
     try {
       _$result = _$v ??
           new _$User._(
-              id: BuiltValueNullFieldError.checkNotNull(id, 'User', 'id'),
+              id: BuiltValueNullFieldError.checkNotNull(id, r'User', 'id'),
               updatedAt: updatedAt,
               username: BuiltValueNullFieldError.checkNotNull(
-                  username, 'User', 'username'),
-              name: BuiltValueNullFieldError.checkNotNull(name, 'User', 'name'),
+                  username, r'User', 'username'),
+              name:
+                  BuiltValueNullFieldError.checkNotNull(name, r'User', 'name'),
               portfolioUrl: portfolioUrl,
               bio: bio,
               location: location,
@@ -365,7 +362,7 @@ class UserBuilder implements Builder<User, UserBuilder> {
         _links?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'User', _$failedField, e.toString());
+            r'User', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -374,4 +371,4 @@ class UserBuilder implements Builder<User, UserBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/fluent_ui/pubspec.yaml
+++ b/desktop_photo_search/fluent_ui/pubspec.yaml
@@ -8,22 +8,22 @@ environment:
 
 dependencies:
   built_collection: ^5.1.1
-  built_value: ^8.5.0
+  built_value: ^8.6.1
   cupertino_icons: ^1.0.5
   file_selector: ^1.0.0
-  fluent_ui: ^4.6.0
-  fluentui_system_icons: ^1.1.200
+  fluent_ui: ^4.7.2
+  fluentui_system_icons: ^1.1.208
   flutter:
     sdk: flutter
-  http: ^1.0.0
-  logging: ^1.1.1
+  http: ^1.1.0
+  logging: ^1.2.0
   menubar:
     git:
       url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/menubar
   provider: ^6.0.5
   transparent_image: ^2.0.1
-  url_launcher: ^6.1.11
+  url_launcher: ^6.1.12
   uuid: ^3.0.7
   window_size:
     git:
@@ -34,13 +34,13 @@ dev_dependencies:
   analysis_defaults:
     path: ../../analysis_defaults
   async: ^2.11.0
-  build: ^2.4.0
-  build_runner: ^2.4.2
-  built_value_generator: 
+  build: ^2.4.1
+  build_runner: ^2.4.6
+  built_value_generator: ^8.6.1
   flutter_test:
     sdk: flutter
   grinder: ^0.9.4
-  msix: ^3.11.1
+  msix: ^3.16.1
 
 flutter:
   uses-material-design: true

--- a/desktop_photo_search/material/analysis_options.yaml
+++ b/desktop_photo_search/material/analysis_options.yaml
@@ -1,8 +1,5 @@
 include: package:analysis_defaults/flutter.yaml
 
-analyzer:
-  exclude: [lib/src/**.g.dart]
-
 linter:
   rules:
     sort_pub_dependencies: true

--- a/desktop_photo_search/material/lib/src/model/search.g.dart
+++ b/desktop_photo_search/material/lib/src/model/search.g.dart
@@ -41,13 +41,13 @@ class _$SearchSerializer implements StructuredSerializer<Search> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'query':
           result.query = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'results':
           result.results.replace(serializers.deserialize(value,
@@ -69,11 +69,11 @@ class _$Search extends Search {
   final BuiltList<Photo> results;
 
   factory _$Search([void Function(SearchBuilder)? updates]) =>
-      (new SearchBuilder()..update(updates)).build();
+      (new SearchBuilder()..update(updates))._build();
 
   _$Search._({required this.query, required this.results}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(query, 'Search', 'query');
-    BuiltValueNullFieldError.checkNotNull(results, 'Search', 'results');
+    BuiltValueNullFieldError.checkNotNull(query, r'Search', 'query');
+    BuiltValueNullFieldError.checkNotNull(results, r'Search', 'results');
   }
 
   @override
@@ -91,12 +91,16 @@ class _$Search extends Search {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, query.hashCode), results.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, query.hashCode);
+    _$hash = $jc(_$hash, results.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Search')
+    return (newBuiltValueToStringHelper(r'Search')
           ..add('query', query)
           ..add('results', results))
         .toString();
@@ -139,13 +143,15 @@ class SearchBuilder implements Builder<Search, SearchBuilder> {
   }
 
   @override
-  _$Search build() {
+  Search build() => _build();
+
+  _$Search _build() {
     _$Search _$result;
     try {
       _$result = _$v ??
           new _$Search._(
               query: BuiltValueNullFieldError.checkNotNull(
-                  query, 'Search', 'query'),
+                  query, r'Search', 'query'),
               results: results.build());
     } catch (_) {
       late String _$failedField;
@@ -154,7 +160,7 @@ class SearchBuilder implements Builder<Search, SearchBuilder> {
         results.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'Search', _$failedField, e.toString());
+            r'Search', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -163,4 +169,4 @@ class SearchBuilder implements Builder<Search, SearchBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/serializers.g.dart
+++ b/desktop_photo_search/material/lib/src/serializers.g.dart
@@ -41,4 +41,4 @@ Serializers _$serializers = (new Serializers().toBuilder()
           () => new ListBuilder<CurrentUserCollections>()))
     .build();
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/unsplash/api_error.g.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/api_error.g.dart
@@ -41,7 +41,7 @@ class _$ApiErrorSerializer implements StructuredSerializer<ApiError> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -63,7 +63,7 @@ class _$ApiError extends ApiError {
   final BuiltList<String>? errors;
 
   factory _$ApiError([void Function(ApiErrorBuilder)? updates]) =>
-      (new ApiErrorBuilder()..update(updates)).build();
+      (new ApiErrorBuilder()..update(updates))._build();
 
   _$ApiError._({this.errors}) : super._();
 
@@ -82,12 +82,15 @@ class _$ApiError extends ApiError {
 
   @override
   int get hashCode {
-    return $jf($jc(0, errors.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, errors.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('ApiError')..add('errors', errors))
+    return (newBuiltValueToStringHelper(r'ApiError')..add('errors', errors))
         .toString();
   }
 }
@@ -123,7 +126,9 @@ class ApiErrorBuilder implements Builder<ApiError, ApiErrorBuilder> {
   }
 
   @override
-  _$ApiError build() {
+  ApiError build() => _build();
+
+  _$ApiError _build() {
     _$ApiError _$result;
     try {
       _$result = _$v ?? new _$ApiError._(errors: _errors?.build());
@@ -134,7 +139,7 @@ class ApiErrorBuilder implements Builder<ApiError, ApiErrorBuilder> {
         _errors?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'ApiError', _$failedField, e.toString());
+            r'ApiError', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -143,4 +148,4 @@ class ApiErrorBuilder implements Builder<ApiError, ApiErrorBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/unsplash/current_user_collections.g.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/current_user_collections.g.dart
@@ -64,13 +64,13 @@ class _$CurrentUserCollectionsSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'id':
           result.id = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int;
+              specifiedType: const FullType(int))! as int;
           break;
         case 'title':
           result.title = serializers.deserialize(value,
@@ -103,12 +103,12 @@ class _$CurrentUserCollections extends CurrentUserCollections {
 
   factory _$CurrentUserCollections(
           [void Function(CurrentUserCollectionsBuilder)? updates]) =>
-      (new CurrentUserCollectionsBuilder()..update(updates)).build();
+      (new CurrentUserCollectionsBuilder()..update(updates))._build();
 
   _$CurrentUserCollections._(
       {required this.id, this.title, this.publishedAt, this.updatedAt})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(id, 'CurrentUserCollections', 'id');
+    BuiltValueNullFieldError.checkNotNull(id, r'CurrentUserCollections', 'id');
   }
 
   @override
@@ -132,14 +132,18 @@ class _$CurrentUserCollections extends CurrentUserCollections {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, id.hashCode), title.hashCode), publishedAt.hashCode),
-        updatedAt.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jc(_$hash, publishedAt.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('CurrentUserCollections')
+    return (newBuiltValueToStringHelper(r'CurrentUserCollections')
           ..add('id', id)
           ..add('title', title)
           ..add('publishedAt', publishedAt)
@@ -194,11 +198,13 @@ class CurrentUserCollectionsBuilder
   }
 
   @override
-  _$CurrentUserCollections build() {
+  CurrentUserCollections build() => _build();
+
+  _$CurrentUserCollections _build() {
     final _$result = _$v ??
         new _$CurrentUserCollections._(
             id: BuiltValueNullFieldError.checkNotNull(
-                id, 'CurrentUserCollections', 'id'),
+                id, r'CurrentUserCollections', 'id'),
             title: title,
             publishedAt: publishedAt,
             updatedAt: updatedAt);
@@ -207,4 +213,4 @@ class CurrentUserCollectionsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/unsplash/exif.g.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/exif.g.dart
@@ -74,7 +74,7 @@ class _$ExifSerializer implements StructuredSerializer<Exif> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -124,7 +124,7 @@ class _$Exif extends Exif {
   final int? iso;
 
   factory _$Exif([void Function(ExifBuilder)? updates]) =>
-      (new ExifBuilder()..update(updates)).build();
+      (new ExifBuilder()..update(updates))._build();
 
   _$Exif._(
       {this.make,
@@ -156,19 +156,20 @@ class _$Exif extends Exif {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc($jc($jc(0, make.hashCode), model.hashCode),
-                    exposureTime.hashCode),
-                aperture.hashCode),
-            focalLength.hashCode),
-        iso.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, make.hashCode);
+    _$hash = $jc(_$hash, model.hashCode);
+    _$hash = $jc(_$hash, exposureTime.hashCode);
+    _$hash = $jc(_$hash, aperture.hashCode);
+    _$hash = $jc(_$hash, focalLength.hashCode);
+    _$hash = $jc(_$hash, iso.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Exif')
+    return (newBuiltValueToStringHelper(r'Exif')
           ..add('make', make)
           ..add('model', model)
           ..add('exposureTime', exposureTime)
@@ -234,7 +235,9 @@ class ExifBuilder implements Builder<Exif, ExifBuilder> {
   }
 
   @override
-  _$Exif build() {
+  Exif build() => _build();
+
+  _$Exif _build() {
     final _$result = _$v ??
         new _$Exif._(
             make: make,
@@ -248,4 +251,4 @@ class ExifBuilder implements Builder<Exif, ExifBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/unsplash/links.g.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/links.g.dart
@@ -61,7 +61,7 @@ class _$LinksSerializer implements StructuredSerializer<Links> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -99,7 +99,7 @@ class _$Links extends Links {
   final String? downloadLocation;
 
   factory _$Links([void Function(LinksBuilder)? updates]) =>
-      (new LinksBuilder()..update(updates)).build();
+      (new LinksBuilder()..update(updates))._build();
 
   _$Links._({this.self, this.html, this.download, this.downloadLocation})
       : super._();
@@ -123,14 +123,18 @@ class _$Links extends Links {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, self.hashCode), html.hashCode), download.hashCode),
-        downloadLocation.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, self.hashCode);
+    _$hash = $jc(_$hash, html.hashCode);
+    _$hash = $jc(_$hash, download.hashCode);
+    _$hash = $jc(_$hash, downloadLocation.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Links')
+    return (newBuiltValueToStringHelper(r'Links')
           ..add('self', self)
           ..add('html', html)
           ..add('download', download)
@@ -185,7 +189,9 @@ class LinksBuilder implements Builder<Links, LinksBuilder> {
   }
 
   @override
-  _$Links build() {
+  Links build() => _build();
+
+  _$Links _build() {
     final _$result = _$v ??
         new _$Links._(
             self: self,
@@ -197,4 +203,4 @@ class LinksBuilder implements Builder<Links, LinksBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/unsplash/location.g.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/location.g.dart
@@ -54,7 +54,7 @@ class _$LocationSerializer implements StructuredSerializer<Location> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -86,7 +86,7 @@ class _$Location extends Location {
   final Position? position;
 
   factory _$Location([void Function(LocationBuilder)? updates]) =>
-      (new LocationBuilder()..update(updates)).build();
+      (new LocationBuilder()..update(updates))._build();
 
   _$Location._({this.city, this.country, this.position}) : super._();
 
@@ -108,13 +108,17 @@ class _$Location extends Location {
 
   @override
   int get hashCode {
-    return $jf(
-        $jc($jc($jc(0, city.hashCode), country.hashCode), position.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, city.hashCode);
+    _$hash = $jc(_$hash, country.hashCode);
+    _$hash = $jc(_$hash, position.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Location')
+    return (newBuiltValueToStringHelper(r'Location')
           ..add('city', city)
           ..add('country', country)
           ..add('position', position))
@@ -162,7 +166,9 @@ class LocationBuilder implements Builder<Location, LocationBuilder> {
   }
 
   @override
-  _$Location build() {
+  Location build() => _build();
+
+  _$Location _build() {
     _$Location _$result;
     try {
       _$result = _$v ??
@@ -175,7 +181,7 @@ class LocationBuilder implements Builder<Location, LocationBuilder> {
         _position?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'Location', _$failedField, e.toString());
+            r'Location', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -184,4 +190,4 @@ class LocationBuilder implements Builder<Location, LocationBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/unsplash/photo.g.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/photo.g.dart
@@ -146,13 +146,13 @@ class _$PhotoSerializer implements StructuredSerializer<Photo> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'id':
           result.id = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'created_at':
           result.createdAt = serializers.deserialize(value,
@@ -266,7 +266,7 @@ class _$Photo extends Photo {
   final User? user;
 
   factory _$Photo([void Function(PhotoBuilder)? updates]) =>
-      (new PhotoBuilder()..update(updates)).build();
+      (new PhotoBuilder()..update(updates))._build();
 
   _$Photo._(
       {required this.id,
@@ -287,7 +287,7 @@ class _$Photo extends Photo {
       this.links,
       this.user})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(id, 'Photo', 'id');
+    BuiltValueNullFieldError.checkNotNull(id, r'Photo', 'id');
   }
 
   @override
@@ -322,49 +322,31 @@ class _$Photo extends Photo {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc(
-                                $jc(
-                                    $jc(
-                                        $jc(
-                                            $jc(
-                                                $jc(
-                                                    $jc(
-                                                        $jc(
-                                                            $jc(
-                                                                $jc(
-                                                                    $jc(
-                                                                        0,
-                                                                        id
-                                                                            .hashCode),
-                                                                    createdAt
-                                                                        .hashCode),
-                                                                updatedAt
-                                                                    .hashCode),
-                                                            width.hashCode),
-                                                        height.hashCode),
-                                                    color.hashCode),
-                                                downloads.hashCode),
-                                            likes.hashCode),
-                                        likedByUser.hashCode),
-                                    description.hashCode),
-                                exif.hashCode),
-                            location.hashCode),
-                        tags.hashCode),
-                    currentUserCollections.hashCode),
-                urls.hashCode),
-            links.hashCode),
-        user.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jc(_$hash, width.hashCode);
+    _$hash = $jc(_$hash, height.hashCode);
+    _$hash = $jc(_$hash, color.hashCode);
+    _$hash = $jc(_$hash, downloads.hashCode);
+    _$hash = $jc(_$hash, likes.hashCode);
+    _$hash = $jc(_$hash, likedByUser.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, exif.hashCode);
+    _$hash = $jc(_$hash, location.hashCode);
+    _$hash = $jc(_$hash, tags.hashCode);
+    _$hash = $jc(_$hash, currentUserCollections.hashCode);
+    _$hash = $jc(_$hash, urls.hashCode);
+    _$hash = $jc(_$hash, links.hashCode);
+    _$hash = $jc(_$hash, user.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Photo')
+    return (newBuiltValueToStringHelper(r'Photo')
           ..add('id', id)
           ..add('createdAt', createdAt)
           ..add('updatedAt', updatedAt)
@@ -500,12 +482,14 @@ class PhotoBuilder implements Builder<Photo, PhotoBuilder> {
   }
 
   @override
-  _$Photo build() {
+  Photo build() => _build();
+
+  _$Photo _build() {
     _$Photo _$result;
     try {
       _$result = _$v ??
           new _$Photo._(
-              id: BuiltValueNullFieldError.checkNotNull(id, 'Photo', 'id'),
+              id: BuiltValueNullFieldError.checkNotNull(id, r'Photo', 'id'),
               createdAt: createdAt,
               updatedAt: updatedAt,
               width: width,
@@ -541,7 +525,7 @@ class PhotoBuilder implements Builder<Photo, PhotoBuilder> {
         _user?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'Photo', _$failedField, e.toString());
+            r'Photo', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -550,4 +534,4 @@ class PhotoBuilder implements Builder<Photo, PhotoBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/unsplash/position.g.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/position.g.dart
@@ -40,17 +40,17 @@ class _$PositionSerializer implements StructuredSerializer<Position> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'latitude':
           result.latitude = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double;
+              specifiedType: const FullType(double))! as double;
           break;
         case 'longitude':
           result.longitude = serializers.deserialize(value,
-              specifiedType: const FullType(double)) as double;
+              specifiedType: const FullType(double))! as double;
           break;
       }
     }
@@ -66,11 +66,11 @@ class _$Position extends Position {
   final double longitude;
 
   factory _$Position([void Function(PositionBuilder)? updates]) =>
-      (new PositionBuilder()..update(updates)).build();
+      (new PositionBuilder()..update(updates))._build();
 
   _$Position._({required this.latitude, required this.longitude}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(latitude, 'Position', 'latitude');
-    BuiltValueNullFieldError.checkNotNull(longitude, 'Position', 'longitude');
+    BuiltValueNullFieldError.checkNotNull(latitude, r'Position', 'latitude');
+    BuiltValueNullFieldError.checkNotNull(longitude, r'Position', 'longitude');
   }
 
   @override
@@ -90,12 +90,16 @@ class _$Position extends Position {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, latitude.hashCode), longitude.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, latitude.hashCode);
+    _$hash = $jc(_$hash, longitude.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Position')
+    return (newBuiltValueToStringHelper(r'Position')
           ..add('latitude', latitude)
           ..add('longitude', longitude))
         .toString();
@@ -137,16 +141,18 @@ class PositionBuilder implements Builder<Position, PositionBuilder> {
   }
 
   @override
-  _$Position build() {
+  Position build() => _build();
+
+  _$Position _build() {
     final _$result = _$v ??
         new _$Position._(
             latitude: BuiltValueNullFieldError.checkNotNull(
-                latitude, 'Position', 'latitude'),
+                latitude, r'Position', 'latitude'),
             longitude: BuiltValueNullFieldError.checkNotNull(
-                longitude, 'Position', 'longitude'));
+                longitude, r'Position', 'longitude'));
     replace(_$result);
     return _$result;
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/unsplash/search_photos_response.g.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/search_photos_response.g.dart
@@ -57,7 +57,7 @@ class _$SearchPhotosResponseSerializer
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -92,12 +92,12 @@ class _$SearchPhotosResponse extends SearchPhotosResponse {
 
   factory _$SearchPhotosResponse(
           [void Function(SearchPhotosResponseBuilder)? updates]) =>
-      (new SearchPhotosResponseBuilder()..update(updates)).build();
+      (new SearchPhotosResponseBuilder()..update(updates))._build();
 
   _$SearchPhotosResponse._({this.total, this.totalPages, required this.results})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
-        results, 'SearchPhotosResponse', 'results');
+        results, r'SearchPhotosResponse', 'results');
   }
 
   @override
@@ -120,13 +120,17 @@ class _$SearchPhotosResponse extends SearchPhotosResponse {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc(0, total.hashCode), totalPages.hashCode), results.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, total.hashCode);
+    _$hash = $jc(_$hash, totalPages.hashCode);
+    _$hash = $jc(_$hash, results.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('SearchPhotosResponse')
+    return (newBuiltValueToStringHelper(r'SearchPhotosResponse')
           ..add('total', total)
           ..add('totalPages', totalPages)
           ..add('results', results))
@@ -176,7 +180,9 @@ class SearchPhotosResponseBuilder
   }
 
   @override
-  _$SearchPhotosResponse build() {
+  SearchPhotosResponse build() => _build();
+
+  _$SearchPhotosResponse _build() {
     _$SearchPhotosResponse _$result;
     try {
       _$result = _$v ??
@@ -189,7 +195,7 @@ class SearchPhotosResponseBuilder
         results.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'SearchPhotosResponse', _$failedField, e.toString());
+            r'SearchPhotosResponse', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -198,4 +204,4 @@ class SearchPhotosResponseBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/unsplash/tags.g.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/tags.g.dart
@@ -37,13 +37,13 @@ class _$TagsSerializer implements StructuredSerializer<Tags> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'title':
           result.title = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -57,10 +57,10 @@ class _$Tags extends Tags {
   final String title;
 
   factory _$Tags([void Function(TagsBuilder)? updates]) =>
-      (new TagsBuilder()..update(updates)).build();
+      (new TagsBuilder()..update(updates))._build();
 
   _$Tags._({required this.title}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(title, 'Tags', 'title');
+    BuiltValueNullFieldError.checkNotNull(title, r'Tags', 'title');
   }
 
   @override
@@ -78,12 +78,15 @@ class _$Tags extends Tags {
 
   @override
   int get hashCode {
-    return $jf($jc(0, title.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Tags')..add('title', title))
+    return (newBuiltValueToStringHelper(r'Tags')..add('title', title))
         .toString();
   }
 }
@@ -118,14 +121,16 @@ class TagsBuilder implements Builder<Tags, TagsBuilder> {
   }
 
   @override
-  _$Tags build() {
+  Tags build() => _build();
+
+  _$Tags _build() {
     final _$result = _$v ??
         new _$Tags._(
             title:
-                BuiltValueNullFieldError.checkNotNull(title, 'Tags', 'title'));
+                BuiltValueNullFieldError.checkNotNull(title, r'Tags', 'title'));
     replace(_$result);
     return _$result;
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/unsplash/urls.g.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/urls.g.dart
@@ -68,7 +68,7 @@ class _$UrlsSerializer implements StructuredSerializer<Urls> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
@@ -112,7 +112,7 @@ class _$Urls extends Urls {
   final String? thumb;
 
   factory _$Urls([void Function(UrlsBuilder)? updates]) =>
-      (new UrlsBuilder()..update(updates)).build();
+      (new UrlsBuilder()..update(updates))._build();
 
   _$Urls._({this.raw, this.full, this.regular, this.small, this.thumb})
       : super._();
@@ -137,15 +137,19 @@ class _$Urls extends Urls {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc($jc(0, raw.hashCode), full.hashCode), regular.hashCode),
-            small.hashCode),
-        thumb.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, raw.hashCode);
+    _$hash = $jc(_$hash, full.hashCode);
+    _$hash = $jc(_$hash, regular.hashCode);
+    _$hash = $jc(_$hash, small.hashCode);
+    _$hash = $jc(_$hash, thumb.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('Urls')
+    return (newBuiltValueToStringHelper(r'Urls')
           ..add('raw', raw)
           ..add('full', full)
           ..add('regular', regular)
@@ -205,7 +209,9 @@ class UrlsBuilder implements Builder<Urls, UrlsBuilder> {
   }
 
   @override
-  _$Urls build() {
+  Urls build() => _build();
+
+  _$Urls _build() {
     final _$result = _$v ??
         new _$Urls._(
             raw: raw, full: full, regular: regular, small: small, thumb: thumb);
@@ -214,4 +220,4 @@ class UrlsBuilder implements Builder<Urls, UrlsBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/lib/src/unsplash/user.g.dart
+++ b/desktop_photo_search/material/lib/src/unsplash/user.g.dart
@@ -94,13 +94,13 @@ class _$UserSerializer implements StructuredSerializer<User> {
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
-      final key = iterator.current as String;
+      final key = iterator.current! as String;
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
         case 'id':
           result.id = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'updated_at':
           result.updatedAt = serializers.deserialize(value,
@@ -108,11 +108,11 @@ class _$UserSerializer implements StructuredSerializer<User> {
           break;
         case 'username':
           result.username = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'name':
           result.name = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String))! as String;
           break;
         case 'portfolio_url':
           result.portfolioUrl = serializers.deserialize(value,
@@ -174,7 +174,7 @@ class _$User extends User {
   final Links? links;
 
   factory _$User([void Function(UserBuilder)? updates]) =>
-      (new UserBuilder()..update(updates)).build();
+      (new UserBuilder()..update(updates))._build();
 
   _$User._(
       {required this.id,
@@ -189,9 +189,9 @@ class _$User extends User {
       this.totalCollections,
       this.links})
       : super._() {
-    BuiltValueNullFieldError.checkNotNull(id, 'User', 'id');
-    BuiltValueNullFieldError.checkNotNull(username, 'User', 'username');
-    BuiltValueNullFieldError.checkNotNull(name, 'User', 'name');
+    BuiltValueNullFieldError.checkNotNull(id, r'User', 'id');
+    BuiltValueNullFieldError.checkNotNull(username, r'User', 'username');
+    BuiltValueNullFieldError.checkNotNull(name, r'User', 'name');
   }
 
   @override
@@ -220,31 +220,25 @@ class _$User extends User {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc(
-                                $jc(
-                                    $jc(
-                                        $jc($jc(0, id.hashCode),
-                                            updatedAt.hashCode),
-                                        username.hashCode),
-                                    name.hashCode),
-                                portfolioUrl.hashCode),
-                            bio.hashCode),
-                        location.hashCode),
-                    totalLikes.hashCode),
-                totalPhotos.hashCode),
-            totalCollections.hashCode),
-        links.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jc(_$hash, username.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, portfolioUrl.hashCode);
+    _$hash = $jc(_$hash, bio.hashCode);
+    _$hash = $jc(_$hash, location.hashCode);
+    _$hash = $jc(_$hash, totalLikes.hashCode);
+    _$hash = $jc(_$hash, totalPhotos.hashCode);
+    _$hash = $jc(_$hash, totalCollections.hashCode);
+    _$hash = $jc(_$hash, links.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper('User')
+    return (newBuiltValueToStringHelper(r'User')
           ..add('id', id)
           ..add('updatedAt', updatedAt)
           ..add('username', username)
@@ -341,16 +335,19 @@ class UserBuilder implements Builder<User, UserBuilder> {
   }
 
   @override
-  _$User build() {
+  User build() => _build();
+
+  _$User _build() {
     _$User _$result;
     try {
       _$result = _$v ??
           new _$User._(
-              id: BuiltValueNullFieldError.checkNotNull(id, 'User', 'id'),
+              id: BuiltValueNullFieldError.checkNotNull(id, r'User', 'id'),
               updatedAt: updatedAt,
               username: BuiltValueNullFieldError.checkNotNull(
-                  username, 'User', 'username'),
-              name: BuiltValueNullFieldError.checkNotNull(name, 'User', 'name'),
+                  username, r'User', 'username'),
+              name:
+                  BuiltValueNullFieldError.checkNotNull(name, r'User', 'name'),
               portfolioUrl: portfolioUrl,
               bio: bio,
               location: location,
@@ -365,7 +362,7 @@ class UserBuilder implements Builder<User, UserBuilder> {
         _links?.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
-            'User', _$failedField, e.toString());
+            r'User', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -374,4 +371,4 @@ class UserBuilder implements Builder<User, UserBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/desktop_photo_search/material/macos/Runner.xcodeproj/project.pbxproj
+++ b/desktop_photo_search/material/macos/Runner.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {

--- a/desktop_photo_search/material/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/desktop_photo_search/material/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/desktop_photo_search/material/pubspec.yaml
+++ b/desktop_photo_search/material/pubspec.yaml
@@ -8,23 +8,23 @@ environment:
 
 dependencies:
   built_collection: ^5.1.1
-  built_value: ^8.3.0
-  cupertino_icons: ^1.0.2
+  built_value: ^8.6.1
+  cupertino_icons: ^1.0.5
   file_selector: ^1.0.0
   flutter:
     sdk: flutter
-  flutter_simple_treeview: ^3.0.0-nullsafety.1
-  http: ^1.0.0
-  logging: ^1.0.2
+  flutter_simple_treeview: ^3.0.2
+  http: ^1.1.0
+  logging: ^1.2.0
   menubar:
     git:
       url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/menubar
       ref: 6c66ad23ee79749f30a8eece542cf54eaf157ed8
-  provider: ^6.0.2
-  transparent_image: ^2.0.0
-  url_launcher: ^6.1.1
-  uuid: ^3.0.5
+  provider: ^6.0.5
+  transparent_image: ^2.0.1
+  url_launcher: ^6.1.12
+  uuid: ^3.0.7
   window_size:
     git:
       url: https://github.com/google/flutter-desktop-embedding.git
@@ -34,14 +34,14 @@ dependencies:
 dev_dependencies:
   analysis_defaults:
     path: ../../analysis_defaults
-  async: ^2.8.2
-  build: ^2.2.1
-  build_runner: ^2.1.7
-  built_value_generator: ^8.3.0
+  async: ^2.11.0
+  build: ^2.4.1
+  build_runner: ^2.4.6
+  built_value_generator: ^8.6.1
   flutter_test:
     sdk: flutter
-  grinder: ^0.9.0
-  msix: ^3.9.2
+  grinder: ^0.9.4
+  msix: ^3.16.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
No functional changes, just cleanup. 

Updating the build_value build dependencies then regenerating allows us to remove the analysis excludes in the `analysis_options.yaml` files due to them now ignoring lints.