### PR TITLE
Remove Expanded from NavigationRail

### DIFF
--- a/material_3_demo/lib/home.dart
+++ b/material_3_demo/lib/home.dart
@@ -214,24 +214,22 @@ class _HomeState extends State<Home> with SingleTickerProviderStateMixin {
                 handleScreenChanged(screenIndex);
               });
             },
-            trailing: Expanded(
-              child: Padding(
-                padding: const EdgeInsets.only(bottom: 20),
-                child: showLargeSizeLayout
-                    ? _ExpandedTrailingActions(
-                        useLightMode: widget.useLightMode,
-                        handleBrightnessChange: widget.handleBrightnessChange,
-                        useMaterial3: widget.useMaterial3,
-                        handleMaterialVersionChange:
-                            widget.handleMaterialVersionChange,
-                        handleImageSelect: widget.handleImageSelect,
-                        handleColorSelect: widget.handleColorSelect,
-                        colorSelectionMethod: widget.colorSelectionMethod,
-                        imageSelected: widget.imageSelected,
-                        colorSelected: widget.colorSelected,
-                      )
-                    : _trailingActions(),
-              ),
+            trailing: Padding(
+              padding: const EdgeInsets.only(bottom: 20),
+              child: showLargeSizeLayout
+                  ? _ExpandedTrailingActions(
+                      useLightMode: widget.useLightMode,
+                      handleBrightnessChange: widget.handleBrightnessChange,
+                      useMaterial3: widget.useMaterial3,
+                      handleMaterialVersionChange:
+                          widget.handleMaterialVersionChange,
+                      handleImageSelect: widget.handleImageSelect,
+                      handleColorSelect: widget.handleColorSelect,
+                      colorSelectionMethod: widget.colorSelectionMethod,
+                      imageSelected: widget.imageSelected,
+                      colorSelected: widget.colorSelected,
+                    )
+                  : _trailingActions(),
             ),
           ),
           navigationBar: NavigationBars(


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/137415 changed NavigationRail to use a SingleChildScrollView, so this sample can't use `Expanded` for the `trailing` widget anymore.

cc: @goderbauer @QuncCccccc 

Fixes flutter/flutter#143061