### PR TITLE
Rename components to use cases. 

### DIFF
--- a/compass_app/app/lib/config/dependencies.dart
+++ b/compass_app/app/lib/config/dependencies.dart
@@ -25,14 +25,14 @@ import '../data/repositories/destination/destination_repository_remote.dart';
 import '../data/repositories/itinerary_config/itinerary_config_repository.dart';
 import '../data/repositories/itinerary_config/itinerary_config_repository_memory.dart';
 import '../data/services/api/api_client.dart';
-import '../domain/components/booking/booking_create_component.dart';
-import '../domain/components/booking/booking_share_component.dart';
+import '../domain/use_cases/booking/booking_create_use_case.dart';
+import '../domain/use_cases/booking/booking_share_use_case.dart';
 
 /// Shared providers for all configurations.
 List<SingleChildWidget> _sharedProviders = [
   Provider(
     lazy: true,
-    create: (context) => BookingCreateComponent(
+    create: (context) => BookingCreateUseCase(
       destinationRepository: context.read(),
       activityRepository: context.read(),
       bookingRepository: context.read(),
@@ -40,7 +40,7 @@ List<SingleChildWidget> _sharedProviders = [
   ),
   Provider(
     lazy: true,
-    create: (context) => BookingShareComponent.withSharePlus(),
+    create: (context) => BookingShareUseCase.withSharePlus(),
   ),
 ];
 

--- a/compass_app/app/lib/domain/use_cases/booking/booking_create_use_case.dart
+++ b/compass_app/app/lib/domain/use_cases/booking/booking_create_use_case.dart
@@ -9,12 +9,12 @@ import '../../models/booking/booking.dart';
 import '../../models/destination/destination.dart';
 import '../../models/itinerary_config/itinerary_config.dart';
 
-/// Component for creating [Booking] objects from [ItineraryConfig].
+/// UseCase for creating [Booking] objects from [ItineraryConfig].
 ///
 /// Fetches [Destination] and [Activity] objects from repositories,
 /// checks if dates are set and creates a [Booking] object.
-class BookingCreateComponent {
-  BookingCreateComponent({
+class BookingCreateUseCase {
+  BookingCreateUseCase({
     required DestinationRepository destinationRepository,
     required ActivityRepository activityRepository,
     required BookingRepository bookingRepository,
@@ -25,7 +25,7 @@ class BookingCreateComponent {
   final DestinationRepository _destinationRepository;
   final ActivityRepository _activityRepository;
   final BookingRepository _bookingRepository;
-  final _log = Logger('BookingComponent');
+  final _log = Logger('BookingCreateUseCase');
 
   /// Create [Booking] from a stored [ItineraryConfig]
   Future<Result<Booking>> createFrom(ItineraryConfig itineraryConfig) async {

--- a/compass_app/app/lib/domain/use_cases/booking/booking_share_use_case.dart
+++ b/compass_app/app/lib/domain/use_cases/booking/booking_share_use_case.dart
@@ -8,20 +8,20 @@ import '../../models/booking/booking.dart';
 
 typedef ShareFunction = Future<void> Function(String text);
 
-/// Component for sharing a booking.
-class BookingShareComponent {
-  BookingShareComponent._(this._share);
+/// UseCase for sharing a booking.
+class BookingShareUseCase {
+  BookingShareUseCase._(this._share);
 
-  /// Create a [BookingShareComponent] that uses `share_plus` package.
-  factory BookingShareComponent.withSharePlus() =>
-      BookingShareComponent._(Share.share);
+  /// Create a [BookingShareUseCase] that uses `share_plus` package.
+  factory BookingShareUseCase.withSharePlus() =>
+      BookingShareUseCase._(Share.share);
 
-  /// Create a [BookingShareComponent] with a custom share function.
-  factory BookingShareComponent.custom(ShareFunction share) =>
-      BookingShareComponent._(share);
+  /// Create a [BookingShareUseCase] with a custom share function.
+  factory BookingShareUseCase.custom(ShareFunction share) =>
+      BookingShareUseCase._(share);
 
   final ShareFunction _share;
-  final _log = Logger('BookingShareComponent');
+  final _log = Logger('BookingShareUseCase');
 
   Future<Result<void>> shareBooking(Booking booking) async {
     final text = 'Trip to ${booking.destination.name}\n'

--- a/compass_app/app/lib/routing/router.dart
+++ b/compass_app/app/lib/routing/router.dart
@@ -89,8 +89,8 @@ GoRouter router(
               builder: (context, state) {
                 final viewModel = BookingViewModel(
                   itineraryConfigRepository: context.read(),
-                  bookingComponent: context.read(),
-                  shareComponent: context.read(),
+                  createBookingUseCase: context.read(),
+                  shareBookingUseCase: context.read(),
                   bookingRepository: context.read(),
                 );
 
@@ -109,8 +109,8 @@ GoRouter router(
                     final id = int.parse(state.pathParameters['id']!);
                     final viewModel = BookingViewModel(
                       itineraryConfigRepository: context.read(),
-                      bookingComponent: context.read(),
-                      shareComponent: context.read(),
+                      createBookingUseCase: context.read(),
+                      shareBookingUseCase: context.read(),
                       bookingRepository: context.read(),
                     );
 

--- a/compass_app/app/lib/ui/auth/logout/view_models/logout_viewmodel.dart
+++ b/compass_app/app/lib/ui/auth/logout/view_models/logout_viewmodel.dart
@@ -8,16 +8,16 @@ class LogoutViewModel {
   LogoutViewModel({
     required AuthRepository authRepository,
     required ItineraryConfigRepository itineraryConfigRepository,
-  })  : _authLogoutComponent = authRepository,
+  })  : _authLogoutRepository = authRepository,
         _itineraryConfigRepository = itineraryConfigRepository {
     logout = Command0(_logout);
   }
-  final AuthRepository _authLogoutComponent;
+  final AuthRepository _authLogoutRepository;
   final ItineraryConfigRepository _itineraryConfigRepository;
   late Command0 logout;
 
   Future<Result> _logout() async {
-    var result = await _authLogoutComponent.logout();
+    var result = await _authLogoutRepository.logout();
     switch (result) {
       case Ok<void>():
         // clear stored itinerary config

--- a/compass_app/app/lib/ui/booking/view_models/booking_viewmodel.dart
+++ b/compass_app/app/lib/ui/booking/view_models/booking_viewmodel.dart
@@ -7,26 +7,26 @@ import '../../../domain/models/booking/booking.dart';
 import '../../../domain/models/itinerary_config/itinerary_config.dart';
 import '../../../utils/command.dart';
 import '../../../utils/result.dart';
-import '../../../domain/components/booking/booking_create_component.dart';
-import '../../../domain/components/booking/booking_share_component.dart';
+import '../../../domain/use_cases/booking/booking_create_use_case.dart';
+import '../../../domain/use_cases/booking/booking_share_use_case.dart';
 
 class BookingViewModel extends ChangeNotifier {
   BookingViewModel({
-    required BookingCreateComponent bookingComponent,
-    required BookingShareComponent shareComponent,
+    required BookingCreateUseCase createBookingUseCase,
+    required BookingShareUseCase shareBookingUseCase,
     required ItineraryConfigRepository itineraryConfigRepository,
     required BookingRepository bookingRepository,
-  })  : _createComponent = bookingComponent,
-        _shareComponent = shareComponent,
+  })  : _createUseCase = createBookingUseCase,
+        _shareUseCase = shareBookingUseCase,
         _itineraryConfigRepository = itineraryConfigRepository,
         _bookingRepository = bookingRepository {
     createBooking = Command0(_createBooking);
-    shareBooking = Command0(() => _shareComponent.shareBooking(_booking!));
+    shareBooking = Command0(() => _shareUseCase.shareBooking(_booking!));
     loadBooking = Command1(_load);
   }
 
-  final BookingCreateComponent _createComponent;
-  final BookingShareComponent _shareComponent;
+  final BookingCreateUseCase _createUseCase;
+  final BookingShareUseCase _shareUseCase;
   final ItineraryConfigRepository _itineraryConfigRepository;
   final BookingRepository _bookingRepository;
   final _log = Logger('BookingViewModel');
@@ -51,7 +51,7 @@ class BookingViewModel extends ChangeNotifier {
     switch (itineraryConfig) {
       case Ok<ItineraryConfig>():
         _log.fine('Loaded stored ItineraryConfig');
-        final result = await _createComponent.createFrom(itineraryConfig.value);
+        final result = await _createUseCase.createFrom(itineraryConfig.value);
         switch (result) {
           case Ok<Booking>():
             _log.fine('Created Booking');

--- a/compass_app/app/test/domain/use_cases/booking/booking_create_use_case_test.dart
+++ b/compass_app/app/test/domain/use_cases/booking/booking_create_use_case_test.dart
@@ -1,4 +1,4 @@
-import 'package:compass_app/domain/components/booking/booking_create_component.dart';
+import 'package:compass_app/domain/use_cases/booking/booking_create_use_case.dart';
 import 'package:compass_app/domain/models/itinerary_config/itinerary_config.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -10,15 +10,15 @@ import '../../../../testing/models/booking.dart';
 import '../../../../testing/models/destination.dart';
 
 void main() {
-  group('BookingCreateComponent tests', () {
+  group('BookingCreateUseCase tests', () {
     test('Create booking', () async {
-      final component = BookingCreateComponent(
+      final useCase = BookingCreateUseCase(
         activityRepository: FakeActivityRepository(),
         destinationRepository: FakeDestinationRepository(),
         bookingRepository: FakeBookingRepository(),
       );
 
-      final booking = await component.createFrom(
+      final booking = await useCase.createFrom(
         ItineraryConfig(
           startDate: DateTime(2024, 01, 01),
           endDate: DateTime(2024, 02, 12),

--- a/compass_app/app/test/domain/use_cases/booking/booking_share_use_case_test.dart
+++ b/compass_app/app/test/domain/use_cases/booking/booking_share_use_case_test.dart
@@ -1,4 +1,4 @@
-import 'package:compass_app/domain/components/booking/booking_share_component.dart';
+import 'package:compass_app/domain/use_cases/booking/booking_share_use_case.dart';
 import 'package:compass_app/domain/models/booking/booking.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -6,10 +6,10 @@ import '../../../../testing/models/activity.dart';
 import '../../../../testing/models/destination.dart';
 
 void main() {
-  group('BookingShareComponent tests', () {
+  group('BookingShareUseCase tests', () {
     test('Share booking', () async {
       String? sharedText;
-      final component = BookingShareComponent.custom((text) async {
+      final useCase = BookingShareUseCase.custom((text) async {
         sharedText = text;
       });
       final booking = Booking(
@@ -18,7 +18,7 @@ void main() {
         destination: kDestination1,
         activity: [kActivity],
       );
-      await component.shareBooking(booking);
+      await useCase.shareBooking(booking);
       expect(
         sharedText,
         'Trip to name1\n'

--- a/compass_app/app/test/ui/booking/booking_screen_test.dart
+++ b/compass_app/app/test/ui/booking/booking_screen_test.dart
@@ -1,5 +1,5 @@
-import 'package:compass_app/domain/components/booking/booking_create_component.dart';
-import 'package:compass_app/domain/components/booking/booking_share_component.dart';
+import 'package:compass_app/domain/use_cases/booking/booking_create_use_case.dart';
+import 'package:compass_app/domain/use_cases/booking/booking_share_use_case.dart';
 import 'package:compass_app/domain/models/itinerary_config/itinerary_config.dart';
 import 'package:compass_app/ui/booking/view_models/booking_viewmodel.dart';
 import 'package:compass_app/ui/booking/widgets/booking_screen.dart';
@@ -37,12 +37,12 @@ void main() {
             activities: [kActivity.ref],
           ),
         ),
-        bookingComponent: BookingCreateComponent(
+        createBookingUseCase: BookingCreateUseCase(
           activityRepository: FakeActivityRepository(),
           destinationRepository: FakeDestinationRepository(),
           bookingRepository: bookingRepository,
         ),
-        shareComponent: BookingShareComponent.custom((text) async {
+        shareBookingUseCase: BookingShareUseCase.custom((text) async {
           shared = true;
         }),
         bookingRepository: bookingRepository,


### PR DESCRIPTION
We decided it was better to use the common term 'use case'.  This PR updates the names of files, classes and several variables.