### PR TITLE
Bump Add to App Sample project to API 36

### DIFF
--- a/add_to_app/android_view/android_view/app/build.gradle
+++ b/add_to_app/android_view/android_view/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdkPreview = "Baklava"
 
     lint {
         baseline = file("lint-baseline.xml")
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         applicationId "dev.flutter.example.androidView"
         minSdkVersion 21
-        targetSdk 35
+        targetSdkPreview = "Baklava"
         versionCode 1
         versionName "1.0"
 

--- a/add_to_app/android_view/android_view/build.gradle
+++ b/add_to_app/android_view/android_view/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.1'
+        classpath 'com.android.tools.build:gradle:8.9.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/add_to_app/android_view/android_view/gradle/wrapper/gradle-wrapper.properties
+++ b/add_to_app/android_view/android_view/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jul 26 11:31:21 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/add_to_app/multiple_flutters/multiple_flutters_android/app/build.gradle
+++ b/add_to_app/multiple_flutters/multiple_flutters_android/app/build.gradle
@@ -8,12 +8,12 @@ android {
         self {
         }
     }
-    compileSdk 35
+    compileSdkPreview = "Baklava"
 
     defaultConfig {
         applicationId "dev.flutter.multipleflutters"
         minSdkVersion 24
-        targetSdk 35
+        targetSdkPreview = "Baklava"
         versionCode 1
         versionName "1.0"
 

--- a/add_to_app/multiple_flutters/multiple_flutters_android/build.gradle
+++ b/add_to_app/multiple_flutters/multiple_flutters_android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.2'
+        classpath 'com.android.tools.build:gradle:8.9.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/add_to_app/multiple_flutters/multiple_flutters_android/gradle/wrapper/gradle-wrapper.properties
+++ b/add_to_app/multiple_flutters/multiple_flutters_android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Dec 11 09:57:20 AEDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Confirm the add to app sample project works as expeceted when bumped to API 36. Currently, we use `Baklava` to refer to API 36 from android docs here.

Fixes #165161
## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [ ] I updated/added relevant documentation (doc comments with `///`).


If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md 