### PR TITLE
Fix add_to_app sample

### DIFF
--- a/add_to_app/android_view/android_view/app/build.gradle
+++ b/add_to_app/android_view/android_view/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "dev.flutter.example.androidView"
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdk 36
         versionCode 1
         versionName "1.0"

--- a/add_to_app/android_view/android_view/build.gradle
+++ b/add_to_app/android_view/android_view/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.0'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/add_to_app/android_view/android_view/settings.gradle
+++ b/add_to_app/android_view/android_view/settings.gradle
@@ -3,5 +3,5 @@ include ':app'
 setBinding(new Binding([gradle: this]))
 evaluate(new File(
   settingsDir.parentFile,
-  'flutter_module_using_plugin/.android/include_flutter.groovy'
+  'flutter_module_using_plugin_android_view/.android/include_flutter.groovy'
 ))


### PR DESCRIPTION
The android_view add_to_app sample is currently broken.  It does not build:

* AGP version is incompatible.
* MIN_SDK is below Flutter min
* Flutter plugin module was renamed awhile ago: https://github.com/flutter/samples/pull/2714

## Pre-launch Checklist

- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I read the [Contributors Guide].
- [X] I have added sample code updates to the [changelog].
- [X] I updated/added relevant documentation (doc comments with `///`).
