### PR TITLE
Update catalog.dart under : lib/screens/catalog.dart

### DIFF
--- a/provider_shopper/lib/screens/catalog.dart
+++ b/provider_shopper/lib/screens/catalog.dart
@@ -58,8 +58,8 @@ class _AddButton extends StatelessWidget {
               cart.add(item);
             },
       style: ButtonStyle(
-        overlayColor: WidgetStateProperty.resolveWith<Color?>((states) {
-          if (states.contains(WidgetState.pressed)) {
+        overlayColor: MaterialStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(MaterialState.pressed)) {
             return Theme.of(context).primaryColor;
           }
           return null; // Defer to the widget's default.


### PR DESCRIPTION
Changes : in line 61 and 62, Replaced WidgetStateproperty with MaterialStateproperty and Widgetstate with Materialstate

Reason : In Flutter, there are no classes called WidgetStateProperty or WidgetState. 

*List which issues are fixed by this PR. For larger changes, raising an issue first helps
reduce redundant work.*

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md