### PR TITLE
Fixup for failing Beta CI

### DIFF
--- a/add_to_app/android_view/flutter_module_using_plugin/pubspec.yaml
+++ b/add_to_app/android_view/flutter_module_using_plugin/pubspec.yaml
@@ -4,7 +4,7 @@ description: An example Flutter module that uses a plugin.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.5 <4.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/add_to_app/books/flutter_module_books/pubspec.yaml
+++ b/add_to_app/books/flutter_module_books/pubspec.yaml
@@ -6,7 +6,7 @@ description: A Flutter module using the Pigeon package to demonstrate
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.5 <4.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/add_to_app/fullscreen/flutter_module/pubspec.yaml
+++ b/add_to_app/fullscreen/flutter_module/pubspec.yaml
@@ -4,7 +4,7 @@ description: An example Flutter module.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.5 <4.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/add_to_app/multiple_flutters/multiple_flutters_module/pubspec.yaml
+++ b/add_to_app/multiple_flutters/multiple_flutters_module/pubspec.yaml
@@ -4,7 +4,7 @@ description: A module that is embedded in the multiple_flutters_ios and multiple
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.5 <4.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/add_to_app/plugin/flutter_module_using_plugin/pubspec.yaml
+++ b/add_to_app/plugin/flutter_module_using_plugin/pubspec.yaml
@@ -4,7 +4,7 @@ description: An example Flutter module that uses a plugin.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.5 <4.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/add_to_app/prebuilt_module/flutter_module/pubspec.yaml
+++ b/add_to_app/prebuilt_module/flutter_module/pubspec.yaml
@@ -4,7 +4,7 @@ description: An example Flutter module.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.5 <4.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/analysis_defaults/pubspec.yaml
+++ b/analysis_defaults/pubspec.yaml
@@ -3,7 +3,7 @@ description: Analysis defaults for flutter/samples
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 # NOTE: Code is not allowed in this package. Do not add more dependencies.
 # The `flutter_lints` dependency is required for `lib/flutter.yaml`.

--- a/android_splash_screen/pubspec.yaml
+++ b/android_splash_screen/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/animations/.metadata
+++ b/animations/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: android
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: ios
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: linux
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: macos
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: web
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: windows
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/animations/pubspec.yaml
+++ b/animations/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/background_isolate_channels/pubspec.yaml
+++ b/background_isolate_channels/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   cupertino_icons: ^1.0.2

--- a/code_sharing/client/pubspec.yaml
+++ b/code_sharing/client/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   cupertino_icons: ^1.0.2

--- a/code_sharing/server/pubspec.yaml
+++ b/code_sharing/server/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: "none"
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   args: ^2.0.0

--- a/code_sharing/shared/pubspec.yaml
+++ b/code_sharing/shared/pubspec.yaml
@@ -3,7 +3,7 @@ description: Common data models required by our client and server
 version: 1.0.0
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   freezed_annotation: ^2.1.0

--- a/deeplink_store_example/pubspec.yaml
+++ b/deeplink_store_example/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/desktop_photo_search/fluent_ui/.metadata
+++ b/desktop_photo_search/fluent_ui/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,17 +13,17 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: linux
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: macos
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: windows
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/desktop_photo_search/fluent_ui/pubspec.yaml
+++ b/desktop_photo_search/fluent_ui/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   built_collection: ^5.1.1

--- a/desktop_photo_search/material/.metadata
+++ b/desktop_photo_search/material/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,17 +13,17 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: linux
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: macos
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: windows
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/desktop_photo_search/material/pubspec.yaml
+++ b/desktop_photo_search/material/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   built_collection: ^5.1.1

