### PR TITLE
[web_embedding] Fix scrollbars on embedding sample.

### DIFF
--- a/web_embedding/element_embedding_demo/web/css/style.css
+++ b/web_embedding/element_embedding_demo/web/css/style.css
@@ -65,6 +65,7 @@ section.contents article {
   margin-top: 50px;
   display: flex;
   justify-content: center;
+  overflow: hidden;
 }
 
 /** Title */
@@ -157,6 +158,7 @@ h1 {
   height: 480px;
   border-radius: 0px;
   transition: all 150ms ease-in;
+  align-self: center;
 }
 #flutter_target.resize {
   width: 480px;
@@ -249,6 +251,7 @@ h1 {
   border-radius: 34px;
   border: 1px solid #000;
   overflow: hidden;
+  align-self: initial;
 }
 
 .imageAttribution {


### PR DESCRIPTION
I was using the embedding sample for an unrelated reason, and found that when using the "rotation" feature, scrollbars would show up all over the place (something changed with regards to `perspective`, maybe?).

This PR addresses the issue.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md