### PR TITLE
Add copyright to source files in simple_shader and simple_sdf

### DIFF
--- a/simple_sdf/lib/main.dart
+++ b/simple_sdf/lib/main.dart
@@ -1,3 +1,7 @@
+// Copyright 2024 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';

--- a/simple_sdf/shaders/SDF.frag
+++ b/simple_sdf/shaders/SDF.frag
@@ -1,3 +1,7 @@
+// Copyright 2024 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #version 460 core
 
 #include <flutter/runtime_effect.glsl>

--- a/simple_sdf/test/widget_test.dart
+++ b/simple_sdf/test/widget_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2024 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:simple_sdf/main.dart';
 

--- a/simple_shader/lib/main.dart
+++ b/simple_shader/lib/main.dart
@@ -1,3 +1,7 @@
+// Copyright 2024 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';

--- a/simple_shader/shaders/simple.frag
+++ b/simple_shader/shaders/simple.frag
@@ -1,3 +1,7 @@
+// Copyright 2024 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #version 460 core
 
 #include <flutter/runtime_effect.glsl>

--- a/simple_shader/test/widget_test.dart
+++ b/simple_shader/test/widget_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2024 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:simple_shader/main.dart';
 


### PR DESCRIPTION
@gaaclarke noticed the copyright was missing from the top of these files, so this PR adds them.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [x] I updated/added relevant documentation (doc comments with `///`).


If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md 