### PR TITLE
Update simple_sdf sample to use uniform-by-name accessor

### DIFF
--- a/simple_sdf/lib/main.dart
+++ b/simple_sdf/lib/main.dart
@@ -44,13 +44,15 @@ class MyHomePage extends StatelessWidget {
 }
 
 class ShaderPainter extends CustomPainter {
-  ShaderPainter({required this.shader});
-  ui.FragmentShader shader;
+  ShaderPainter({required this.shader})
+    : _resolution = shader.getUniformVec2('resolution');
+
+  final ui.FragmentShader shader;
+  final ui.UniformVec2Slot _resolution;
 
   @override
   void paint(Canvas canvas, Size size) {
-    shader.setFloat(0, size.width);
-    shader.setFloat(1, size.height);
+    _resolution.set(size.width, size.height);
 
     final paint = Paint()..shader = shader;
     canvas.drawRect(Rect.fromLTWH(0, 0, size.width, size.height), paint);


### PR DESCRIPTION
The newer, more convenient method `getUniformVec2` is now available on stable, so let's use that in the `simple_sdf` sample

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [x] I updated/added relevant documentation (doc comments with `///`).

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md 