### PR TITLE
remove SVN tip from samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,23 +105,6 @@ See the [getting started guide] to install the `flutter` tool.
 > If you want to run an add-to-app sample, there are additional requirements.
 > We suggest reading the [add-to-app documentation].
 
-### Tip: minimize download size
-
-As this repository is quite big, you can use 
-[svn] to download a single example.
-For example:
-
-```
-svn co https://github.com/flutter/samples/trunk/provider_shopper
-```
-
-You can also use a [partial clone] to skip blob objects 
-that aren't currently checked out, while including the full commit history:
-
-```
-git clone --filter=blob:none https://github.com/flutter/samples.git
-```
-
 ## Interested in contributing?
 
 See the [contributor's guide]!


### PR DESCRIPTION
Per #2565, this tip doesn't actually work anymore, so I'm removing it from the README

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I have added sample code updates to the [changelog].
- [x] I updated/added relevant documentation (doc comments with `///`).