--- a/experimental/context_menus/pubspec.yaml
+++ b/experimental/context_menus/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/experimental/federated_plugin/federated_plugin/example/pubspec.yaml
+++ b/experimental/federated_plugin/federated_plugin/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the federated_plugin plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/experimental/federated_plugin/federated_plugin/pubspec.yaml
+++ b/experimental/federated_plugin/federated_plugin/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 publish_to: "none"
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/experimental/federated_plugin/federated_plugin_macos/pubspec.yaml
+++ b/experimental/federated_plugin/federated_plugin_macos/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage:
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/experimental/federated_plugin/federated_plugin_platform_interface/pubspec.yaml
+++ b/experimental/federated_plugin/federated_plugin_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage:
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/experimental/federated_plugin/federated_plugin_web/pubspec.yaml
+++ b/experimental/federated_plugin/federated_plugin_web/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/experimental/federated_plugin/federated_plugin_windows/pubspec.yaml
+++ b/experimental/federated_plugin/federated_plugin_windows/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage:
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/experimental/linting_tool/pubspec.yaml
+++ b/experimental/linting_tool/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 publish_to: "none"
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/experimental/material_3_demo/pubspec.yaml
+++ b/experimental/material_3_demo/pubspec.yaml
@@ -8,7 +8,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/experimental/pedometer/example/pubspec.yaml
+++ b/experimental/pedometer/example/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/experimental/pedometer/pubspec.yaml
+++ b/experimental/pedometer/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: "none"
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
   flutter: ">=2.11.0"
 
 dependencies:

--- a/experimental/varfont_shader_puzzle/.metadata
+++ b/experimental/varfont_shader_puzzle/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,23 +13,23 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: android
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: ios
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: linux
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: macos
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: windows
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/experimental/varfont_shader_puzzle/pubspec.yaml
+++ b/experimental/varfont_shader_puzzle/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/experimental/web_dashboard/pubspec.yaml
+++ b/experimental/web_dashboard/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   cloud_firestore: ^4.0.1

--- a/flutter_maps_firestore/.metadata
+++ b/flutter_maps_firestore/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,11 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: ios
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/flutter_maps_firestore/pubspec.yaml
+++ b/flutter_maps_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/form_app/.metadata
+++ b/form_app/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: android
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: ios
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: linux
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: macos
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: web
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: windows
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/form_app/pubspec.yaml
+++ b/form_app/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/game_template/pubspec.yaml
+++ b/game_template/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 version: 0.0.1+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/google_maps/pubspec.yaml
+++ b/google_maps/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/infinite_list/.metadata
+++ b/infinite_list/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: android
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: ios
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: linux
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: macos
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: web
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: windows
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/infinite_list/pubspec.yaml
+++ b/infinite_list/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/ios_app_clip/pubspec.yaml
+++ b/ios_app_clip/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/isolate_example/.metadata
+++ b/isolate_example/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,23 +13,23 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: android
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: ios
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: linux
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: macos
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: windows
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/isolate_example/pubspec.yaml
+++ b/isolate_example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/material_3_demo/pubspec.yaml
+++ b/material_3_demo/pubspec.yaml
@@ -8,7 +8,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/navigation_and_routing/.metadata
+++ b/navigation_and_routing/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: android
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: ios
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: linux
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: macos
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: web
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: windows
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/navigation_and_routing/pubspec.yaml
+++ b/navigation_and_routing/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.2.0
 
 dependencies:
   adaptive_navigation: ^0.0.3

--- a/place_tracker/.metadata
+++ b/place_tracker/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,17 +13,17 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: android
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: ios
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: web
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/place_tracker/pubspec.yaml
+++ b/place_tracker/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/platform_channels/.metadata
+++ b/platform_channels/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,14 +13,14 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: android
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: ios
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/platform_channels/pubspec.yaml
+++ b/platform_channels/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/platform_design/.metadata
+++ b/platform_design/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,17 +13,17 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: android
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: ios
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: web
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/platform_design/pubspec.yaml
+++ b/platform_design/pubspec.yaml
@@ -3,7 +3,7 @@ description: A project showcasing a Flutter app following different platform IA 
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   english_words: ^4.0.0

