### PR TITLE
axisAlignment is deprecated in beta causing PRs to fail checks

### DIFF
--- a/animations/lib/src/misc/animated_list.dart
+++ b/animations/lib/src/misc/animated_list.dart
@@ -49,6 +49,7 @@ class _AnimatedListDemoState extends State<AnimatedListDemo> {
               parent: animation,
               curve: const Interval(0.0, 1.0),
             ),
+            // ignore: deprecated_member_use
             axisAlignment: 0.0,
             child: _buildItem(user),
           ),


### PR DESCRIPTION
axisAlignment has been deprecated (currently deprecated in beta).  This causes sample PRs to fail.  

See: https://github.com/flutter/samples/pull/2809

## Pre-launch Checklist

- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I read the [Contributors Guide].
- [X] I have added sample code updates to the [changelog].
- [X] I updated/added relevant documentation (doc comments with `///`).