### PR TITLE
[samples] Remove usesCleartextTraffic

### DIFF
--- a/add_to_app/fullscreen/android_fullscreen/app/src/debug/AndroidManifest.xml
+++ b/add_to_app/fullscreen/android_fullscreen/app/src/debug/AndroidManifest.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <!-- Include Cleartext traffic for the espresso package -->
-
-    <application android:usesCleartextTraffic="true" />
-
+    <!-- The network security config is needed for Espresso testing since it
+         uses http cleartext traffic. 
+    -->
+    <application android:networkSecurityConfig="@xml/network_security_config"> 
+        <meta-data android:name="io.flutter.network-policy"
+            android:resource="@xml/network_security_config"/>
+    </application>
 </manifest>

--- a/add_to_app/fullscreen/android_fullscreen/app/src/debug/res/xml/network_security_config.xml
+++ b/add_to_app/fullscreen/android_fullscreen/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Cleartext is needed for Espresso testing. -->
+    <base-config cleartextTrafficPermitted="true">
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Removes deprecated usesCleartextTraffic. 

Addresses: https://github.com/flutter/flutter/issues/182553

## Pre-launch Checklist

- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I read the [Contributors Guide].
- [X] I have added sample code updates to the [changelog].
- [X] I updated/added relevant documentation (doc comments with `///`).