### PR TITLE
Use `Card.outlined` instead of using hard-coded values for outlined card

### DIFF
--- a/experimental/material_3_demo/lib/component_screen.dart
+++ b/experimental/material_3_demo/lib/component_screen.dart
@@ -2466,14 +2466,7 @@ class _ComponentDecorationState extends State<ComponentDecoration> {
                     focusNode.requestFocus();
                   },
                   behavior: HitTestBehavior.opaque,
-                  child: Card(
-                    elevation: 0,
-                    shape: RoundedRectangleBorder(
-                      side: BorderSide(
-                        color: Theme.of(context).colorScheme.outlineVariant,
-                      ),
-                      borderRadius: const BorderRadius.all(Radius.circular(12)),
-                    ),
+                  child: Card.outlined(
                     child: Padding(
                       padding: const EdgeInsets.symmetric(
                           horizontal: 5.0, vertical: 20.0),

--- a/material_3_demo/lib/component_screen.dart
+++ b/material_3_demo/lib/component_screen.dart
@@ -2466,14 +2466,7 @@ class _ComponentDecorationState extends State<ComponentDecoration> {
                     focusNode.requestFocus();
                   },
                   behavior: HitTestBehavior.opaque,
-                  child: Card(
-                    elevation: 0,
-                    shape: RoundedRectangleBorder(
-                      side: BorderSide(
-                        color: Theme.of(context).colorScheme.outlineVariant,
-                      ),
-                      borderRadius: const BorderRadius.all(Radius.circular(12)),
-                    ),
+                  child: Card.outlined(
                     child: Padding(
                       padding: const EdgeInsets.symmetric(
                           horizontal: 5.0, vertical: 20.0),


### PR DESCRIPTION
We created the factory method [`Card.outlined`](https://github.com/flutter/flutter/pull/136229) a couple weeks ago, so this PR is just to update the outlined card to use the factory method instead of using hard-coded values. No appearance change.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