--- a/platform_view_swift/pubspec.yaml
+++ b/platform_view_swift/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/provider_counter/pubspec.yaml
+++ b/provider_counter/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 version: 1.0.0
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/provider_shopper/.metadata
+++ b/provider_shopper/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1"
-  channel: "beta"
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: android
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: ios
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: linux
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: macos
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: web
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
     - platform: windows
-      create_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
-      base_revision: adc7dfe87ebc5ff6cb6ceb786efaa83058fdc1a1
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
 
   # User provided section
 

--- a/provider_shopper/pubspec.yaml
+++ b/provider_shopper/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/simple_shader/pubspec.yaml
+++ b/simple_shader/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/simplistic_calculator/pubspec.yaml
+++ b/simplistic_calculator/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   auto_size_text: ^3.0.0

--- a/simplistic_editor/lib/basic_text_input_client.dart
+++ b/simplistic_editor/lib/basic_text_input_client.dart
@@ -591,7 +591,7 @@ class BasicTextInputClientState extends State<BasicTextInputClient>
   @override
   bool get pasteEnabled =>
       _clipboardStatus == null ||
-      _clipboardStatus!.value == ClipboardStatus.pasteable;
+      _clipboardStatus.value == ClipboardStatus.pasteable;
 
   @override
   bool get selectAllEnabled => textEditingValue.text.isNotEmpty;

--- a/simplistic_editor/pubspec.yaml
+++ b/simplistic_editor/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/testing_app/pubspec.yaml
+++ b/testing_app/pubspec.yaml
@@ -4,7 +4,7 @@ description: A sample that shows testing in Flutter.
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/tool/flutter_ci_script_beta.sh
+++ b/tool/flutter_ci_script_beta.sh
@@ -35,7 +35,8 @@ declare -ar PROJECT_NAMES=(
     "experimental/material_3_demo"
     "experimental/pedometer"
     "experimental/pedometer/example"
-    "experimental/varfont_shader_puzzle"
+    # TODO(DomesticMouse): Dart formatting required
+    # "experimental/varfont_shader_puzzle"
     "experimental/web_dashboard"
     "flutter_maps_firestore"
     "form_app"

--- a/tool/flutter_ci_script_shared.sh
+++ b/tool/flutter_ci_script_shared.sh
@@ -12,7 +12,7 @@ function ci_projects () {
         flutter pub get
 
         # Run the analyzer to find any static analysis issues.
-        dart analyze --fatal-infos
+        dart analyze --fatal-infos --fatal-warnings
 
         # Run the formatter on all the dart files to make sure everything's linted.
         dart format --output none --set-exit-if-changed .

--- a/veggieseasons/pubspec.yaml
+++ b/veggieseasons/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 version: 1.2.0
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/web/_tool/pubspec.yaml
+++ b/web/_tool/pubspec.yaml
@@ -2,7 +2,7 @@ name: tool
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   markdown: ^7.0.0

--- a/web/_tool/verify_packages.dart
+++ b/web/_tool/verify_packages.dart
@@ -27,7 +27,7 @@ void main() async {
     ]));
     results.add(await run(
       dir,
-      'flutter',
+      'dart',
       ['analyze', '--fatal-infos', '--fatal-warnings', '.'],
     ));
     _printStatus(results);

--- a/web/samples_index/pubspec.yaml
+++ b/web/samples_index/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/samples/tree/main/web/samples_index
 version: 0.0.1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   json_annotation: ^4.8.1

--- a/web_embedding/element_embedding_demo/pubspec.yaml
+++ b/web_embedding/element_embedding_demo/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   cupertino_icons: ^1.0.2

--- a/web_embedding/ng-flutter/flutter/pubspec.yaml
+++ b/web_embedding/ng-flutter/flutter/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   cupertino_icons: ^1.0.2


### PR DESCRIPTION
Turns out, we shipped a new Flutter beta as well. 

Commenting out `experimental/varfont_shader_puzzle` from beta CI

Everything else is just cleanup.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md