### PR TITLE
typo: AuthTokenRepository -> AuthRepository

### DIFF
--- a/compass_app/app/lib/routing/router.dart
+++ b/compass_app/app/lib/routing/router.dart
@@ -23,7 +23,7 @@ import 'routes.dart';
 
 /// Top go_router entry point.
 ///
-/// Listens to changes in [AuthTokenRepository] to redirect the user
+/// Listens to changes in [AuthRepository] to redirect the user
 /// to /login when the user logs out.
 GoRouter router(AuthRepository authRepository) => GoRouter(
   initialLocation: Routes.home,


### PR DESCRIPTION
AuthTokenRepository got renamed in #2394 but the comment was not updated.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [x] I updated/added relevant documentation (doc comments with `///`).

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md 