### PR TITLE
Fixed ThemeData in the Flutter Samples unnecessarily includes useMaterial3 = true (Issue #2214)

### DIFF
--- a/add_to_app/android_view/flutter_module_using_plugin/lib/main.dart
+++ b/add_to_app/android_view/flutter_module_using_plugin/lib/main.dart
@@ -78,7 +78,6 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Module Title',
       theme: ThemeData(
         colorSchemeSeed: Colors.blue,
-        useMaterial3: true,
       ),
       routes: {
         '/': (context) => const FullScreenView(),

--- a/add_to_app/books/flutter_module_books/lib/main.dart
+++ b/add_to_app/books/flutter_module_books/lib/main.dart
@@ -15,7 +15,6 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData(
         primaryColor: const Color(0xff6200ee),
-        useMaterial3: true,
       ),
       home: const BookDetail(),
     );

--- a/add_to_app/fullscreen/flutter_module/lib/main.dart
+++ b/add_to_app/fullscreen/flutter_module/lib/main.dart
@@ -64,7 +64,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Module Title',
-      theme: ThemeData.light(useMaterial3: true),
+      theme: ThemeData.light(),
       routes: {
         '/': (context) => const FullScreenView(),
         '/mini': (context) => const Contents(),

--- a/add_to_app/multiple_flutters/multiple_flutters_module/lib/main.dart
+++ b/add_to_app/multiple_flutters/multiple_flutters_module/lib/main.dart
@@ -25,7 +25,6 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         colorSchemeSeed: color,
-        useMaterial3: true,
         appBarTheme: AppBarTheme(
           backgroundColor: color,
           foregroundColor: Colors.white,

--- a/add_to_app/plugin/flutter_module_using_plugin/lib/main.dart
+++ b/add_to_app/plugin/flutter_module_using_plugin/lib/main.dart
@@ -75,7 +75,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Module Title',
-      theme: ThemeData.light(useMaterial3: true),
+      theme: ThemeData.light(),
       routes: {
         '/': (context) => const FullScreenView(),
         '/mini': (context) => const Contents(),

--- a/add_to_app/prebuilt_module/flutter_module/lib/main.dart
+++ b/add_to_app/prebuilt_module/flutter_module/lib/main.dart
@@ -64,7 +64,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Module Title',
-      theme: ThemeData.light(useMaterial3: true),
+      theme: ThemeData.light(),
       routes: {
         '/': (context) => const FullScreenView(),
         '/mini': (context) => const Contents(),

--- a/android_splash_screen/lib/main.dart
+++ b/android_splash_screen/lib/main.dart
@@ -30,7 +30,6 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
-        useMaterial3: true,
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );

--- a/animations/lib/main.dart
+++ b/animations/lib/main.dart
@@ -184,7 +184,6 @@ class AnimationSamples extends StatelessWidget {
       title: 'Animation Samples',
       theme: ThemeData(
         colorSchemeSeed: Colors.deepPurple,
-        useMaterial3: true,
       ),
       routerConfig: router,
     );

--- a/background_isolate_channels/lib/main.dart
+++ b/background_isolate_channels/lib/main.dart
@@ -31,7 +31,6 @@ class MyApp extends StatelessWidget {
       title: 'Background Isolate Channels',
       theme: ThemeData(
         primarySwatch: Colors.blue,
-        useMaterial3: true,
       ),
       home: const MyHomePage(title: 'Background Isolate Channels'),
     );

--- a/code_sharing/client/lib/main.dart
+++ b/code_sharing/client/lib/main.dart
@@ -34,7 +34,6 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         colorSchemeSeed: Colors.blue,
-        useMaterial3: true,
       ),
       home: MyHomePage(
         title: 'Flutter Demo Home Page',

--- a/context_menus/lib/main.dart
+++ b/context_menus/lib/main.dart
@@ -62,7 +62,6 @@ class _MyAppState extends State<MyApp> {
       theme: ThemeData(
         primarySwatch: Colors.blue,
         platform: defaultTargetPlatform,
-        useMaterial3: true,
       ),
       initialRoute: '/',
       routes: <String, Widget Function(BuildContext)>{

--- a/deeplink_store_example/lib/main.dart
+++ b/deeplink_store_example/lib/main.dart
@@ -28,7 +28,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
-      theme: ThemeData.light(useMaterial3: true),
+      theme: ThemeData.light(),
       routerConfig: GoRouter(
         routes: [
           GoRoute(

--- a/desktop_photo_search/material/lib/main.dart
+++ b/desktop_photo_search/material/lib/main.dart
@@ -64,7 +64,6 @@ class UnsplashSearchApp extends StatelessWidget {
       title: 'Photo Search',
       theme: ThemeData(
         colorSchemeSeed: Colors.orange,
-        useMaterial3: true,
       ),
       home: const UnsplashHomePage(title: 'Photo Search'),
     );

--- a/experimental/federated_plugin/federated_plugin/example/lib/main.dart
+++ b/experimental/federated_plugin/federated_plugin/example/lib/main.dart
@@ -15,7 +15,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      theme: ThemeData.light(useMaterial3: true),
+      theme: ThemeData.light(),
       home: const HomePage(),
     );
   }

--- a/experimental/linting_tool/lib/theme/app_theme.dart
+++ b/experimental/linting_tool/lib/theme/app_theme.dart
@@ -9,7 +9,7 @@ import 'package:linting_tool/theme/colors.dart';
 
 abstract class AppTheme {
   static ThemeData buildReplyLightTheme(BuildContext context) {
-    final base = ThemeData.light(useMaterial3: true);
+    final base = ThemeData.light();
     return base.copyWith(
       bottomSheetTheme: BottomSheetThemeData(
         backgroundColor: AppColors.blue700,

--- a/experimental/pedometer/example/lib/main.dart
+++ b/experimental/pedometer/example/lib/main.dart
@@ -17,7 +17,6 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
-        useMaterial3: true,
       ),
       home: const Home(),
     );

--- a/experimental/varfont_shader_puzzle/lib/main.dart
+++ b/experimental/varfont_shader_puzzle/lib/main.dart
@@ -19,7 +19,6 @@ class TypePuzzle extends StatelessWidget {
       title: 'Type Jam',
       theme: ThemeData(
         primarySwatch: Colors.grey,
-        useMaterial3: true,
       ),
       home: const Scaffold(
         appBar: null,

--- a/experimental/web_dashboard/lib/src/app.dart
+++ b/experimental/web_dashboard/lib/src/app.dart
@@ -66,7 +66,7 @@ class _DashboardAppState extends State<DashboardApp> {
     return Provider.value(
       value: _appState,
       child: MaterialApp(
-        theme: ThemeData.light(useMaterial3: true),
+        theme: ThemeData.light(),
         home: SignInSwitcher(
           appState: _appState,
           apiBuilder: widget.apiBuilder,

--- a/flutter_maps_firestore/lib/main.dart
+++ b/flutter_maps_firestore/lib/main.dart
@@ -36,7 +36,6 @@ class App extends StatelessWidget {
       theme: ThemeData(
         colorSchemeSeed: Colors.pink,
         scaffoldBackgroundColor: Colors.pink[50],
-        useMaterial3: true,
       ),
     );
   }

--- a/form_app/lib/main.dart
+++ b/form_app/lib/main.dart
@@ -90,7 +90,6 @@ class FormApp extends StatelessWidget {
       title: 'Form Samples',
       theme: ThemeData(
         colorSchemeSeed: Colors.teal,
-        useMaterial3: true,
       ),
       routerConfig: router,
     );

--- a/game_template/lib/main.dart
+++ b/game_template/lib/main.dart
@@ -273,7 +273,6 @@ class MyApp extends StatelessWidget {
                   color: palette.ink,
                 ),
               ),
-              useMaterial3: true,
             ),
             routeInformationProvider: _router.routeInformationProvider,
             routeInformationParser: _router.routeInformationParser,

--- a/google_maps/lib/main.dart
+++ b/google_maps/lib/main.dart
@@ -41,7 +41,6 @@ class _MyAppState extends State<MyApp> {
       title: 'Flutter Demo',
       theme: ThemeData(
         primarySwatch: Colors.green,
-        useMaterial3: true,
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/infinite_list/lib/main.dart
+++ b/infinite_list/lib/main.dart
@@ -46,7 +46,7 @@ class MyApp extends StatelessWidget {
       create: (context) => Catalog(),
       child: MaterialApp(
         title: 'Infinite List Sample',
-        theme: ThemeData.light(useMaterial3: true),
+        theme: ThemeData.light(),
         home: const MyHomePage(),
       ),
     );

--- a/isolate_example/lib/main.dart
+++ b/isolate_example/lib/main.dart
@@ -48,7 +48,7 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      theme: ThemeData.light(useMaterial3: true),
+      theme: ThemeData.light(),
       home: DefaultTabController(
         length: 3,
         child: Scaffold(

--- a/place_tracker/lib/place_tracker_app.dart
+++ b/place_tracker/lib/place_tracker_app.dart
@@ -25,7 +25,6 @@ class PlaceTrackerApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       theme: ThemeData(
-        useMaterial3: true,
         colorSchemeSeed: Colors.green,
         appBarTheme: AppBarTheme(
           backgroundColor: Colors.green[700],

--- a/platform_channels/lib/main.dart
+++ b/platform_channels/lib/main.dart
@@ -25,7 +25,6 @@ class PlatformChannelSample extends StatelessWidget {
         snackBarTheme: SnackBarThemeData(
           backgroundColor: Colors.blue[500],
         ),
-        useMaterial3: true,
       ),
       routerConfig: router(),
     );

--- a/platform_design/lib/main.dart
+++ b/platform_design/lib/main.dart
@@ -25,7 +25,6 @@ class MyAdaptingApp extends StatelessWidget {
       theme: ThemeData(
         // Use the green theme for Material widgets.
         primarySwatch: Colors.green,
-        useMaterial3: true,
       ),
       darkTheme: ThemeData.dark(),
       builder: (context, child) {

--- a/platform_view_swift/lib/main.dart
+++ b/platform_view_swift/lib/main.dart
@@ -20,7 +20,6 @@ class PlatformView extends StatelessWidget {
       title: 'Platform View',
       theme: ThemeData(
         primarySwatch: Colors.grey,
-        useMaterial3: true,
       ),
       home: const HomePage(),
     );

--- a/provider_counter/lib/main.dart
+++ b/provider_counter/lib/main.dart
@@ -69,7 +69,6 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
-        useMaterial3: true,
       ),
       home: const MyHomePage(),
     );

--- a/provider_shopper/lib/common/theme.dart
+++ b/provider_shopper/lib/common/theme.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 
 final appTheme = ThemeData(
   colorSchemeSeed: Colors.yellow,
-  useMaterial3: true,
   textTheme: const TextTheme(
     displayLarge: TextStyle(
       fontFamily: 'Corben',

--- a/simple_shader/lib/main.dart
+++ b/simple_shader/lib/main.dart
@@ -16,7 +16,6 @@ class MyApp extends StatelessWidget {
       title: 'Simple Shader Demo',
       theme: ThemeData(
         colorSchemeSeed: Colors.blue,
-        useMaterial3: true,
       ),
       home: const MyHomePage(),
     );

--- a/simplistic_calculator/lib/main.dart
+++ b/simplistic_calculator/lib/main.dart
@@ -347,7 +347,7 @@ class CalculatorApp extends ConsumerWidget {
 
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      theme: ThemeData.light(useMaterial3: true),
+      theme: ThemeData.light(),
       home: Scaffold(
         body: Container(
           color: Colors.white,

--- a/simplistic_editor/lib/main.dart
+++ b/simplistic_editor/lib/main.dart
@@ -22,7 +22,6 @@ class MyApp extends StatelessWidget {
         title: 'Simplistic Editor',
         theme: ThemeData(
           primarySwatch: Colors.blue,
-          useMaterial3: true,
         ),
         home: const MyHomePage(title: 'Simplistic Editor'),
       ),

--- a/testing_app/lib/main.dart
+++ b/testing_app/lib/main.dart
@@ -42,7 +42,6 @@ class TestingApp extends StatelessWidget {
         theme: ThemeData(
           colorSchemeSeed: Colors.blue,
           visualDensity: VisualDensity.adaptivePlatformDensity,
-          useMaterial3: true,
         ),
         routerConfig: router(),
       ),

--- a/web/_packages/web_startup_analyzer/example/lib/main.dart
+++ b/web/_packages/web_startup_analyzer/example/lib/main.dart
@@ -41,7 +41,6 @@ class WebStartupAnalyzerSample extends StatelessWidget {
       title: 'Flutter web app timing',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.green.shade100),
-        useMaterial3: true,
       ),
       home: WebStartupAnalyzerScreen(analyzer: analyzer),
     );

--- a/web_embedding/element_embedding_demo/lib/main.dart
+++ b/web_embedding/element_embedding_demo/lib/main.dart
@@ -65,7 +65,6 @@ class _MyAppState extends State<MyApp> {
       title: 'Element embedding',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-        useMaterial3: true,
       ),
       debugShowCheckedModeBanner: false,
       home: demoScreenRouter(_currentDemoScreen),

--- a/web_embedding/ng-flutter/flutter/lib/main.dart
+++ b/web_embedding/ng-flutter/flutter/lib/main.dart
@@ -52,7 +52,6 @@ class _MyAppState extends State<MyApp> {
       title: 'Element embedding',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-        useMaterial3: true,
       ),
       home: ValueListenableBuilder<DemoScreen>(
         valueListenable: _screen,


### PR DESCRIPTION
This PR has fixed an Issue(#2214) by removing the useMaterial3 = true as it is already true by default


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.