### PR TITLE
fix: compass-app bug in dismissable homescreen item

### DIFF
--- a/compass_app/app/lib/ui/home/widgets/home_screen.dart
+++ b/compass_app/app/lib/ui/home/widgets/home_screen.dart
@@ -96,10 +96,20 @@ class _HomeScreenState extends State<HomeScreen> {
                       booking: widget.viewModel.bookings[index],
                       onTap: () => context.push(Routes.bookingWithId(
                           widget.viewModel.bookings[index].id)),
-                      onDismissed: (_) =>
-                          widget.viewModel.deleteBooking.execute(
-                        widget.viewModel.bookings[index].id,
-                      ),
+                      confirmDismiss: (_) async {
+                        // wait for command to complete
+                        await widget.viewModel.deleteBooking.execute(
+                          widget.viewModel.bookings[index].id,
+                        );
+                        // if command completed successfully, return true
+                        if (widget.viewModel.deleteBooking.completed) {
+                          // removes the dismissable from the list
+                          return true;
+                        } else {
+                          // the dismissable stays in the list
+                          return false;
+                        }
+                      },
                     ),
                   )
                 ],
@@ -137,19 +147,19 @@ class _Booking extends StatelessWidget {
     super.key,
     required this.booking,
     required this.onTap,
-    required this.onDismissed,
+    required this.confirmDismiss,
   });
 
   final BookingSummary booking;
   final GestureTapCallback onTap;
-  final DismissDirectionCallback onDismissed;
+  final ConfirmDismissCallback confirmDismiss;
 
   @override
   Widget build(BuildContext context) {
     return Dismissible(
       key: ValueKey(booking.id),
       direction: DismissDirection.endToStart,
-      onDismissed: onDismissed,
+      confirmDismiss: confirmDismiss,
       child: InkWell(
         onTap: onTap,
         child: Padding(

--- a/compass_app/app/test/ui/home/widgets/home_screen_test.dart
+++ b/compass_app/app/test/ui/home/widgets/home_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:compass_app/data/repositories/itinerary_config/itinerary_config_
 import 'package:compass_app/routing/routes.dart';
 import 'package:compass_app/ui/home/view_models/home_viewmodel.dart';
 import 'package:compass_app/ui/home/widgets/home_screen.dart';
+import 'package:compass_app/utils/result.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -98,5 +99,29 @@ void main() {
       // Booking should be deleted from repository
       expect(bookingRepository.bookings, isEmpty);
     });
+
+    testWidgets('fail to delete booking', (tester) async {
+      // Create a ViewModel with a repository that will fail to delete
+      viewModel = HomeViewModel(
+        bookingRepository: _BadFakeBookingRepository()..createBooking(kBooking),
+        userRepository: FakeUserRepository(),
+      );
+      await loadWidget(tester);
+      await tester.pumpAndSettle();
+
+      // Swipe on booking (created from kBooking)
+      await tester.drag(find.text('name1, Europe'), const Offset(-1000, 0));
+      await tester.pumpAndSettle();
+
+      // Existing booking should be there
+      expect(find.text('name1, Europe'), findsOneWidget);
+    });
   });
+}
+
+class _BadFakeBookingRepository extends FakeBookingRepository {
+  @override
+  Future<Result<void>> delete(int id) async {
+    return Result.error(Exception('Failed to delete booking'));
+  }
 }


### PR DESCRIPTION
Doing some testing on the "Optimistic State" I noticed the use of `Dismissable` was incorrect.

If the delete request failed and the item cannot be removed, the removed item then gets stays in the item list.

This causes the `Dismissable` widget to throw an exception, because it expects that the item with a unique key has been removed. To fix that, I switched from `onDismissed` to `confirmDismiss`, and use the `Command` status result to know if the dismiss action was successful or not.

I have created a widget test that reproduces the issue.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md