### PR TITLE
Update android samples to target/compile android 35 and AGP/Gradle updates

### DIFF
--- a/add_to_app/plugin/android_using_plugin/app/build.gradle
+++ b/add_to_app/plugin/android_using_plugin/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 34
+    compileSdk 35
     defaultConfig {
         applicationId "dev.flutter.example.androidusingplugin"
         minSdkVersion 21
-        targetSdk 34
+        targetSdk 35
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -18,27 +18,27 @@ android {
         }
     }
     // Remove when #flutter/flutter/issues/150955 is merged to stable.
-    lintOptions {
-        checkReleaseBuilds false
-    }
     // Keep java and kotlin versions in sync.
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility 17
+        targetCompatibility 17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     namespace 'dev.flutter.example.androidusingplugin'
+    lint {
+        checkReleaseBuilds false
+    }
 }
 
 dependencies {
     implementation project(':flutter')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.core:core-ktx:1.13.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.core:core-ktx:1.15.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'

--- a/add_to_app/plugin/android_using_plugin/app/build.gradle
+++ b/add_to_app/plugin/android_using_plugin/app/build.gradle
@@ -17,7 +17,6 @@ android {
             minifyEnabled false
         }
     }
-    // Remove when #flutter/flutter/issues/150955 is merged to stable.
     // Keep java and kotlin versions in sync.
     compileOptions {
         sourceCompatibility 17

--- a/add_to_app/plugin/android_using_plugin/build.gradle
+++ b/add_to_app/plugin/android_using_plugin/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.2'
+        classpath 'com.android.tools.build:gradle:8.8.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/add_to_app/plugin/android_using_plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/add_to_app/plugin/android_using_plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/add_to_app/prebuilt_module/android_using_prebuilt_module/app/build.gradle
+++ b/add_to_app/prebuilt_module/android_using_prebuilt_module/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 34
+    compileSdk 35
     defaultConfig {
         applicationId "dev.flutter.example.androidusingprebuiltmodule"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -19,11 +19,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility 17
+        targetCompatibility 17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     namespace 'dev.flutter.example.androidusingprebuiltmodule'
 }

--- a/add_to_app/prebuilt_module/android_using_prebuilt_module/build.gradle
+++ b/add_to_app/prebuilt_module/android_using_prebuilt_module/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.2'
+        classpath 'com.android.tools.build:gradle:8.8.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/add_to_app/prebuilt_module/android_using_prebuilt_module/gradle/wrapper/gradle-wrapper.properties
+++ b/add_to_app/prebuilt_module/android_using_prebuilt_module/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- **update AGP and gradle versions**
- **[prebuilt_module] update agp and gradle**
- **[prebuilt_module] targetsdk and jvm compatabiliity**

Fixes flutter/flutter/152374

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [x] I updated/added relevant documentation (doc comments with `///`).
