### PR TITLE
[compass_app] Mark classes used for namespacing as `abstract final`

### DIFF
--- a/compass_app/app/lib/config/assets.dart
+++ b/compass_app/app/lib/config/assets.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-class Assets {
+abstract final class Assets {
   static const activities = 'assets/activities.json';
   static const destinations = 'assets/destinations.json';
 }

--- a/compass_app/app/lib/routing/routes.dart
+++ b/compass_app/app/lib/routing/routes.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-class Routes {
+abstract final class Routes {
   static const home = '/';
   static const login = '/login';
   static const search = '/$searchRelative';

--- a/compass_app/app/lib/ui/core/themes/colors.dart
+++ b/compass_app/app/lib/ui/core/themes/colors.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-class AppColors {
+abstract final class AppColors {
   static const black1 = Color(0xFF101010);
   static const white1 = Color(0xFFFFF7FA);
   static const grey1 = Color(0xFFF2F2F2);

--- a/compass_app/app/lib/ui/core/themes/theme.dart
+++ b/compass_app/app/lib/ui/core/themes/theme.dart
@@ -6,7 +6,7 @@ import 'colors.dart';
 import '../ui/tag_chip.dart';
 import 'package:flutter/material.dart';
 
-class AppTheme {
+abstract final class AppTheme {
   static const _textTheme = TextTheme(
     headlineLarge: TextStyle(
       fontSize: 32,

--- a/compass_app/server/lib/config/assets.dart
+++ b/compass_app/server/lib/config/assets.dart
@@ -8,7 +8,7 @@ import 'dart:io';
 import '../model/activity/activity.dart';
 import '../model/destination/destination.dart';
 
-class Assets {
+abstract final class Assets {
   static const _activities = '../app/assets/activities.json';
   static const _destinations = '../app/assets/destinations.json';
 

--- a/compass_app/server/lib/config/constants.dart
+++ b/compass_app/server/lib/config/constants.dart
@@ -4,7 +4,7 @@
 
 import '../model/user/user.dart';
 
-class Constants {
+abstract final class Constants {
   /// Email for the hardcoded login.
   static const email = 'email@example.com';
 


### PR DESCRIPTION
As they are just used for namespacing static properties, these classes shouldn't be extended, implemented, or instantiated.