### PR TITLE
docs: fix typo in `compass_app` `BookingSummary` class doc

### DIFF
--- a/compass_app/app/lib/domain/models/booking/booking_summary.dart
+++ b/compass_app/app/lib/domain/models/booking/booking_summary.dart
@@ -9,7 +9,7 @@ part 'booking_summary.g.dart';
 
 /// BookingSummary contains the necessary data to display a booking
 /// in the user home screen, but lacks the rest of the booking data
-/// like activitities or destination.
+/// like activities or destination.
 ///
 /// Use the [BookingRepository] to obtain a full [Booking]
 /// using the [BookingSummary.id].


### PR DESCRIPTION
Fixes a [typo] in the [`compass_app`] sample's [`booking_summary.dart`]. The class doc for the `BookingSummary` class had "activities" written as "activitities".


[`compass_app`]: https://github.com/flutter/samples/tree/main/compass_app
[`booking_summary.dart`]: https://github.com/flutter/samples/blob/main/compass_app/app/lib/domain/models/booking/booking_summary.dart
[typo]: https://github.com/flutter/samples/blob/7abc7b91f219e9cab71f537663057f2509a0d4a9/compass_app/app/lib/domain/models/booking/booking_summary.dart#L12C10-L12C22

Fixes #2785 .

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog]. **Not completed as changelog link didn't work (and change is to documentation only).**
- [x] I updated/added relevant documentation (doc comments with `///`).


If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md 