### PR TITLE
Fix 'Unsupported operation: removeAt' error when IconLoadingAnimator …

### DIFF
--- a/ai_recipe_generation/lib/router.dart
+++ b/ai_recipe_generation/lib/router.dart
@@ -175,7 +175,7 @@ class _AdaptiveRouterState extends State<AdaptiveRouter>
                   height: 160,
                   width: 160,
                   child: IconLoadingAnimator(
-                    icons: const [
+                    icons: [
                       Symbols.icecream,
                       Symbols.local_pizza,
                       Symbols.restaurant_menu,


### PR DESCRIPTION
This is a bug from ai_recipe_generation presented at Google I/O 2024

When you press Submit Prompt button the IconLoadingAnimator show an error: Unsupported operation: removeAt

![Captura de pantalla 2024-05-24 a la(s) 10 03 09 a  m](https://github.com/flutter/samples/assets/352200/71568236-f0de-46bb-8469-586df0e4bfa5)

This error occurs because it's trying to remove an element from a constant list

`currentIcon =
        notYetSeenIcons.removeAt(rand.nextInt(notYetSeenIcons.length));`

`child: IconLoadingAnimator(
                    icons: const [
                      Symbols.icecream,
                      Symbols.local_pizza,
                      Symbols.restaurant_menu,
                      Symbols.egg,
                      Symbols.bakery_dining,
                      Symbols.skillet,
                      Symbols.nutrition,
                      Symbols.grocery,
                      Symbols.set_meal,
                      Icons.egg_alt,
                      Symbols.oven,
                      Icons.dinner_dining,
                      Icons.outdoor_grill,
                      Icons.cookie,
                      Icons.blender,
                      Symbols.stockpot,
                    ],
                  ),`

cc: @domesticmouse @ericwindmill 
