### PR TITLE
[samples] Remove axisAlignment

### DIFF
--- a/animations/lib/src/misc/animated_list.dart
+++ b/animations/lib/src/misc/animated_list.dart
@@ -49,7 +49,7 @@ class _AnimatedListDemoState extends State<AnimatedListDemo> {
               parent: animation,
               curve: const Interval(0.0, 1.0),
             ),
-            axisAlignment: 0.0,
+            alignment: Alignment.center,
             child: _buildItem(user),
           ),
         );


### PR DESCRIPTION
Remove deprecated axisAlignment.  Caught in: https://github.com/flutter/samples/actions/runs/22420998290/job/64918394575?pr=2809

## Pre-launch Checklist

- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I read the [Contributors Guide].
- [X] I have added sample code updates to the [changelog].
- [X] I updated/added relevant documentation (doc comments with `///`).
