### PR TITLE
m3_demo - Enables edge to edge support.

### DIFF
--- a/material_3_demo/android/app/src/main/kotlin/com/example/material_3_demo/MainActivity.kt
+++ b/material_3_demo/android/app/src/main/kotlin/com/example/material_3_demo/MainActivity.kt
@@ -1,6 +1,14 @@
 package com.example.material_3_demo
 
 import io.flutter.embedding.android.FlutterActivity
+import android.os.Bundle
+import androidx.core.view.WindowCompat
 
 class MainActivity: FlutterActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+    }
+
 }

--- a/material_3_demo/android/app/src/main/res/values/styles.xml
+++ b/material_3_demo/android/app/src/main/res/values/styles.xml
@@ -14,5 +14,19 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
+        <!-- values-v29/themes.xml -->
+        <item name="android:navigationBarColor">
+            @android:color/transparent
+        </item>
+
+        <!-- Optional: set to transparent if your app is drawing behind the status bar. -->
+        <item name="android:statusBarColor">
+            @android:color/transparent
+        </item>
+
+        <!-- Optional: set for a light status bar with dark content. -->
+        <item name="android:windowLightStatusBar">
+            true
+        </item>
     </style>
 </resources>


### PR DESCRIPTION
Edge to edge is coming by default to Flutter 3.26+ (or thereabouts) when the targetSdk is raised to Android 15(API 35). In the meantime, it can be done manually by adjusting the theme and setting `WindowCompat.setDecorFitsSystemWindows`.

The fix is purely on the Android side. iOS is unaffected.

Sourced from https://developer.android.com/develop/ui/views/layout/edge-to-edge-manually

Fixes #1720 .

## Pre-launch Checklist

- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I read the [Contributors Guide].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md