### PR TITLE
Removes outdated 'window_size' package from navigation_and_routing app

### DIFF
--- a/navigation_and_routing/lib/main.dart
+++ b/navigation_and_routing/lib/main.dart
@@ -2,12 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io' show Platform;
-
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:url_strategy/url_strategy.dart';
-import 'package:window_size/window_size.dart';
 
 import 'src/app.dart';
 
@@ -23,25 +19,8 @@ void main() {
   setHashUrlStrategy();
   // setPathUrlStrategy();
 
-  setupWindow();
   runApp(const Bookstore());
 }
 
 const double windowWidth = 480;
 const double windowHeight = 854;
-
-void setupWindow() {
-  if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
-    WidgetsFlutterBinding.ensureInitialized();
-    setWindowTitle('Navigation and routing');
-    setWindowMinSize(const Size(windowWidth, windowHeight));
-    setWindowMaxSize(const Size(windowWidth, windowHeight));
-    getCurrentScreen().then((screen) {
-      setWindowFrame(Rect.fromCenter(
-        center: screen!.frame.center,
-        width: windowWidth,
-        height: windowHeight,
-      ));
-    });
-  }
-}

--- a/navigation_and_routing/pubspec.yaml
+++ b/navigation_and_routing/pubspec.yaml
@@ -17,10 +17,6 @@ dependencies:
   quiver: ^3.1.0
   url_launcher: ^6.1.1
   url_strategy: ^0.2.0
-  window_size:
-    git:
-      url: https://github.com/google/flutter-desktop-embedding.git
-      path: plugins/window_size
 
 dev_dependencies:
   analysis_defaults:


### PR DESCRIPTION
That package was breaking the app, and 'pub get'. And according to the [plugin's Github](https://github.com/google/flutter-desktop-embedding), it's no longer necessary. 